### PR TITLE
Add backtest result records, cursor pagination, and instrument abstraction

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ curl -i -H "Authorization: Bearer <QF_API_TOKEN>" \
 <summary><strong>首次部署具体做了什么？</strong></summary>
 
 1. 从 `backend/.env.example` 创建权限为 `0600` 的根目录 `.env`，并补充 Web 端口；
-2. 使用 Python `secrets` 生成 256-bit PostgreSQL 随机密码和 API Token；
+2. 使用 Python `secrets` 生成 256-bit PostgreSQL 随机密码、API Token 和游标签名密钥；
 3. 分别构建 Backend 和 Frontend 镜像；
 4. 创建持久化数据卷并启动 PostgreSQL；
 5. 执行全部 Alembic 迁移；
@@ -247,8 +247,9 @@ cd quant-foundry
 cp backend/.env.example backend/.env
 ```
 
-编辑 `.env`，为 `QF_API_TOKEN` 和 `QF_DATABASE_PASSWORD` 设置真实值，并确保对应的
-PostgreSQL 用户和数据库已经存在。API Token 至少需要 32 个字符。然后执行：
+编辑 `.env`，为 `QF_API_TOKEN`、`QF_CURSOR_SIGNING_KEY` 和 `QF_DATABASE_PASSWORD`
+设置真实值，并确保对应的 PostgreSQL 用户和数据库已经存在。API Token 与游标签名密钥
+都至少需要 32 个字符；游标签名密钥仅服务端持有，不得下发给任何客户端。然后执行：
 
 ```bash
 cd backend
@@ -287,6 +288,7 @@ cd frontend && pnpm build
 | `QF_SERVER_HOST` / `QF_SERVER_PORT` | Backend 容器内监听地址和端口；容器部署时 Host 应为 `0.0.0.0` |
 | `QF_WEB_HOST` / `QF_WEB_PORT` | Web 管理台发布到宿主机的地址和端口；局域网访问使用 `0.0.0.0` |
 | `QF_API_TOKEN` | 用于验证 API 请求的共享 Bearer Token |
+| `QF_CURSOR_SIGNING_KEY` | 回测结果游标 HMAC 签名的服务端专用密钥，至少 32 个字符，不得与任何客户端共享 |
 | `QF_DATABASE_*` | PostgreSQL 地址、端口、用户、密码和数据库名 |
 | `QF_LOG_DIR` / `QF_LOG_LEVEL` | 日志目录和最低日志级别 |
 | `QF_LOG_RETENTION_DAYS` | 轮转日志保留天数 |

--- a/README_EN.md
+++ b/README_EN.md
@@ -125,7 +125,7 @@ curl -i -H "Authorization: Bearer <QF_API_TOKEN>" \
 <summary><strong>What happens during the first deployment?</strong></summary>
 
 1. Create the root `.env` from `backend/.env.example`, add the web port, and set `0600` permissions;
-2. Generate a random 256-bit PostgreSQL password and API token with Python `secrets`;
+2. Generate a random 256-bit PostgreSQL password, API token, and cursor signing key with Python `secrets`;
 3. Build separate Backend and Frontend images;
 4. Create persistent volumes and start PostgreSQL;
 5. Apply all Alembic migrations;
@@ -258,8 +258,10 @@ cd quant-foundry
 cp backend/.env.example backend/.env
 ```
 
-Edit `.env`, set real values for `QF_API_TOKEN` and `QF_DATABASE_PASSWORD`, and make sure the
-configured PostgreSQL user and database exist. The API token must contain at least 32 characters.
+Edit `.env`, set real values for `QF_API_TOKEN`, `QF_CURSOR_SIGNING_KEY`, and
+`QF_DATABASE_PASSWORD`, and make sure the configured PostgreSQL user and database exist.
+Both the API token and the cursor signing key must contain at least 32 characters; the
+cursor signing key is server-only and must never be shared with any client.
 Then run:
 
 ```bash
@@ -300,6 +302,7 @@ creates the root `.env` from [`backend/.env.example`](./backend/.env.example) an
 | `QF_SERVER_HOST` / `QF_SERVER_PORT` | Backend container bind address and port; use `0.0.0.0` in containers |
 | `QF_WEB_HOST` / `QF_WEB_PORT` | Host address and port published for the web console; use `0.0.0.0` for LAN access |
 | `QF_API_TOKEN` | Shared Bearer Token used to authenticate API requests |
+| `QF_CURSOR_SIGNING_KEY` | Server-only secret (at least 32 characters) used to HMAC-sign backtest result cursors; never share it with clients |
 | `QF_DATABASE_*` | PostgreSQL host, port, user, password, and database name |
 | `QF_LOG_DIR` / `QF_LOG_LEVEL` | Log directory and minimum log level |
 | `QF_LOG_RETENTION_DAYS` | Retention period for rotated logs |

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -16,6 +16,9 @@ QF_SERVER_PORT=8000
 # API Bearer Token；首次执行 make selfhost 时自动生成，请勿提交真实 Token。
 QF_API_TOKEN=
 
+# 游标签名密钥；仅服务端持有，用于回测结果游标的 HMAC 签名，不得下发给客户端。首次执行 make selfhost 时自动生成。
+QF_CURSOR_SIGNING_KEY=
+
 # 本地结构化日志目录；相对路径以项目根目录为基准。
 QF_LOG_DIR=data/logs
 

--- a/backend/app/backtesting/instrument_specs.py
+++ b/backend/app/backtesting/instrument_specs.py
@@ -1,0 +1,87 @@
+"""Instrument identity and point-in-time display specification.
+
+The backtesting result layer never links rows by trading code or name: the
+only stable association key is ``instrument_id``.  Display fields (code,
+name, display name) are only valid at a query-time instant, so they are
+resolved through the :class:`InstrumentSpecProvider` protocol when results
+are written and then frozen into each result row.  Trading rules and
+capability facts belong to the data foundation and are intentionally not
+part of this minimal contract.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Protocol
+from uuid import UUID
+
+from app.backtesting.domain import DomainValidationError
+
+
+def _optional_label(value: str | None, field_name: str) -> str | None:
+    """Normalize an optional human-readable label; blank text means missing."""
+
+    if value is None:
+        return None
+    if not isinstance(value, str):
+        raise DomainValidationError(f"{field_name} must be text when provided")
+    normalized = value.strip()
+    return normalized or None
+
+
+@dataclass(frozen=True, slots=True)
+class InstrumentSpec:
+    """Query-time-valid description of one tradable instrument.
+
+    ``instrument_id`` is mandatory and stable across trading-code changes.
+    All display fields may be ``None`` for asset protocols that do not
+    provide them; an empty display field must never be replaced by the
+    trading code.
+    """
+
+    instrument_id: UUID
+    asset_class: str
+    trading_code: str | None = None
+    name: str | None = None
+    display_name: str | None = None
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.instrument_id, UUID):
+            raise DomainValidationError(
+                "instrument_id must be a UUID (stable instrument identity)"
+            )
+        asset_class = _optional_label(self.asset_class, "asset_class")
+        if asset_class is None:
+            raise DomainValidationError("asset_class must be non-blank text")
+        object.__setattr__(self, "asset_class", asset_class)
+        object.__setattr__(
+            self, "trading_code", _optional_label(self.trading_code, "trading_code")
+        )
+        object.__setattr__(self, "name", _optional_label(self.name, "name"))
+        object.__setattr__(
+            self,
+            "display_name",
+            _optional_label(self.display_name, "display_name"),
+        )
+
+
+class InstrumentSpecProvider(Protocol):
+    """Structural source of query-time-valid instrument descriptions.
+
+    Implementations may be backed by the ORM catalogue, a market-data
+    client, or an in-memory fake in tests; result-writing code depends only
+    on this protocol.
+    """
+
+    def resolve(
+        self,
+        instrument_id: UUID,
+        *,
+        as_of: datetime,
+    ) -> InstrumentSpec | None:
+        """Return the spec valid at ``as_of``, or ``None`` when unknown."""
+        ...
+
+
+__all__ = ["InstrumentSpec", "InstrumentSpecProvider"]

--- a/backend/app/backtesting/pagination.py
+++ b/backend/app/backtesting/pagination.py
@@ -11,10 +11,16 @@ an opaque JSON cursor token.  The token carries:
 - ``query_upper_bound``: the maximum sort-key tuple visible when the first
   page was created, so appended rows never leak into an existing cursor.
 
-Tokens are canonical JSON encoded as unpadded base64url.  Clients must treat
-them as opaque; any tampering, version mismatch, format error, or query
-mismatch raises :class:`CursorError` so callers can return a clear parameter
-error instead of silently restarting from the first page.
+Tokens are canonical JSON encoded as unpadded base64url and signed with a
+server-side HMAC-SHA256 (``<payload>.<signature>``).  The signature covers
+every payload field, including ``last_sort_key`` and ``query_upper_bound``,
+so a token edited into another syntactically valid shape is still rejected.
+The ``query_digest`` itself covers the canonicalized query plus the encoded
+upper bound, binding the cursor to one exact server-side query state.
+Clients must treat tokens as opaque; any tampering, version mismatch,
+format error, or query mismatch raises :class:`CursorError` so callers can
+return a clear parameter error instead of silently restarting from the
+first page.
 """
 
 from __future__ import annotations
@@ -175,6 +181,12 @@ def _decode_element(element: Any, kind: str, label: str) -> Any:
 # ---------------------------------------------------------------------------
 
 
+def encode_sort_element(kind: str, value: Any) -> dict[str, Any]:
+    """Public wrapper so callers can canonicalize bound values for digests."""
+
+    return _encode_element(kind, value)
+
+
 @dataclass(frozen=True, slots=True)
 class ParsedCursor:
     """Decoded cursor payload with typed sort-key values."""
@@ -187,13 +199,14 @@ class ParsedCursor:
 
 def build_cursor(
     *,
+    signing_key: str,
     query_digest: str,
     key_kinds: Sequence[str],
     last_sort_key: Sequence[Any],
     upper_bound_columns: Mapping[str, str],
     query_upper_bound: Mapping[str, Any],
 ) -> str:
-    """Encode a cursor token from typed sort-key values.
+    """Encode a signed cursor token from typed sort-key values.
 
     ``upper_bound_columns`` maps each bound column to its element kind.
     Raises :class:`ValueError` when values do not match their declared
@@ -201,6 +214,7 @@ def build_cursor(
     because both sides come from the same result-kind specification.
     """
 
+    key = _require_signing_key(signing_key)
     if len(key_kinds) != len(last_sort_key):
         raise ValueError("last_sort_key length must match key_kinds")
     if set(upper_bound_columns) != set(query_upper_bound):
@@ -209,15 +223,15 @@ def build_cursor(
         "version": CURSOR_VERSION,
         "query_digest": query_digest,
         "last_sort_key": [
-            _encode_element(kind, value)
+            encode_sort_element(kind, value)
             for kind, value in zip(key_kinds, last_sort_key)
         ],
         "query_upper_bound": {
-            column: _encode_element(upper_bound_columns[column], query_upper_bound[column])
+            column: encode_sort_element(upper_bound_columns[column], query_upper_bound[column])
             for column in sorted(query_upper_bound)
         },
     }
-    return _encode_token(payload)
+    return sign_token(payload, key)
 
 
 def _encode_token(payload: dict[str, Any]) -> str:
@@ -227,10 +241,37 @@ def _encode_token(payload: dict[str, Any]) -> str:
     return urlsafe_b64encode(canonical.encode("utf-8")).decode("ascii").rstrip("=")
 
 
-def _decode_token(token: str) -> dict[str, Any]:
+def _require_signing_key(signing_key: str | None) -> str:
+    if not isinstance(signing_key, str) or not signing_key.strip():
+        raise ValueError("cursor signing key must be non-blank text")
+    return signing_key
+
+
+def sign_token(payload: dict[str, Any], signing_key: str) -> str:
+    """Encode the payload and append a server-side HMAC-SHA256 signature.
+
+    The signature covers the exact base64url payload bytes, so any change to
+    any field (including ``last_sort_key`` and ``query_upper_bound``)
+    invalidates the token.
+    """
+
+    encoded = _encode_token(payload)
+    mac = hmac.new(
+        signing_key.encode("utf-8"), encoded.encode("ascii"), hashlib.sha256
+    ).hexdigest()
+    return f"{encoded}.{mac}"
+
+
+def _split_signed_token(token: str) -> tuple[str, dict[str, Any], str]:
+    """Split a token into (payload-b64, decoded-payload, signature)."""
+
     if not isinstance(token, str) or not token or len(token) > 8192:
         raise MalformedCursorError("cursor must be a non-empty short token")
-    padded = token + "=" * (-len(token) % 4)
+    parts = token.split(".")
+    if len(parts) != 2 or not parts[0] or not parts[1]:
+        raise MalformedCursorError("cursor is missing its signature")
+    encoded_payload, signature = parts
+    padded = encoded_payload + "=" * (-len(encoded_payload) % 4)
     try:
         raw = urlsafe_b64decode(padded.encode("ascii"))
         payload = json.loads(raw.decode("utf-8"))
@@ -238,24 +279,34 @@ def _decode_token(token: str) -> dict[str, Any]:
         raise MalformedCursorError("cursor is not valid base64url JSON") from exc
     if not isinstance(payload, dict):
         raise MalformedCursorError("cursor payload must be a JSON object")
-    return payload
+    return encoded_payload, payload, signature
 
 
 def parse_cursor(
     token: str,
     *,
+    signing_key: str,
     expected_query_digest: str | None = None,
     key_kinds: Sequence[str] | None = None,
     upper_bound_columns: Mapping[str, str] | None = None,
 ) -> ParsedCursor:
     """Decode and fully validate a cursor token.
 
-    ``key_kinds`` declares the positional sort-key kinds of the result type;
+    The server-side MAC is verified first; tokens without a valid signature
+    are rejected before their content is interpreted.  ``key_kinds`` declares
+    the positional sort-key kinds of the result type;
     ``upper_bound_columns`` declares the expected upper-bound columns and
     their kinds.  When provided, structural mismatches are rejected.
     """
 
-    payload = _decode_token(token)
+    key = _require_signing_key(signing_key)
+    encoded_payload, payload, signature = _split_signed_token(token)
+    recomputed = hmac.new(
+        key.encode("utf-8"), encoded_payload.encode("ascii"), hashlib.sha256
+    ).hexdigest()
+    if not hmac_compare(signature, recomputed):
+        raise MalformedCursorError("cursor signature verification failed")
+
     version = payload.get("version")
     if version != CURSOR_VERSION:
         raise UnsupportedCursorVersionError(
@@ -327,7 +378,9 @@ __all__ = [
     "build_cursor",
     "canonical_query_payload",
     "compute_query_digest",
+    "encode_sort_element",
     "hmac_compare",
     "normalize_limit",
     "parse_cursor",
+    "sign_token",
 ]

--- a/backend/app/backtesting/pagination.py
+++ b/backend/app/backtesting/pagination.py
@@ -28,6 +28,7 @@ from __future__ import annotations
 import hashlib
 import hmac
 import json
+import re
 from base64 import urlsafe_b64decode, urlsafe_b64encode
 from dataclasses import dataclass
 from datetime import datetime, timezone
@@ -262,6 +263,12 @@ def sign_token(payload: dict[str, Any], signing_key: str) -> str:
     return f"{encoded}.{mac}"
 
 
+# Tokens are base64url payloads plus a hex signature joined by a dot; any
+# other character (including non-ASCII) is malformed and must map to
+# MalformedCursorError instead of leaking codec errors to clients.
+_TOKEN_CHARSET = re.compile(r"[A-Za-z0-9_\-.]+")
+
+
 def _split_signed_token(token: str) -> tuple[str, str]:
     """Split a token into its raw (payload-b64, signature) parts.
 
@@ -271,6 +278,8 @@ def _split_signed_token(token: str) -> tuple[str, str]:
 
     if not isinstance(token, str) or not token or len(token) > 8192:
         raise MalformedCursorError("cursor must be a non-empty short token")
+    if _TOKEN_CHARSET.fullmatch(token) is None:
+        raise MalformedCursorError("cursor contains unsupported characters")
     parts = token.split(".")
     if len(parts) != 2 or not parts[0] or not parts[1]:
         raise MalformedCursorError("cursor is missing its signature")

--- a/backend/app/backtesting/pagination.py
+++ b/backend/app/backtesting/pagination.py
@@ -1,0 +1,333 @@
+"""Stable opaque-cursor pagination for backtest result lists.
+
+Long result ranges are read exclusively through keyset pagination backed by
+an opaque JSON cursor token.  The token carries:
+
+- ``version``: cursor format version;
+- ``query_digest``: SHA-256 over the canonicalized query (run id, every
+  filter, sort direction/keys, page-size policy, and the result upper
+  bound captured for running runs);
+- ``last_sort_key``: the sort-key tuple of the last row on the previous page;
+- ``query_upper_bound``: the maximum sort-key tuple visible when the first
+  page was created, so appended rows never leak into an existing cursor.
+
+Tokens are canonical JSON encoded as unpadded base64url.  Clients must treat
+them as opaque; any tampering, version mismatch, format error, or query
+mismatch raises :class:`CursorError` so callers can return a clear parameter
+error instead of silently restarting from the first page.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import hmac
+import json
+from base64 import urlsafe_b64decode, urlsafe_b64encode
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from decimal import Decimal, InvalidOperation
+from typing import Any, Mapping, Sequence
+from uuid import UUID
+
+
+DEFAULT_PAGE_SIZE = 100
+MAX_PAGE_SIZE = 500
+CURSOR_VERSION = 1
+
+# Supported sort-element kinds.  Each maps to one deterministic wire
+# representation and back, preserving ordering within its kind.
+
+
+class CursorError(ValueError):
+    """Base class for every rejected cursor condition."""
+
+
+class MalformedCursorError(CursorError):
+    """The token is not decodable base64url JSON with the expected shape."""
+
+
+class UnsupportedCursorVersionError(CursorError):
+    """The token was written by an incompatible cursor format version."""
+
+
+class CursorQueryMismatchError(CursorError):
+    """The token belongs to a different query than the current request."""
+
+
+@dataclass(frozen=True, slots=True)
+class CursorPage:
+    """Uniform envelope for every long-range result list."""
+
+    items: tuple[Any, ...]
+    next_cursor: str | None
+    has_more: bool
+
+
+def normalize_limit(value: int) -> int:
+    """Validate the requested page size against the first-version policy."""
+
+    if isinstance(value, bool) or not isinstance(value, int):
+        raise ValueError("limit must be an integer between 1 and 500")
+    if not 1 <= value <= MAX_PAGE_SIZE:
+        raise ValueError(f"limit must be between 1 and {MAX_PAGE_SIZE}")
+    return value
+
+
+def canonical_query_payload(payload: Mapping[str, Any]) -> str:
+    """Serialize a query description canonically for digest computation."""
+
+    try:
+        return json.dumps(
+            payload,
+            sort_keys=True,
+            separators=(",", ":"),
+            ensure_ascii=False,
+            allow_nan=False,
+        )
+    except (TypeError, ValueError) as exc:
+        raise ValueError("query payload must be canonically serializable") from exc
+
+
+def compute_query_digest(payload: Mapping[str, Any]) -> str:
+    """SHA-256 hex digest of the canonicalized query payload."""
+
+    return hashlib.sha256(canonical_query_payload(payload).encode("utf-8")).hexdigest()
+
+
+# ---------------------------------------------------------------------------
+# Sort-key element encoding
+# ---------------------------------------------------------------------------
+
+
+def _encode_element(kind: str, value: Any) -> dict[str, Any]:
+    if kind == "str":
+        if not isinstance(value, str):
+            raise ValueError("sort element declared as str")
+        return {"k": kind, "v": value}
+    if kind == "int":
+        if isinstance(value, bool) or not isinstance(value, int):
+            raise ValueError("sort element declared as int")
+        return {"k": kind, "v": value}
+    if kind == "uuid":
+        if not isinstance(value, UUID):
+            raise ValueError("sort element declared as uuid")
+        return {"k": kind, "v": str(value)}
+    if kind == "ts":
+        if not isinstance(value, datetime):
+            raise ValueError("sort element declared as ts")
+        # Normalize to UTC ISO-8601 so identical instants always produce
+        # identical tokens regardless of the source timezone.
+        if value.tzinfo is None or value.utcoffset() is None:
+            raise ValueError("sort timestamps must be timezone-aware")
+        return {"k": kind, "v": value.astimezone(timezone.utc).isoformat()}
+    if kind == "dec":
+        if isinstance(value, float):
+            raise ValueError("sort elements never carry binary floats")
+        if not isinstance(value, Decimal):
+            try:
+                value = Decimal(str(value))
+            except InvalidOperation as exc:
+                raise ValueError("sort element declared as dec") from exc
+        return {"k": kind, "v": str(value)}
+    raise ValueError(f"unsupported sort element kind: {kind!r}")
+
+
+def _decode_element(element: Any, kind: str, label: str) -> Any:
+    if not isinstance(element, dict):
+        raise MalformedCursorError(f"{label} must contain tagged elements")
+    element_kind = element.get("k")
+    raw_value = element.get("v")
+    if element_kind != kind:
+        raise MalformedCursorError(
+            f"{label} element kind {element_kind!r} does not match expected {kind!r}"
+        )
+    try:
+        if kind == "str":
+            if not isinstance(raw_value, str):
+                raise ValueError
+            return raw_value
+        if kind == "int":
+            if isinstance(raw_value, bool) or not isinstance(raw_value, int):
+                raise ValueError
+            return raw_value
+        if kind == "uuid":
+            if not isinstance(raw_value, str):
+                raise ValueError
+            return UUID(raw_value)
+        if kind == "ts":
+            if not isinstance(raw_value, str):
+                raise ValueError
+            parsed = datetime.fromisoformat(raw_value)
+            if parsed.tzinfo is None or parsed.utcoffset() is None:
+                raise ValueError
+            return parsed
+        if kind == "dec":
+            if not isinstance(raw_value, str):
+                raise ValueError
+            return Decimal(raw_value)
+    except (ValueError, InvalidOperation) as exc:
+        raise MalformedCursorError(f"{label} contains an invalid {kind} value") from exc
+    raise MalformedCursorError(f"unsupported sort element kind: {kind!r}")
+
+
+# ---------------------------------------------------------------------------
+# Token building and parsing
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True, slots=True)
+class ParsedCursor:
+    """Decoded cursor payload with typed sort-key values."""
+
+    version: int
+    query_digest: str
+    last_sort_key: tuple[Any, ...]
+    query_upper_bound: Mapping[str, Any]
+
+
+def build_cursor(
+    *,
+    query_digest: str,
+    key_kinds: Sequence[str],
+    last_sort_key: Sequence[Any],
+    upper_bound_columns: Mapping[str, str],
+    query_upper_bound: Mapping[str, Any],
+) -> str:
+    """Encode a cursor token from typed sort-key values.
+
+    ``upper_bound_columns`` maps each bound column to its element kind.
+    Raises :class:`ValueError` when values do not match their declared
+    kinds; callers should treat that as an internal programming error
+    because both sides come from the same result-kind specification.
+    """
+
+    if len(key_kinds) != len(last_sort_key):
+        raise ValueError("last_sort_key length must match key_kinds")
+    if set(upper_bound_columns) != set(query_upper_bound):
+        raise ValueError("query_upper_bound keys must match upper_bound_columns")
+    payload = {
+        "version": CURSOR_VERSION,
+        "query_digest": query_digest,
+        "last_sort_key": [
+            _encode_element(kind, value)
+            for kind, value in zip(key_kinds, last_sort_key)
+        ],
+        "query_upper_bound": {
+            column: _encode_element(upper_bound_columns[column], query_upper_bound[column])
+            for column in sorted(query_upper_bound)
+        },
+    }
+    return _encode_token(payload)
+
+
+def _encode_token(payload: dict[str, Any]) -> str:
+    canonical = json.dumps(
+        payload, sort_keys=True, separators=(",", ":"), ensure_ascii=False
+    )
+    return urlsafe_b64encode(canonical.encode("utf-8")).decode("ascii").rstrip("=")
+
+
+def _decode_token(token: str) -> dict[str, Any]:
+    if not isinstance(token, str) or not token or len(token) > 8192:
+        raise MalformedCursorError("cursor must be a non-empty short token")
+    padded = token + "=" * (-len(token) % 4)
+    try:
+        raw = urlsafe_b64decode(padded.encode("ascii"))
+        payload = json.loads(raw.decode("utf-8"))
+    except (ValueError, UnicodeDecodeError) as exc:
+        raise MalformedCursorError("cursor is not valid base64url JSON") from exc
+    if not isinstance(payload, dict):
+        raise MalformedCursorError("cursor payload must be a JSON object")
+    return payload
+
+
+def parse_cursor(
+    token: str,
+    *,
+    expected_query_digest: str | None = None,
+    key_kinds: Sequence[str] | None = None,
+    upper_bound_columns: Mapping[str, str] | None = None,
+) -> ParsedCursor:
+    """Decode and fully validate a cursor token.
+
+    ``key_kinds`` declares the positional sort-key kinds of the result type;
+    ``upper_bound_columns`` declares the expected upper-bound columns and
+    their kinds.  When provided, structural mismatches are rejected.
+    """
+
+    payload = _decode_token(token)
+    version = payload.get("version")
+    if version != CURSOR_VERSION:
+        raise UnsupportedCursorVersionError(
+            f"cursor version {version!r} is unsupported; expected {CURSOR_VERSION}"
+        )
+    query_digest = payload.get("query_digest")
+    if not isinstance(query_digest, str) or not query_digest:
+        raise MalformedCursorError("cursor query_digest must be non-empty text")
+    if (
+        expected_query_digest is not None
+        and not hmac_compare(query_digest, expected_query_digest)
+    ):
+        raise CursorQueryMismatchError(
+            "cursor belongs to a different query; restart from the first page"
+        )
+
+    raw_last_key = payload.get("last_sort_key")
+    if not isinstance(raw_last_key, list):
+        raise MalformedCursorError("cursor last_sort_key must be a list")
+    if key_kinds is not None and len(raw_last_key) != len(key_kinds):
+        raise MalformedCursorError("cursor last_sort_key has an unexpected length")
+    last_sort_key = tuple(
+        _decode_element(element, kind, "last_sort_key")
+        for element, kind in zip(
+            raw_last_key,
+            key_kinds if key_kinds is not None else ("str",) * len(raw_last_key),
+        )
+    )
+
+    raw_bound = payload.get("query_upper_bound")
+    if not isinstance(raw_bound, dict):
+        raise MalformedCursorError("cursor query_upper_bound must be an object")
+    if upper_bound_columns is not None:
+        if set(raw_bound) != set(upper_bound_columns):
+            raise MalformedCursorError(
+                "cursor query_upper_bound columns do not match this result type"
+            )
+        decoded_bound = {
+            column: _decode_element(raw_bound[column], kind, f"query_upper_bound[{column}]")
+            for column, kind in upper_bound_columns.items()
+        }
+    else:
+        decoded_bound = dict(raw_bound)
+
+    return ParsedCursor(
+        version=payload["version"],
+        query_digest=query_digest,
+        last_sort_key=last_sort_key,
+        query_upper_bound=decoded_bound,
+    )
+
+
+def hmac_compare(left: str, right: str) -> bool:
+    """Constant-time string comparison for digest equality checks."""
+
+    return hmac.compare_digest(left.encode("utf-8"), right.encode("utf-8"))
+
+
+__all__ = [
+    "CURSOR_VERSION",
+    "CursorError",
+    "CursorPage",
+    "CursorQueryMismatchError",
+    "DEFAULT_PAGE_SIZE",
+    "MalformedCursorError",
+    "MAX_PAGE_SIZE",
+    "ParsedCursor",
+    "UnsupportedCursorVersionError",
+    "build_cursor",
+    "canonical_query_payload",
+    "compute_query_digest",
+    "hmac_compare",
+    "normalize_limit",
+    "parse_cursor",
+]

--- a/backend/app/backtesting/pagination.py
+++ b/backend/app/backtesting/pagination.py
@@ -262,15 +262,22 @@ def sign_token(payload: dict[str, Any], signing_key: str) -> str:
     return f"{encoded}.{mac}"
 
 
-def _split_signed_token(token: str) -> tuple[str, dict[str, Any], str]:
-    """Split a token into (payload-b64, decoded-payload, signature)."""
+def _split_signed_token(token: str) -> tuple[str, str]:
+    """Split a token into its raw (payload-b64, signature) parts.
+
+    No decoding happens here: the caller must verify the MAC over the raw
+    payload bytes before interpreting any content.
+    """
 
     if not isinstance(token, str) or not token or len(token) > 8192:
         raise MalformedCursorError("cursor must be a non-empty short token")
     parts = token.split(".")
     if len(parts) != 2 or not parts[0] or not parts[1]:
         raise MalformedCursorError("cursor is missing its signature")
-    encoded_payload, signature = parts
+    return parts[0], parts[1]
+
+
+def _decode_signed_payload(encoded_payload: str) -> dict[str, Any]:
     padded = encoded_payload + "=" * (-len(encoded_payload) % 4)
     try:
         raw = urlsafe_b64decode(padded.encode("ascii"))
@@ -279,7 +286,7 @@ def _split_signed_token(token: str) -> tuple[str, dict[str, Any], str]:
         raise MalformedCursorError("cursor is not valid base64url JSON") from exc
     if not isinstance(payload, dict):
         raise MalformedCursorError("cursor payload must be a JSON object")
-    return encoded_payload, payload, signature
+    return payload
 
 
 def parse_cursor(
@@ -292,20 +299,24 @@ def parse_cursor(
 ) -> ParsedCursor:
     """Decode and fully validate a cursor token.
 
-    The server-side MAC is verified first; tokens without a valid signature
-    are rejected before their content is interpreted.  ``key_kinds`` declares
-    the positional sort-key kinds of the result type;
-    ``upper_bound_columns`` declares the expected upper-bound columns and
-    their kinds.  When provided, structural mismatches are rejected.
+    The server-side MAC is verified over the raw payload bytes BEFORE the
+    content is decoded or interpreted; tokens without a valid signature are
+    rejected outright.  ``key_kinds`` declares the positional sort-key kinds
+    of the result type; ``upper_bound_columns`` declares the expected
+    upper-bound columns and their kinds.  When provided, structural
+    mismatches are rejected.
     """
 
     key = _require_signing_key(signing_key)
-    encoded_payload, payload, signature = _split_signed_token(token)
+    encoded_payload, signature = _split_signed_token(token)
     recomputed = hmac.new(
         key.encode("utf-8"), encoded_payload.encode("ascii"), hashlib.sha256
     ).hexdigest()
     if not hmac_compare(signature, recomputed):
         raise MalformedCursorError("cursor signature verification failed")
+
+    # The signature is valid; only now is the content decoded and trusted.
+    payload = _decode_signed_payload(encoded_payload)
 
     version = payload.get("version")
     if version != CURSOR_VERSION:

--- a/backend/app/backtesting/result_models.py
+++ b/backend/app/backtesting/result_models.py
@@ -1,0 +1,851 @@
+"""Immutable result-record DTOs for backtest runs.
+
+Each class in this module is one validated, immutable row of the logical
+result tables (steps, decisions, orders, order updates, fills, positions,
+equity curve, metrics, data preflight reports, and data chunks).  The DTOs
+are the boundary between the backtesting engine and persistence/query
+layers: mutable runtime objects (``AccountState``, ``Order``, ...) are never
+exposed through results.
+
+Contracts enforced here:
+
+- ``run_id`` and every business entity id are mandatory UUIDs;
+- timestamps must be timezone-aware ``datetime`` values;
+- money, prices, quantities, and ratios are ``Decimal``; binary ``float``
+  is rejected everywhere, including nested JSON structures;
+- instrument-bearing rows carry a point-in-time
+  :class:`InstrumentDisplaySnapshot` keyed by the stable ``instrument_id``;
+- no ETF-specific field (ts_code, fund type, creation/redemption state,
+  ...) exists on any result object, so fictional assets, stocks, futures,
+  and ETFs share the same DTOs.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime
+from decimal import Decimal
+from enum import StrEnum
+from types import MappingProxyType
+from typing import Any, Mapping, Sequence
+from uuid import UUID
+
+from app.backtesting.accounting import OrderSide
+from app.backtesting.domain import (
+    DomainValidationError,
+    PositionSide,
+    ValuationStatus,
+    _aware_datetime,
+    _decimal,
+    _non_negative,
+    _optional_price,
+    _positive,
+)
+from app.backtesting.instrument_specs import InstrumentSpec, InstrumentSpecProvider
+
+
+ZERO = Decimal("0")
+
+
+# ---------------------------------------------------------------------------
+# Shared normalization helpers
+# ---------------------------------------------------------------------------
+
+
+def _uuid(value: UUID, field_name: str) -> UUID:
+    """Require a real UUID; identity fields are never free-form strings."""
+
+    if not isinstance(value, UUID):
+        raise DomainValidationError(f"{field_name} must be a UUID")
+    return value
+
+
+def _optional_uuid(value: UUID | None, field_name: str) -> UUID | None:
+    if value is None:
+        return None
+    return _uuid(value, field_name)
+
+
+def _optional_text(value: str | None, field_name: str) -> str | None:
+    """Normalize optional text; blank strings are treated as missing."""
+
+    if value is None:
+        return None
+    if not isinstance(value, str):
+        raise DomainValidationError(f"{field_name} must be text when provided")
+    normalized = value.strip()
+    return normalized or None
+
+
+def _required_text(value: str, field_name: str) -> str:
+    normalized = _optional_text(value, field_name)
+    if normalized is None:
+        raise DomainValidationError(f"{field_name} must be non-blank text")
+    return normalized
+
+
+def _sequence(value: int, field_name: str) -> int:
+    """Require a non-negative, non-boolean integer sequence number."""
+
+    if isinstance(value, bool) or not isinstance(value, int):
+        raise DomainValidationError(f"{field_name} must be an integer")
+    if value < 0:
+        raise DomainValidationError(f"{field_name} must be non-negative")
+    return value
+
+
+def _optional_int(value: int | None, field_name: str) -> int | None:
+    if value is None:
+        return None
+    if isinstance(value, bool) or not isinstance(value, int):
+        raise DomainValidationError(f"{field_name} must be an integer when provided")
+    return value
+
+
+def _optional_decimal(value: Decimal | int | str | None, field_name: str) -> Decimal | None:
+    if value is None:
+        return None
+    return _decimal(value, field_name)
+
+
+def _frozen_json(value: Any, field_name: str) -> Any:
+    """Deep-freeze a JSON-like structure into immutable containers.
+
+    Binary floats are rejected so persisted JSON can never lose precision;
+    numeric values that are not exact integers must be passed as strings or
+    ``Decimal``-free structures (serialize weights as strings, for example).
+    """
+
+    if value is None or isinstance(value, (str, bool)):
+        return value
+    if isinstance(value, int):
+        return value
+    if isinstance(value, Decimal):
+        # Keep exactness: JSON payloads carry decimals as canonical strings.
+        return str(_decimal(value, field_name))
+    if isinstance(value, float):
+        raise DomainValidationError(
+            f"{field_name} must not contain binary floats; use strings or integers"
+        )
+    if isinstance(value, Mapping):
+        frozen_items: dict[str, Any] = {}
+        for key, item in value.items():
+            if not isinstance(key, str):
+                raise DomainValidationError(f"{field_name} keys must be strings")
+            frozen_items[key] = _frozen_json(item, f"{field_name}[{key!r}]")
+        return MappingProxyType(frozen_items)
+    if isinstance(value, (list, tuple)):
+        return tuple(
+            _frozen_json(item, f"{field_name}[{index}]")
+            for index, item in enumerate(value)
+        )
+    raise DomainValidationError(
+        f"{field_name} must be a JSON-compatible structure (str/int/bool/None/"
+        "mapping/sequence)"
+    )
+
+
+def _json_payload(value: Mapping[str, Any] | None, field_name: str) -> Mapping[str, Any]:
+    """Freeze a mapping payload, defaulting to an empty read-only mapping."""
+
+    if value is None:
+        return MappingProxyType({})
+    frozen = _frozen_json(value, field_name)
+    if not isinstance(frozen, Mapping):
+        raise DomainValidationError(f"{field_name} must be a mapping")
+    return frozen
+
+
+def _enum(value: StrEnum, enum_type: type[StrEnum], field_name: str) -> StrEnum:
+    try:
+        return enum_type(getattr(value, "value", value))
+    except ValueError as exc:
+        allowed = [member.value for member in enum_type]
+        raise DomainValidationError(
+            f"{field_name} must be one of {allowed}"
+        ) from exc
+
+
+# ---------------------------------------------------------------------------
+# Instrument display snapshot
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True, slots=True)
+class InstrumentDisplaySnapshot:
+    """Point-in-time display fields frozen when a result row is written.
+
+    ``instrument_id`` is the only association key.  The display fields are
+    optional for every asset protocol and are never used to substitute the
+    stable identity.  Historical queries read these frozen values; they must
+    not be refreshed from today's catalogue.
+    """
+
+    instrument_id: UUID
+    event_trading_code: str | None = None
+    event_name: str | None = None
+    event_display_name: str | None = None
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "instrument_id", _uuid(self.instrument_id, "instrument_id"))
+        object.__setattr__(
+            self,
+            "event_trading_code",
+            _optional_text(self.event_trading_code, "event_trading_code"),
+        )
+        object.__setattr__(
+            self, "event_name", _optional_text(self.event_name, "event_name")
+        )
+        object.__setattr__(
+            self,
+            "event_display_name",
+            _optional_text(self.event_display_name, "event_display_name"),
+        )
+
+    @classmethod
+    def from_spec(cls, spec: InstrumentSpec) -> "InstrumentDisplaySnapshot":
+        """Freeze the display fields of a query-time-valid spec."""
+
+        return cls(
+            instrument_id=spec.instrument_id,
+            event_trading_code=spec.trading_code,
+            event_name=spec.name,
+            event_display_name=spec.display_name,
+        )
+
+    def require_matching_instrument(self, instrument_id: UUID, field_name: str) -> None:
+        """Reject snapshots belonging to a different instrument."""
+
+        if self.instrument_id != instrument_id:
+            raise DomainValidationError(
+                f"{field_name} snapshot instrument_id must match the row instrument_id"
+            )
+
+
+def resolve_display_snapshot(
+    provider: InstrumentSpecProvider,
+    instrument_id: UUID,
+    *,
+    as_of: datetime,
+) -> InstrumentDisplaySnapshot:
+    """Resolve display fields from a provider at the event time.
+
+    A missing spec is not an error: asset protocols may not expose display
+    fields, so the snapshot simply stays empty while ``instrument_id`` keeps
+    carrying the identity.  Result repositories depend on the caller (or
+    this helper) rather than on any concrete market-data client.
+    """
+
+    _aware_datetime(as_of, "as_of")
+    spec = provider.resolve(_uuid(instrument_id, "instrument_id"), as_of=as_of)
+    if spec is None:
+        return InstrumentDisplaySnapshot(instrument_id=instrument_id)
+    if spec.instrument_id != instrument_id:
+        raise DomainValidationError("provider returned a mismatched instrument_id")
+    return InstrumentDisplaySnapshot.from_spec(spec)
+
+
+# ---------------------------------------------------------------------------
+# Result enums (stable persisted values)
+# ---------------------------------------------------------------------------
+
+
+class StepPhase(StrEnum):
+    """Coarse phase of one time step; the registry may grow without breaks."""
+
+    DATA = "data"
+    DECISION = "decision"
+    EXECUTION = "execution"
+    VALUATION = "valuation"
+    FINALIZE = "finalize"
+
+
+class DataQualityStatus(StrEnum):
+    """Whether the step's input data passed quality checks."""
+
+    OK = "ok"
+    DEGRADED = "degraded"
+    BLOCKED = "blocked"
+
+
+class DecisionValidationStatus(StrEnum):
+    """Outcome of validating one strategy decision."""
+
+    ACCEPTED = "accepted"
+    REJECTED = "rejected"
+
+
+class ResultOrderStatus(StrEnum):
+    """Lifecycle states persisted for result orders."""
+
+    SUBMITTED = "submitted"
+    PARTIALLY_FILLED = "partially_filled"
+    FILLED = "filled"
+    EXPIRED = "expired"
+    REJECTED = "rejected"
+    CANCELLED = "cancelled"
+
+
+class DataPhase(StrEnum):
+    """Run-level data phases shared by preflight reports and chunks."""
+
+    ADMISSION = "admission"
+    SESSION = "session"
+
+
+class ChunkValidationStatus(StrEnum):
+    """Validation outcome of one bounded data chunk."""
+
+    PASSED = "passed"
+    FAILED = "failed"
+
+
+# ---------------------------------------------------------------------------
+# Result DTOs
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True, slots=True)
+class BacktestStepRecord:
+    """One time step of a run (logical ``backtest_steps`` row)."""
+
+    run_id: UUID
+    step_sequence: int
+    time_start: datetime
+    time_end: datetime
+    data_cutoff_at: datetime
+    phase: StepPhase
+    data_quality: DataQualityStatus
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "run_id", _uuid(self.run_id, "run_id"))
+        object.__setattr__(self, "step_sequence", _sequence(self.step_sequence, "step_sequence"))
+        object.__setattr__(self, "time_start", _aware_datetime(self.time_start, "time_start"))
+        object.__setattr__(self, "time_end", _aware_datetime(self.time_end, "time_end"))
+        object.__setattr__(
+            self, "data_cutoff_at", _aware_datetime(self.data_cutoff_at, "data_cutoff_at")
+        )
+        if self.time_start > self.time_end:
+            raise DomainValidationError("time_start cannot be after time_end")
+        object.__setattr__(self, "phase", _enum(self.phase, StepPhase, "phase"))
+        object.__setattr__(
+            self, "data_quality", _enum(self.data_quality, DataQualityStatus, "data_quality")
+        )
+
+    @property
+    def cursor_sort_key(self) -> tuple[int]:
+        return (self.step_sequence,)
+
+
+@dataclass(frozen=True, slots=True)
+class BacktestDecisionRecord:
+    """One strategy decision (logical ``backtest_decisions`` row)."""
+
+    run_id: UUID
+    decision_id: UUID
+    step_sequence: int
+    decision_time: datetime
+    mode: str
+    validation_status: DecisionValidationStatus
+    targets: Mapping[str, Any] = field(default_factory=lambda: MappingProxyType({}))
+    validation_issues: Sequence[str] = ()
+    duration_ms: Decimal | int | str | None = None
+    error: str | None = None
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "run_id", _uuid(self.run_id, "run_id"))
+        object.__setattr__(self, "decision_id", _uuid(self.decision_id, "decision_id"))
+        object.__setattr__(self, "step_sequence", _sequence(self.step_sequence, "step_sequence"))
+        object.__setattr__(
+            self, "decision_time", _aware_datetime(self.decision_time, "decision_time")
+        )
+        object.__setattr__(self, "mode", _required_text(self.mode, "mode"))
+        object.__setattr__(
+            self,
+            "validation_status",
+            _enum(
+                self.validation_status,
+                DecisionValidationStatus,
+                "validation_status",
+            ),
+        )
+        object.__setattr__(self, "targets", _json_payload(self.targets, "targets"))
+        normalized_issues = tuple(
+            issue if isinstance(issue, str) and issue.strip() else None
+            for issue in self.validation_issues
+        )
+        if any(issue is None for issue in normalized_issues):
+            raise DomainValidationError("validation_issues must contain non-blank text")
+        object.__setattr__(self, "validation_issues", normalized_issues)
+        object.__setattr__(
+            self, "duration_ms", _optional_decimal(self.duration_ms, "duration_ms")
+        )
+        object.__setattr__(self, "error", _optional_text(self.error, "error"))
+
+    @property
+    def cursor_sort_key(self) -> tuple[int, datetime, UUID]:
+        return (self.step_sequence, self.decision_time, self.decision_id)
+
+
+@dataclass(frozen=True, slots=True)
+class BacktestOrderRecord:
+    """One standard order (logical ``backtest_orders`` row)."""
+
+    run_id: UUID
+    order_id: UUID
+    instrument_id: UUID
+    display: InstrumentDisplaySnapshot
+    side: OrderSide
+    order_type: str
+    quantity: Decimal | int | str
+    status: ResultOrderStatus
+    submitted_at: datetime
+    intent_id: UUID | None = None
+    price: Decimal | int | str | None = None
+    filled_quantity: Decimal | int | str = ZERO
+    status_reason: str | None = None
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "run_id", _uuid(self.run_id, "run_id"))
+        object.__setattr__(self, "order_id", _uuid(self.order_id, "order_id"))
+        object.__setattr__(self, "instrument_id", _uuid(self.instrument_id, "instrument_id"))
+        if not isinstance(self.display, InstrumentDisplaySnapshot):
+            raise DomainValidationError("display must be an InstrumentDisplaySnapshot")
+        self.display.require_matching_instrument(self.instrument_id, "display")
+        try:
+            side = OrderSide(getattr(self.side, "value", self.side))
+        except ValueError as exc:
+            raise DomainValidationError("side must be buy or sell") from exc
+        object.__setattr__(self, "side", side)
+        object.__setattr__(self, "order_type", _required_text(self.order_type, "order_type"))
+        object.__setattr__(self, "quantity", _positive(self.quantity, "quantity"))
+        object.__setattr__(
+            self,
+            "status",
+            _enum(self.status, ResultOrderStatus, "status"),
+        )
+        object.__setattr__(
+            self, "submitted_at", _aware_datetime(self.submitted_at, "submitted_at")
+        )
+        object.__setattr__(self, "intent_id", _optional_uuid(self.intent_id, "intent_id"))
+        object.__setattr__(self, "price", _optional_price(self.price, "price"))
+        object.__setattr__(
+            self, "filled_quantity", _non_negative(self.filled_quantity, "filled_quantity")
+        )
+        if self.filled_quantity > self.quantity:
+            raise DomainValidationError("filled_quantity cannot exceed quantity")
+        object.__setattr__(
+            self, "status_reason", _optional_text(self.status_reason, "status_reason")
+        )
+
+    @property
+    def cursor_sort_key(self) -> tuple[datetime, UUID]:
+        return (self.submitted_at, self.order_id)
+
+
+@dataclass(frozen=True, slots=True)
+class BacktestOrderUpdateRecord:
+    """One order status transition (logical ``backtest_order_updates`` row)."""
+
+    run_id: UUID
+    order_id: UUID
+    update_sequence: int
+    new_status: ResultOrderStatus
+    updated_at: datetime
+    old_status: ResultOrderStatus | None = None
+    reason: str | None = None
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "run_id", _uuid(self.run_id, "run_id"))
+        object.__setattr__(self, "order_id", _uuid(self.order_id, "order_id"))
+        object.__setattr__(
+            self, "update_sequence", _sequence(self.update_sequence, "update_sequence")
+        )
+        object.__setattr__(
+            self,
+            "new_status",
+            _enum(self.new_status, ResultOrderStatus, "new_status"),
+        )
+        object.__setattr__(
+            self, "updated_at", _aware_datetime(self.updated_at, "updated_at")
+        )
+        if self.old_status is not None:
+            object.__setattr__(
+                self,
+                "old_status",
+                _enum(self.old_status, ResultOrderStatus, "old_status"),
+            )
+        object.__setattr__(self, "reason", _optional_text(self.reason, "reason"))
+
+    @property
+    def cursor_sort_key(self) -> tuple[datetime, UUID, int]:
+        return (self.updated_at, self.order_id, self.update_sequence)
+
+
+@dataclass(frozen=True, slots=True)
+class BacktestFillRecord:
+    """One simulated fill fact (logical ``backtest_fills`` row)."""
+
+    run_id: UUID
+    fill_id: UUID
+    order_id: UUID
+    instrument_id: UUID
+    display: InstrumentDisplaySnapshot
+    side: OrderSide
+    timestamp: datetime
+    price: Decimal | int | str
+    quantity: Decimal | int | str
+    fees: Decimal | int | str = ZERO
+    reference_price: Decimal | int | str | None = None
+    slippage_bps: Decimal | int | str | None = None
+    slippage_amount: Decimal | int | str | None = None
+    slippage_model_key: str | None = None
+    slippage_model_version: int | None = None
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "run_id", _uuid(self.run_id, "run_id"))
+        object.__setattr__(self, "fill_id", _uuid(self.fill_id, "fill_id"))
+        object.__setattr__(self, "order_id", _uuid(self.order_id, "order_id"))
+        object.__setattr__(self, "instrument_id", _uuid(self.instrument_id, "instrument_id"))
+        if not isinstance(self.display, InstrumentDisplaySnapshot):
+            raise DomainValidationError("display must be an InstrumentDisplaySnapshot")
+        self.display.require_matching_instrument(self.instrument_id, "display")
+        try:
+            side = OrderSide(getattr(self.side, "value", self.side))
+        except ValueError as exc:
+            raise DomainValidationError("side must be buy or sell") from exc
+        object.__setattr__(self, "side", side)
+        object.__setattr__(self, "timestamp", _aware_datetime(self.timestamp, "timestamp"))
+        object.__setattr__(self, "price", _positive(self.price, "price"))
+        object.__setattr__(self, "quantity", _positive(self.quantity, "quantity"))
+        object.__setattr__(self, "fees", _non_negative(self.fees, "fees"))
+        object.__setattr__(
+            self, "reference_price", _optional_price(self.reference_price, "reference_price")
+        )
+        object.__setattr__(
+            self, "slippage_bps", _optional_decimal(self.slippage_bps, "slippage_bps")
+        )
+        object.__setattr__(
+            self,
+            "slippage_amount",
+            _optional_decimal(self.slippage_amount, "slippage_amount"),
+        )
+        object.__setattr__(
+            self,
+            "slippage_model_key",
+            _optional_text(self.slippage_model_key, "slippage_model_key"),
+        )
+        object.__setattr__(
+            self,
+            "slippage_model_version",
+            _optional_int(self.slippage_model_version, "slippage_model_version"),
+        )
+
+    @property
+    def cursor_sort_key(self) -> tuple[datetime, UUID]:
+        return (self.timestamp, self.fill_id)
+
+
+@dataclass(frozen=True, slots=True)
+class BacktestPositionRecord:
+    """One non-zero position at a valuation point (``backtest_positions`` row).
+
+    Zero-quantity rows are rejected by construction: a missing row at a
+    valuation point means the instrument is flat, and no zero row is ever
+    synthesized.
+    """
+
+    run_id: UUID
+    as_of: datetime
+    instrument_id: UUID
+    display: InstrumentDisplaySnapshot
+    side: PositionSide
+    quantity: Decimal | int | str
+    available_quantity: Decimal | int | str
+    average_price: Decimal | int | str
+    realized_pnl: Decimal | int | str
+    unrealized_pnl: Decimal | int | str
+    mark_price: Decimal | int | str | None = None
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "run_id", _uuid(self.run_id, "run_id"))
+        object.__setattr__(self, "as_of", _aware_datetime(self.as_of, "as_of"))
+        object.__setattr__(self, "instrument_id", _uuid(self.instrument_id, "instrument_id"))
+        if not isinstance(self.display, InstrumentDisplaySnapshot):
+            raise DomainValidationError("display must be an InstrumentDisplaySnapshot")
+        self.display.require_matching_instrument(self.instrument_id, "display")
+        try:
+            side = PositionSide(getattr(self.side, "value", self.side))
+        except ValueError as exc:
+            allowed = [member.value for member in PositionSide]
+            raise DomainValidationError(f"side must be one of {allowed}") from exc
+        object.__setattr__(self, "side", side)
+        quantity = _positive(self.quantity, "quantity")
+        available_quantity = _non_negative(
+            self.available_quantity, "available_quantity"
+        )
+        if available_quantity > quantity:
+            raise DomainValidationError(
+                "available_quantity cannot exceed quantity"
+            )
+        object.__setattr__(self, "quantity", quantity)
+        object.__setattr__(self, "available_quantity", available_quantity)
+        object.__setattr__(
+            self, "average_price", _positive(self.average_price, "average_price")
+        )
+        object.__setattr__(
+            self, "mark_price", _optional_price(self.mark_price, "mark_price")
+        )
+        object.__setattr__(
+            self, "realized_pnl", _decimal(self.realized_pnl, "realized_pnl")
+        )
+        object.__setattr__(
+            self, "unrealized_pnl", _decimal(self.unrealized_pnl, "unrealized_pnl")
+        )
+
+    @property
+    def cursor_sort_key(self) -> tuple[datetime, UUID, str]:
+        return (self.as_of, self.instrument_id, self.side.value)
+
+
+@dataclass(frozen=True, slots=True)
+class BacktestEquityCurveRecord:
+    """One account valuation point (logical ``backtest_equity_curve`` row).
+
+    Field presence follows the same rule as the runtime equity curve:
+    equity-derived values exist exactly when the valuation is not blocked.
+    """
+
+    run_id: UUID
+    sequence: int
+    as_of: datetime
+    valuation_status: ValuationStatus
+    cumulative_fees: Decimal | int | str = ZERO
+    cash: Decimal | int | str | None = None
+    market_value: Decimal | int | str | None = None
+    equity: Decimal | int | str | None = None
+    cumulative_return: Decimal | int | str | None = None
+    drawdown: Decimal | int | str | None = None
+    valuation_reason: str | None = None
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "run_id", _uuid(self.run_id, "run_id"))
+        object.__setattr__(self, "sequence", _sequence(self.sequence, "sequence"))
+        object.__setattr__(self, "as_of", _aware_datetime(self.as_of, "as_of"))
+        object.__setattr__(
+            self,
+            "valuation_status",
+            _enum(self.valuation_status, ValuationStatus, "valuation_status"),
+        )
+        object.__setattr__(
+            self, "cumulative_fees", _non_negative(self.cumulative_fees, "cumulative_fees")
+        )
+        for name in ("cash", "market_value", "equity", "cumulative_return", "drawdown"):
+            object.__setattr__(
+                self, name, _optional_decimal(getattr(self, name), name)
+            )
+        blocked = self.valuation_status is ValuationStatus.BLOCKED
+        derived = ("market_value", "equity", "cumulative_return", "drawdown")
+        if blocked:
+            missing_value = any(
+                getattr(self, name) is not None for name in ("market_value", "equity")
+            )
+            if missing_value:
+                raise DomainValidationError(
+                    "blocked valuation points cannot carry equity-derived values"
+                )
+        else:
+            for name in ("cash", *derived):
+                if getattr(self, name) is None:
+                    raise DomainValidationError(
+                        f"{name} is required for {self.valuation_status.value} valuations"
+                    )
+        object.__setattr__(
+            self,
+            "valuation_reason",
+            _optional_text(self.valuation_reason, "valuation_reason"),
+        )
+
+    @property
+    def cursor_sort_key(self) -> tuple[datetime, int]:
+        return (self.as_of, self.sequence)
+
+
+@dataclass(frozen=True, slots=True)
+class BacktestMetricRecord:
+    """One metric value (logical ``backtest_metrics`` row).
+
+    A missing value is expressed as ``value = None`` plus a mandatory
+    ``unavailable_reason``; metrics are never faked with zero.
+    """
+
+    run_id: UUID
+    metric_key: str
+    formula_version: str
+    value: Decimal | int | str | None = None
+    unit: str | None = None
+    annualization_factor: Decimal | int | str | None = None
+    risk_free_rate_note: str | None = None
+    sample_count: int | None = None
+    unavailable_reason: str | None = None
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "run_id", _uuid(self.run_id, "run_id"))
+        object.__setattr__(self, "metric_key", _required_text(self.metric_key, "metric_key"))
+        object.__setattr__(
+            self, "formula_version", _required_text(self.formula_version, "formula_version")
+        )
+        object.__setattr__(self, "value", _optional_decimal(self.value, "value"))
+        object.__setattr__(self, "unit", _optional_text(self.unit, "unit"))
+        object.__setattr__(
+            self,
+            "annualization_factor",
+            _optional_decimal(self.annualization_factor, "annualization_factor"),
+        )
+        object.__setattr__(
+            self,
+            "risk_free_rate_note",
+            _optional_text(self.risk_free_rate_note, "risk_free_rate_note"),
+        )
+        object.__setattr__(
+            self, "sample_count", _optional_int(self.sample_count, "sample_count")
+        )
+        if self.sample_count is not None and self.sample_count < 0:
+            raise DomainValidationError("sample_count must be non-negative")
+        object.__setattr__(
+            self,
+            "unavailable_reason",
+            _optional_text(self.unavailable_reason, "unavailable_reason"),
+        )
+        if (self.value is None) != (self.unavailable_reason is not None):
+            raise DomainValidationError(
+                "metrics must either carry a value or an unavailable_reason, never both"
+            )
+
+    @property
+    def cursor_sort_key(self) -> tuple[str, str]:
+        return (self.metric_key, self.formula_version)
+
+
+@dataclass(frozen=True, slots=True)
+class BacktestDataPreflightRecord:
+    """One run-level data preflight report (``backtest_data_preflight`` row)."""
+
+    run_id: UUID
+    phase: DataPhase
+    status: str
+    report_hash: str
+    capabilities: Mapping[str, Any] | None = None
+    calendar_summary: Mapping[str, Any] | None = None
+    session_summary: Mapping[str, Any] | None = None
+    pit_status: str | None = None
+    coverage: Mapping[str, Any] | None = None
+    source_revisions: Mapping[str, Any] | None = None
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "run_id", _uuid(self.run_id, "run_id"))
+        object.__setattr__(self, "phase", _enum(self.phase, DataPhase, "phase"))
+        object.__setattr__(self, "status", _required_text(self.status, "status"))
+        object.__setattr__(
+            self, "report_hash", _required_text(self.report_hash, "report_hash")
+        )
+        object.__setattr__(
+            self, "pit_status", _optional_text(self.pit_status, "pit_status")
+        )
+        for name in (
+            "capabilities",
+            "calendar_summary",
+            "session_summary",
+            "coverage",
+            "source_revisions",
+        ):
+            object.__setattr__(
+                self, name, _json_payload(getattr(self, name), name)
+            )
+
+    @property
+    def cursor_sort_key(self) -> tuple[str]:
+        return (self.phase.value,)
+
+
+@dataclass(frozen=True, slots=True)
+class BacktestDataChunkRecord:
+    """One bounded data chunk (logical ``backtest_data_chunks`` row)."""
+
+    run_id: UUID
+    phase: DataPhase
+    chunk_sequence: int
+    time_start: datetime
+    time_end: datetime
+    chunk_strategy_version: str
+    token_digest: str
+    validation_status: ChunkValidationStatus
+    started_at: datetime | None = None
+    finished_at: datetime | None = None
+    failure_reason: str | None = None
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "run_id", _uuid(self.run_id, "run_id"))
+        object.__setattr__(self, "phase", _enum(self.phase, DataPhase, "phase"))
+        object.__setattr__(
+            self, "chunk_sequence", _sequence(self.chunk_sequence, "chunk_sequence")
+        )
+        object.__setattr__(self, "time_start", _aware_datetime(self.time_start, "time_start"))
+        object.__setattr__(self, "time_end", _aware_datetime(self.time_end, "time_end"))
+        if self.time_start > self.time_end:
+            raise DomainValidationError("time_start cannot be after time_end")
+        object.__setattr__(
+            self,
+            "chunk_strategy_version",
+            _required_text(self.chunk_strategy_version, "chunk_strategy_version"),
+        )
+        object.__setattr__(
+            self, "token_digest", _required_text(self.token_digest, "token_digest")
+        )
+        object.__setattr__(
+            self,
+            "validation_status",
+            _enum(self.validation_status, ChunkValidationStatus, "validation_status"),
+        )
+        if self.started_at is not None:
+            object.__setattr__(
+                self, "started_at", _aware_datetime(self.started_at, "started_at")
+            )
+        if self.finished_at is not None:
+            object.__setattr__(
+                self, "finished_at", _aware_datetime(self.finished_at, "finished_at")
+            )
+        object.__setattr__(
+            self, "failure_reason", _optional_text(self.failure_reason, "failure_reason")
+        )
+        if self.validation_status is ChunkValidationStatus.FAILED:
+            if self.failure_reason is None:
+                raise DomainValidationError("failed chunks require a failure_reason")
+        elif self.failure_reason is not None:
+            raise DomainValidationError("passed chunks cannot carry a failure_reason")
+
+    @property
+    def cursor_sort_key(self) -> tuple[str, int]:
+        return (self.phase.value, self.chunk_sequence)
+
+
+__all__ = [
+    "ChunkValidationStatus",
+    "DataPhase",
+    "DataQualityStatus",
+    "DecisionValidationStatus",
+    "BacktestDataChunkRecord",
+    "BacktestDecisionRecord",
+    "BacktestEquityCurveRecord",
+    "BacktestFillRecord",
+    "BacktestMetricRecord",
+    "BacktestOrderRecord",
+    "BacktestOrderUpdateRecord",
+    "BacktestPositionRecord",
+    "BacktestDataPreflightRecord",
+    "BacktestStepRecord",
+    "InstrumentDisplaySnapshot",
+    "ResultOrderStatus",
+    "StepPhase",
+    "resolve_display_snapshot",
+]

--- a/backend/app/backtesting/result_models.py
+++ b/backend/app/backtesting/result_models.py
@@ -624,6 +624,8 @@ class BacktestEquityCurveRecord:
     cash: Decimal | int | str | None = None
     market_value: Decimal | int | str | None = None
     equity: Decimal | int | str | None = None
+    period_return: Decimal | int | str | None = None
+    total_pnl: Decimal | int | str | None = None
     cumulative_return: Decimal | int | str | None = None
     drawdown: Decimal | int | str | None = None
     valuation_reason: str | None = None
@@ -640,19 +642,39 @@ class BacktestEquityCurveRecord:
         object.__setattr__(
             self, "cumulative_fees", _non_negative(self.cumulative_fees, "cumulative_fees")
         )
-        for name in ("cash", "market_value", "equity", "cumulative_return", "drawdown"):
+        for name in (
+            "cash",
+            "market_value",
+            "equity",
+            "period_return",
+            "total_pnl",
+            "cumulative_return",
+            "drawdown",
+        ):
             object.__setattr__(
                 self, name, _optional_decimal(getattr(self, name), name)
             )
         blocked = self.valuation_status is ValuationStatus.BLOCKED
-        derived = ("market_value", "equity", "cumulative_return", "drawdown")
+        derived = (
+            "market_value",
+            "equity",
+            "period_return",
+            "total_pnl",
+            "cumulative_return",
+            "drawdown",
+        )
         if blocked:
-            missing_value = any(
-                getattr(self, name) is not None for name in ("market_value", "equity")
-            )
-            if missing_value:
+            if any(getattr(self, name) is not None for name in derived):
                 raise DomainValidationError(
                     "blocked valuation points cannot carry equity-derived values"
+                )
+            if self.cash is None:
+                raise DomainValidationError(
+                    "blocked valuation points must still carry the cash balance"
+                )
+            if self.valuation_reason is None:
+                raise DomainValidationError(
+                    "blocked valuation points require a valuation_reason"
                 )
         else:
             for name in ("cash", *derived):

--- a/backend/app/backtesting/result_models.py
+++ b/backend/app/backtesting/result_models.py
@@ -663,6 +663,11 @@ class BacktestEquityCurveRecord:
             "cumulative_return",
             "drawdown",
         )
+        # Normalize text BEFORE validating so blank strings cannot pose as a
+        # present reason (they normalize to None).
+        normalized_reason = _optional_text(
+            self.valuation_reason, "valuation_reason"
+        )
         if blocked:
             if any(getattr(self, name) is not None for name in derived):
                 raise DomainValidationError(
@@ -672,7 +677,7 @@ class BacktestEquityCurveRecord:
                 raise DomainValidationError(
                     "blocked valuation points must still carry the cash balance"
                 )
-            if self.valuation_reason is None:
+            if normalized_reason is None:
                 raise DomainValidationError(
                     "blocked valuation points require a valuation_reason"
                 )
@@ -682,11 +687,7 @@ class BacktestEquityCurveRecord:
                     raise DomainValidationError(
                         f"{name} is required for {self.valuation_status.value} valuations"
                     )
-        object.__setattr__(
-            self,
-            "valuation_reason",
-            _optional_text(self.valuation_reason, "valuation_reason"),
-        )
+        object.__setattr__(self, "valuation_reason", normalized_reason)
 
     @property
     def cursor_sort_key(self) -> tuple[datetime, int]:

--- a/backend/app/backtesting/result_records.py
+++ b/backend/app/backtesting/result_records.py
@@ -1,0 +1,827 @@
+"""ORM records for backtest result tables.
+
+These tables store execution-time facts only; nothing is recomputed at query
+time.  Every row is bound to ``run_id`` and carries the run-scoped uniqueness
+contract defined by the result specification.  Instrument-bearing rows keep
+the stable ``instrument_id`` plus the point-in-time display snapshot frozen
+at write time; no ETF-specific column exists anywhere, so any asset class
+shares these tables.
+
+JSON columns use a PostgreSQL ``JSONB`` type with a generic ``JSON``
+variant so the repository layer can also run against SQLite in tests
+without dialect-specific constraints.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from decimal import Decimal
+from uuid import UUID, uuid4
+
+from sqlalchemy import (
+    CheckConstraint,
+    DateTime,
+    Index,
+    Integer,
+    Numeric,
+    String,
+    Uuid,
+)
+from sqlalchemy.dialects.postgresql import JSONB
+from sqlalchemy.orm import Mapped, mapped_column
+from sqlalchemy.types import JSON
+
+from app.db.base import Base
+
+
+# Money, prices, quantities, and ratios keep exact decimal semantics.
+NUMERIC_PRECISION = 38
+NUMERIC_SCALE = 18
+
+JsonType = JSONB().with_variant(JSON(), "sqlite")
+
+# Exact table names owned by this module; used by the SQLite-based tests to
+# create only these tables from the shared declarative metadata.
+RESULT_TABLE_NAMES = [
+    "backtest_steps",
+    "backtest_decisions",
+    "backtest_orders",
+    "backtest_order_updates",
+    "backtest_fills",
+    "backtest_positions",
+    "backtest_equity_curve",
+    "backtest_metrics",
+    "backtest_data_preflight",
+    "backtest_data_chunks",
+]
+
+
+def _amount_column(name: str, comment: str, nullable: bool = False):
+    return mapped_column(
+        name,
+        Numeric(NUMERIC_PRECISION, NUMERIC_SCALE),
+        nullable=nullable,
+        comment=comment,
+    )
+
+
+class _RunBoundRecord(Base):
+    """Abstract base carrying the shared run binding and timestamps."""
+
+    __abstract__ = True
+
+    id: Mapped[UUID] = mapped_column(
+        Uuid,
+        primary_key=True,
+        default=uuid4,
+        comment="Surrogate primary key; business identity lives in the unique key.",
+    )
+    run_id: Mapped[UUID] = mapped_column(
+        Uuid,
+        nullable=False,
+        comment="Owning backtest run; every result row is bound to exactly one run. "
+        "A foreign key to backtest_runs is added by the run-creation task.",
+    )
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        nullable=False,
+        # Python-side default keeps inserts portable across PostgreSQL and
+        # the SQLite test dialect; no database-specific SQL default is used.
+        default=lambda: datetime.now(timezone.utc),
+        comment="Row creation timestamp.",
+    )
+
+
+class BacktestStepRecord(_RunBoundRecord):
+    """One time step of one run."""
+
+    __tablename__ = "backtest_steps"
+    __table_args__ = (
+        CheckConstraint(
+            "time_start <= time_end",
+            name="step_time_range_ordered",
+        ),
+        Index(
+            "uq_backtest_steps_run_sequence",
+            "run_id",
+            "step_sequence",
+            unique=True,
+        ),
+    )
+
+    step_sequence: Mapped[int] = mapped_column(
+        Integer,
+        nullable=False,
+        comment="Stable in-run step number used as the pagination sort key.",
+    )
+    time_start: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        nullable=False,
+        comment="Inclusive start of the step interval.",
+    )
+    time_end: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        nullable=False,
+        comment="Inclusive end of the step interval.",
+    )
+    data_cutoff_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        nullable=False,
+        comment="Point-in-time data cutoff observed by this step.",
+    )
+    phase: Mapped[str] = mapped_column(
+        String(32),
+        nullable=False,
+        comment="Coarse step phase (stable persisted enum value).",
+    )
+    data_quality: Mapped[str] = mapped_column(
+        String(16),
+        nullable=False,
+        comment="Input data quality outcome for the step.",
+    )
+
+
+class BacktestDecisionRecord(_RunBoundRecord):
+    """One strategy decision produced during a step."""
+
+    __tablename__ = "backtest_decisions"
+    __table_args__ = (
+        Index(
+            "uq_backtest_decisions_run_decision",
+            "run_id",
+            "decision_id",
+            unique=True,
+        ),
+        Index(
+            "ix_backtest_decisions_run_sort_key",
+            "run_id",
+            "step_sequence",
+            "decision_time",
+            "decision_id",
+        ),
+    )
+
+    decision_id: Mapped[UUID] = mapped_column(
+        Uuid,
+        nullable=False,
+        comment="Business identity of the decision within the run.",
+    )
+    step_sequence: Mapped[int] = mapped_column(
+        Integer,
+        nullable=False,
+        comment="Step that produced the decision.",
+    )
+    decision_time: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        nullable=False,
+        comment="Timezone-aware decision timestamp.",
+    )
+    mode: Mapped[str] = mapped_column(
+        String(64),
+        nullable=False,
+        comment="Registered strategy decision mode.",
+    )
+    targets: Mapped[dict] = mapped_column(
+        JsonType,
+        nullable=False,
+        comment="Normalized decision targets (no binary floats).",
+    )
+    validation_status: Mapped[str] = mapped_column(
+        String(16),
+        nullable=False,
+        comment="Outcome of decision validation.",
+    )
+    validation_issues: Mapped[list] = mapped_column(
+        JsonType,
+        nullable=False,
+        comment="Structured validation issues when the decision was rejected.",
+    )
+    duration_ms: Mapped[Decimal | None] = mapped_column(
+        Numeric(NUMERIC_PRECISION, NUMERIC_SCALE),
+        nullable=True,
+        comment="Strategy wall-clock duration in milliseconds.",
+    )
+    error: Mapped[str | None] = mapped_column(
+        String(1000),
+        nullable=True,
+        comment="Error summary when the decision failed.",
+    )
+
+
+class BacktestOrderResultRecord(_RunBoundRecord):
+    """One standard order persisted as a result fact."""
+
+    __tablename__ = "backtest_orders"
+    __table_args__ = (
+        CheckConstraint(
+            "filled_quantity >= 0 AND filled_quantity <= quantity",
+            name="order_filled_within_quantity",
+        ),
+        Index(
+            "uq_backtest_orders_run_order",
+            "run_id",
+            "order_id",
+            unique=True,
+        ),
+        Index(
+            "ix_backtest_orders_run_sort_key",
+            "run_id",
+            "submitted_at",
+            "order_id",
+        ),
+        Index(
+            "ix_backtest_orders_run_instrument",
+            "run_id",
+            "instrument_id",
+        ),
+    )
+
+    order_id: Mapped[UUID] = mapped_column(
+        Uuid,
+        nullable=False,
+        comment="Business identity of the order within the run.",
+    )
+    intent_id: Mapped[UUID | None] = mapped_column(
+        Uuid,
+        nullable=True,
+        comment="Originating order intent, when the pipeline recorded one.",
+    )
+    instrument_id: Mapped[UUID] = mapped_column(
+        Uuid,
+        nullable=False,
+        comment="Stable instrument identity; never a trading code.",
+    )
+    event_trading_code: Mapped[str | None] = mapped_column(
+        String(64),
+        nullable=True,
+        comment="Trading code valid at the event time, frozen on write.",
+    )
+    event_name: Mapped[str | None] = mapped_column(
+        String(200),
+        nullable=True,
+        comment="Instrument name valid at the event time, frozen on write.",
+    )
+    event_display_name: Mapped[str | None] = mapped_column(
+        String(200),
+        nullable=True,
+        comment="Display name valid at the event time, frozen on write.",
+    )
+    side: Mapped[str] = mapped_column(
+        String(8),
+        nullable=False,
+        comment="Order direction (buy/sell).",
+    )
+    order_type: Mapped[str] = mapped_column(
+        String(32),
+        nullable=False,
+        comment="Standard order type identifier.",
+    )
+    price: Mapped[Decimal | None] = mapped_column(
+        Numeric(NUMERIC_PRECISION, NUMERIC_SCALE),
+        nullable=True,
+        comment="Limit price; null for market orders.",
+    )
+    quantity: Mapped[Decimal] = mapped_column(
+        Numeric(NUMERIC_PRECISION, NUMERIC_SCALE),
+        nullable=False,
+        comment="Ordered quantity.",
+    )
+    filled_quantity: Mapped[Decimal] = mapped_column(
+        Numeric(NUMERIC_PRECISION, NUMERIC_SCALE),
+        nullable=False,
+        comment="Cumulative filled quantity at the latest update.",
+    )
+    status: Mapped[str] = mapped_column(
+        String(24),
+        nullable=False,
+        comment="Latest persisted order status.",
+    )
+    status_reason: Mapped[str | None] = mapped_column(
+        String(500),
+        nullable=True,
+        comment="Human-readable reason attached to the latest status.",
+    )
+    submitted_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        nullable=False,
+        comment="Order submission time; first half of the pagination sort key.",
+    )
+
+
+class BacktestOrderUpdateRecord(_RunBoundRecord):
+    """One order status transition."""
+
+    __tablename__ = "backtest_order_updates"
+    __table_args__ = (
+        Index(
+            "uq_backtest_order_updates_run_order_seq",
+            "run_id",
+            "order_id",
+            "update_sequence",
+            unique=True,
+        ),
+        Index(
+            "ix_backtest_order_updates_run_sort_key",
+            "run_id",
+            "updated_at",
+            "order_id",
+            "update_sequence",
+        ),
+    )
+
+    order_id: Mapped[UUID] = mapped_column(
+        Uuid,
+        nullable=False,
+        comment="Order whose state changed.",
+    )
+    update_sequence: Mapped[int] = mapped_column(
+        Integer,
+        nullable=False,
+        comment="Monotonic update counter within the order.",
+    )
+    old_status: Mapped[str | None] = mapped_column(
+        String(24),
+        nullable=True,
+        comment="Status before the transition; null for the first update.",
+    )
+    new_status: Mapped[str] = mapped_column(
+        String(24),
+        nullable=False,
+        comment="Status after the transition.",
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        nullable=False,
+        comment="Transition timestamp.",
+    )
+    reason: Mapped[str | None] = mapped_column(
+        String(500),
+        nullable=True,
+        comment="Reason recorded with the transition.",
+    )
+
+
+class BacktestFillResultRecord(_RunBoundRecord):
+    """One simulated fill fact."""
+
+    __tablename__ = "backtest_fills"
+    __table_args__ = (
+        Index(
+            "uq_backtest_fills_run_fill",
+            "run_id",
+            "fill_id",
+            unique=True,
+        ),
+        Index(
+            "ix_backtest_fills_run_sort_key",
+            "run_id",
+            "timestamp",
+            "fill_id",
+        ),
+        Index(
+            "ix_backtest_fills_run_instrument",
+            "run_id",
+            "instrument_id",
+        ),
+    )
+
+    fill_id: Mapped[UUID] = mapped_column(
+        Uuid,
+        nullable=False,
+        comment="Business identity of the fill within the run.",
+    )
+    order_id: Mapped[UUID] = mapped_column(
+        Uuid,
+        nullable=False,
+        comment="Order that produced this fill.",
+    )
+    instrument_id: Mapped[UUID] = mapped_column(
+        Uuid,
+        nullable=False,
+        comment="Stable instrument identity; never a trading code.",
+    )
+    event_trading_code: Mapped[str | None] = mapped_column(
+        String(64),
+        nullable=True,
+        comment="Trading code valid at the event time, frozen on write.",
+    )
+    event_name: Mapped[str | None] = mapped_column(
+        String(200),
+        nullable=True,
+        comment="Instrument name valid at the event time, frozen on write.",
+    )
+    event_display_name: Mapped[str | None] = mapped_column(
+        String(200),
+        nullable=True,
+        comment="Display name valid at the event time, frozen on write.",
+    )
+    side: Mapped[str] = mapped_column(
+        String(8),
+        nullable=False,
+        comment="Fill direction (buy/sell).",
+    )
+    timestamp: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        nullable=False,
+        comment="Execution timestamp; first half of the pagination sort key.",
+    )
+    reference_price: Mapped[Decimal | None] = mapped_column(
+        Numeric(NUMERIC_PRECISION, NUMERIC_SCALE),
+        nullable=True,
+        comment="Pre-slippage reference price kept for auditability.",
+    )
+    price: Mapped[Decimal] = mapped_column(
+        Numeric(NUMERIC_PRECISION, NUMERIC_SCALE),
+        nullable=False,
+        comment="Final execution price.",
+    )
+    quantity: Mapped[Decimal] = mapped_column(
+        Numeric(NUMERIC_PRECISION, NUMERIC_SCALE),
+        nullable=False,
+        comment="Executed quantity.",
+    )
+    fees: Mapped[Decimal] = mapped_column(
+        Numeric(NUMERIC_PRECISION, NUMERIC_SCALE),
+        nullable=False,
+        comment="Total fees charged with this fill.",
+    )
+    slippage_bps: Mapped[Decimal | None] = mapped_column(
+        Numeric(NUMERIC_PRECISION, NUMERIC_SCALE),
+        nullable=True,
+        comment="Realized slippage in basis points.",
+    )
+    slippage_amount: Mapped[Decimal | None] = mapped_column(
+        Numeric(NUMERIC_PRECISION, NUMERIC_SCALE),
+        nullable=True,
+        comment="Realized slippage amount in currency units.",
+    )
+    slippage_model_key: Mapped[str | None] = mapped_column(
+        String(100),
+        nullable=True,
+        comment="Slippage model identifier applied to this fill.",
+    )
+    slippage_model_version: Mapped[int | None] = mapped_column(
+        Integer,
+        nullable=True,
+        comment="Version of the slippage model applied to this fill.",
+    )
+
+
+class BacktestPositionResultRecord(_RunBoundRecord):
+    """One non-zero position at one valuation point."""
+
+    __tablename__ = "backtest_positions"
+    __table_args__ = (
+        CheckConstraint(
+            "quantity > 0",
+            name="position_quantity_non_zero",
+        ),
+        CheckConstraint(
+            "available_quantity >= 0 AND available_quantity <= quantity",
+            name="position_available_within_quantity",
+        ),
+        Index(
+            "uq_backtest_positions_run_point_instrument_side",
+            "run_id",
+            "as_of",
+            "instrument_id",
+            "side",
+            unique=True,
+        ),
+    )
+
+    as_of: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        nullable=False,
+        comment="Valuation timestamp; first part of the pagination sort key.",
+    )
+    instrument_id: Mapped[UUID] = mapped_column(
+        Uuid,
+        nullable=False,
+        comment="Stable instrument identity; never a trading code.",
+    )
+    event_trading_code: Mapped[str | None] = mapped_column(
+        String(64),
+        nullable=True,
+        comment="Trading code valid at the valuation point, frozen on write.",
+    )
+    event_name: Mapped[str | None] = mapped_column(
+        String(200),
+        nullable=True,
+        comment="Instrument name valid at the valuation point, frozen on write.",
+    )
+    event_display_name: Mapped[str | None] = mapped_column(
+        String(200),
+        nullable=True,
+        comment="Display name valid at the valuation point, frozen on write.",
+    )
+    side: Mapped[str] = mapped_column(
+        String(8),
+        nullable=False,
+        comment="Position side (long/short/net).",
+    )
+    quantity: Mapped[Decimal] = mapped_column(
+        Numeric(NUMERIC_PRECISION, NUMERIC_SCALE),
+        nullable=False,
+        comment="Non-zero held quantity.",
+    )
+    available_quantity: Mapped[Decimal] = mapped_column(
+        Numeric(NUMERIC_PRECISION, NUMERIC_SCALE),
+        nullable=False,
+        comment="Quantity currently sellable under settlement rules.",
+    )
+    average_price: Mapped[Decimal] = mapped_column(
+        Numeric(NUMERIC_PRECISION, NUMERIC_SCALE),
+        nullable=False,
+        comment="Cost-basis average price.",
+    )
+    mark_price: Mapped[Decimal | None] = mapped_column(
+        Numeric(NUMERIC_PRECISION, NUMERIC_SCALE),
+        nullable=True,
+        comment="Valuation mark price; null when no valid mark existed.",
+    )
+    realized_pnl: Mapped[Decimal] = mapped_column(
+        Numeric(NUMERIC_PRECISION, NUMERIC_SCALE),
+        nullable=False,
+        comment="Realized profit and loss up to this point.",
+    )
+    unrealized_pnl: Mapped[Decimal] = mapped_column(
+        Numeric(NUMERIC_PRECISION, NUMERIC_SCALE),
+        nullable=False,
+        comment="Unrealized profit and loss at this valuation point.",
+    )
+
+
+class BacktestEquityCurveRecord(_RunBoundRecord):
+    """One account valuation point of the equity curve."""
+
+    __tablename__ = "backtest_equity_curve"
+    __table_args__ = (
+        Index(
+            "uq_backtest_equity_curve_run_sequence",
+            "run_id",
+            "sequence",
+            unique=True,
+        ),
+        Index(
+            "ix_backtest_equity_curve_run_sort_key",
+            "run_id",
+            "as_of",
+            "sequence",
+        ),
+    )
+
+    sequence: Mapped[int] = mapped_column(
+        Integer,
+        nullable=False,
+        comment="Stable in-run valuation counter.",
+    )
+    as_of: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        nullable=False,
+        comment="Valuation timestamp.",
+    )
+    valuation_status: Mapped[str] = mapped_column(
+        String(16),
+        nullable=False,
+        comment="Whether the valuation was complete, degraded, or blocked.",
+    )
+    valuation_reason: Mapped[str | None] = mapped_column(
+        String(500),
+        nullable=True,
+        comment="Reason attached to degraded or blocked valuations.",
+    )
+    cash: Mapped[Decimal | None] = mapped_column(
+        Numeric(NUMERIC_PRECISION, NUMERIC_SCALE),
+        nullable=True,
+        comment="Cash balance; null only for blocked points.",
+    )
+    market_value: Mapped[Decimal | None] = mapped_column(
+        Numeric(NUMERIC_PRECISION, NUMERIC_SCALE),
+        nullable=True,
+        comment="Marked market value; null for blocked points.",
+    )
+    equity: Mapped[Decimal | None] = mapped_column(
+        Numeric(NUMERIC_PRECISION, NUMERIC_SCALE),
+        nullable=True,
+        comment="Account equity; null for blocked points.",
+    )
+    cumulative_return: Mapped[Decimal | None] = mapped_column(
+        Numeric(NUMERIC_PRECISION, NUMERIC_SCALE),
+        nullable=True,
+        comment="Cumulative return versus initial equity; null for blocked points.",
+    )
+    drawdown: Mapped[Decimal | None] = mapped_column(
+        Numeric(NUMERIC_PRECISION, NUMERIC_SCALE),
+        nullable=True,
+        comment="Drawdown from peak equity; null for blocked points.",
+    )
+    cumulative_fees: Mapped[Decimal] = mapped_column(
+        Numeric(NUMERIC_PRECISION, NUMERIC_SCALE),
+        nullable=False,
+        comment="Total fees accumulated through this point.",
+    )
+
+
+class BacktestMetricRecord(_RunBoundRecord):
+    """One metric value or an explicit unavailability record."""
+
+    __tablename__ = "backtest_metrics"
+    __table_args__ = (
+        CheckConstraint(
+            "(value IS NULL) = (unavailable_reason IS NOT NULL)",
+            name="metric_value_xor_reason",
+        ),
+        Index(
+            "uq_backtest_metrics_run_key_version",
+            "run_id",
+            "metric_key",
+            "formula_version",
+            unique=True,
+        ),
+    )
+
+    metric_key: Mapped[str] = mapped_column(
+        String(100),
+        nullable=False,
+        comment="Stable metric key.",
+    )
+    formula_version: Mapped[str] = mapped_column(
+        String(32),
+        nullable=False,
+        comment="Version of the metric formula that produced the value.",
+    )
+    value: Mapped[Decimal | None] = mapped_column(
+        Numeric(NUMERIC_PRECISION, NUMERIC_SCALE),
+        nullable=True,
+        comment="Metric value; null together with unavailable_reason when missing.",
+    )
+    unit: Mapped[str | None] = mapped_column(
+        String(32),
+        nullable=True,
+        comment="Unit of the metric value.",
+    )
+    annualization_factor: Mapped[Decimal | None] = mapped_column(
+        Numeric(NUMERIC_PRECISION, NUMERIC_SCALE),
+        nullable=True,
+        comment="Annualization factor applied by the formula.",
+    )
+    risk_free_rate_note: Mapped[str | None] = mapped_column(
+        String(200),
+        nullable=True,
+        comment="Risk-free rate convention used by the formula.",
+    )
+    sample_count: Mapped[int | None] = mapped_column(
+        Integer,
+        nullable=True,
+        comment="Number of samples behind the value.",
+    )
+    unavailable_reason: Mapped[str | None] = mapped_column(
+        String(500),
+        nullable=True,
+        comment="Why the value is unavailable; required exactly when value is null.",
+    )
+
+
+class BacktestDataPreflightResultRecord(_RunBoundRecord):
+    """One run-level data preflight report."""
+
+    __tablename__ = "backtest_data_preflight"
+    __table_args__ = (
+        Index(
+            "uq_backtest_data_preflight_run_phase",
+            "run_id",
+            "phase",
+            unique=True,
+        ),
+    )
+
+    phase: Mapped[str] = mapped_column(
+        String(16),
+        nullable=False,
+        comment="Preflight phase (admission/session).",
+    )
+    status: Mapped[str] = mapped_column(
+        String(32),
+        nullable=False,
+        comment="Overall preflight outcome.",
+    )
+    report_hash: Mapped[str] = mapped_column(
+        String(128),
+        nullable=False,
+        comment="Hash over the preflight report content.",
+    )
+    capabilities: Mapped[dict] = mapped_column(
+        JsonType,
+        nullable=False,
+        comment="Capability checklist captured by the report.",
+    )
+    calendar_summary: Mapped[dict] = mapped_column(
+        JsonType,
+        nullable=False,
+        comment="Named calendar sets and their coverage summary.",
+    )
+    session_summary: Mapped[dict] = mapped_column(
+        JsonType,
+        nullable=False,
+        comment="Session compatibility and day-level differences summary.",
+    )
+    pit_status: Mapped[str | None] = mapped_column(
+        String(32),
+        nullable=True,
+        comment="Point-in-time readiness conclusion.",
+    )
+    coverage: Mapped[dict] = mapped_column(
+        JsonType,
+        nullable=False,
+        comment="Coverage statistics of the requested data.",
+    )
+    source_revisions: Mapped[dict] = mapped_column(
+        JsonType,
+        nullable=False,
+        comment="Source-data revisions observed by the report.",
+    )
+
+
+class BacktestDataChunkRecord(_RunBoundRecord):
+    """One bounded data chunk consistency record."""
+
+    __tablename__ = "backtest_data_chunks"
+    __table_args__ = (
+        CheckConstraint(
+            "time_start <= time_end",
+            name="chunk_time_range_ordered",
+        ),
+        Index(
+            "uq_backtest_data_chunks_run_phase_seq",
+            "run_id",
+            "phase",
+            "chunk_sequence",
+            unique=True,
+        ),
+    )
+
+    phase: Mapped[str] = mapped_column(
+        String(16),
+        nullable=False,
+        comment="Data phase owning the chunk (admission/session).",
+    )
+    chunk_sequence: Mapped[int] = mapped_column(
+        Integer,
+        nullable=False,
+        comment="Chunk counter within the run and phase.",
+    )
+    time_start: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        nullable=False,
+        comment="Inclusive chunk start.",
+    )
+    time_end: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        nullable=False,
+        comment="Inclusive chunk end.",
+    )
+    chunk_strategy_version: Mapped[str] = mapped_column(
+        String(32),
+        nullable=False,
+        comment="Version of the chunking policy that produced boundaries.",
+    )
+    token_digest: Mapped[str] = mapped_column(
+        String(128),
+        nullable=False,
+        comment="Non-sensitive digest identifying the data token.",
+    )
+    validation_status: Mapped[str] = mapped_column(
+        String(16),
+        nullable=False,
+        comment="Chunk validation outcome.",
+    )
+    started_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True),
+        nullable=True,
+        comment="When chunk validation started.",
+    )
+    finished_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True),
+        nullable=True,
+        comment="When chunk validation finished.",
+    )
+    failure_reason: Mapped[str | None] = mapped_column(
+        String(1000),
+        nullable=True,
+        comment="Failure reason; required exactly for failed chunks.",
+    )
+
+
+__all__ = [
+    "BacktestDataChunkRecord",
+    "BacktestDataPreflightResultRecord",
+    "BacktestDecisionRecord",
+    "BacktestEquityCurveRecord",
+    "BacktestFillResultRecord",
+    "BacktestMetricRecord",
+    "BacktestOrderResultRecord",
+    "BacktestOrderUpdateRecord",
+    "BacktestPositionResultRecord",
+    "BacktestStepRecord",
+]

--- a/backend/app/backtesting/result_records.py
+++ b/backend/app/backtesting/result_records.py
@@ -606,6 +606,16 @@ class BacktestEquityCurveRecord(_RunBoundRecord):
         nullable=True,
         comment="Account equity; null for blocked points.",
     )
+    period_return: Mapped[Decimal | None] = mapped_column(
+        Numeric(NUMERIC_PRECISION, NUMERIC_SCALE),
+        nullable=True,
+        comment="Period return versus the previous valid point; null for blocked points.",
+    )
+    total_pnl: Mapped[Decimal | None] = mapped_column(
+        Numeric(NUMERIC_PRECISION, NUMERIC_SCALE),
+        nullable=True,
+        comment="Total profit and loss versus initial equity; null for blocked points.",
+    )
     cumulative_return: Mapped[Decimal | None] = mapped_column(
         Numeric(NUMERIC_PRECISION, NUMERIC_SCALE),
         nullable=True,

--- a/backend/app/backtesting/result_records.py
+++ b/backend/app/backtesting/result_records.py
@@ -591,10 +591,10 @@ class BacktestEquityCurveRecord(_RunBoundRecord):
         nullable=True,
         comment="Reason attached to degraded or blocked valuations.",
     )
-    cash: Mapped[Decimal | None] = mapped_column(
+    cash: Mapped[Decimal] = mapped_column(
         Numeric(NUMERIC_PRECISION, NUMERIC_SCALE),
-        nullable=True,
-        comment="Cash balance; null only for blocked points.",
+        nullable=False,
+        comment="Cash balance; carried even by blocked valuation points.",
     )
     market_value: Mapped[Decimal | None] = mapped_column(
         Numeric(NUMERIC_PRECISION, NUMERIC_SCALE),

--- a/backend/app/backtesting/result_repository.py
+++ b/backend/app/backtesting/result_repository.py
@@ -713,6 +713,14 @@ class BacktestResultRepository:
         conditions.extend(
             self._filter_condition(spec, name, value) for name, value in filters.items()
         )
+        # All first_value calls MUST share one window ordered by the FULL
+        # sort-key tuple.  Ordering each column independently would pick the
+        # maximum of every column from different rows, producing a bound no
+        # real row ever had.
+        window_order = [
+            getattr(record_cls, column_name).desc()
+            for column_name in spec.sort_columns
+        ]
         window_columns = []
         for position, column_name in enumerate(spec.sort_columns):
             column = getattr(record_cls, column_name)
@@ -720,7 +728,7 @@ class BacktestResultRepository:
             # dialect's result processor still converts raw DB values.
             first_value = func.first_value(column, type_=column.type)
             window_columns.append(
-                first_value.over(order_by=column.desc()).label(
+                first_value.over(order_by=window_order).label(
                     f"__upper_bound_{position}"
                 )
             )

--- a/backend/app/backtesting/result_repository.py
+++ b/backend/app/backtesting/result_repository.py
@@ -24,7 +24,7 @@ from types import MappingProxyType
 from typing import Any, Callable, Mapping, Sequence
 from uuid import UUID
 
-from sqlalchemy import and_, or_, select
+from sqlalchemy import and_, func, or_, select
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
 
@@ -32,8 +32,11 @@ from app.backtesting.pagination import (
     DEFAULT_PAGE_SIZE,
     MAX_PAGE_SIZE,
     CursorPage,
+    CursorQueryMismatchError,
     build_cursor,
     compute_query_digest,
+    encode_sort_element,
+    hmac_compare,
     normalize_limit,
     parse_cursor,
 )
@@ -104,6 +107,18 @@ def _aware(value: datetime) -> datetime:
 
     if value.tzinfo is None or value.utcoffset() is None:
         return value.replace(tzinfo=timezone.utc)
+    return value
+
+
+def _normalize_sort_value(kind: str, value: Any) -> Any:
+    """Coerce a raw column value into its typed, comparable sort-key form."""
+
+    if kind == "ts":
+        return _aware(value)
+    if kind == "uuid":
+        return value if isinstance(value, UUID) else UUID(str(value))
+    if kind == "dec":
+        return value if isinstance(value, Decimal) else Decimal(str(value))
     return value
 
 
@@ -216,6 +231,8 @@ def _equity_record(dto: BacktestEquityCurveDto) -> dict[str, Any]:
         "cash": dto.cash,
         "market_value": dto.market_value,
         "equity": dto.equity,
+        "period_return": dto.period_return,
+        "total_pnl": dto.total_pnl,
         "cumulative_return": dto.cumulative_return,
         "drawdown": dto.drawdown,
         "cumulative_fees": dto.cumulative_fees,
@@ -494,8 +511,13 @@ def build_query_payload(
 class BacktestResultRepository:
     """Write result facts and read them back through stable cursor pages."""
 
-    def __init__(self, session: Session) -> None:
+    def __init__(self, session: Session, *, cursor_signing_key: str) -> None:
+        # Cursors are HMAC-signed server-side; without a secret they could be
+        # forged into another syntactically valid shape.
+        if not isinstance(cursor_signing_key, str) or not cursor_signing_key.strip():
+            raise ValueError("cursor_signing_key must be non-blank text")
         self.session = session
+        self._signing_key = cursor_signing_key
 
     # -- writes ------------------------------------------------------------
 
@@ -518,10 +540,14 @@ class BacktestResultRepository:
                     f"{kind} expects {spec.dto_cls.__name__}, got "
                     f"{type(dto).__name__}"
                 )
-            identity = tuple(getattr(dto, name) for name in spec.identity_fields)
+            identity = (
+                dto.run_id,
+                *(getattr(dto, name) for name in spec.identity_fields),
+            )
             if identity in seen:
                 raise ResultRecordConflictError(
-                    f"duplicate {kind} identity {identity} within the batch"
+                    f"duplicate {kind} identity {identity[1:]} within the same "
+                    "run's batch"
                 )
             seen.add(identity)
             payloads.append(spec.to_record(dto))
@@ -548,9 +574,12 @@ class BacktestResultRepository:
         """Return one stable page of results for a run.
 
         The first call captures the maximum visible sort-key tuple as the
-        query's upper bound; every later page reached through the returned
-        cursor stays inside that bound, so rows appended while a client is
-        paging never create duplicates or shift earlier pages.
+        query's upper bound inside the SAME SQL statement that reads the
+        page (window functions), so under READ COMMITTED the page and the
+        bound always come from one snapshot.  Every later page reached
+        through the returned cursor stays inside that bound, so rows
+        appended while a client is paging never create duplicates or shift
+        earlier pages.
         """
 
         spec = get_result_kind_spec(kind)
@@ -566,52 +595,159 @@ class BacktestResultRepository:
                 filters[name] = normalized
 
         payload = build_query_payload(spec, run_id=run_uuid, limit=checked_limit, filters=filters)
-        digest = compute_query_digest(payload)
 
-        statement = self._base_statement(spec, run_uuid, filters)
-        parsed = None
-        if cursor is not None:
-            parsed = self._parse_cursor(spec, cursor, digest)
-            statement = statement.where(
-                self._keyset_predicate(spec, parsed.last_sort_key, mode="after")
-            ).where(
-                self._keyset_predicate(
-                    spec,
-                    tuple(parsed.query_upper_bound[column] for column in spec.sort_columns),
-                    # Inclusive bound: the maximum row visible at snapshot time
-                    # must stay readable; appended rows sort strictly beyond it.
-                    mode="at_or_before",
-                )
-            )
+        if cursor is None:
+            return self._read_first_page(spec, payload, run_uuid, filters, checked_limit)
+        return self._read_continuation_page(
+            spec, payload, run_uuid, filters, checked_limit, cursor
+        )
 
-        rows = self._fetch_page(statement, spec, checked_limit)
-        has_more = len(rows) > checked_limit
-        items = tuple(rows[:checked_limit])
+    # -- internals ---------------------------------------------------------
+
+    def _read_first_page(
+        self,
+        spec: ResultKindSpec,
+        payload: Mapping[str, Any],
+        run_id: UUID,
+        filters: Mapping[str, str],
+        limit: int,
+    ) -> CursorPage:
+        """Read the first page and its upper bound from one statement.
+
+        ``first_value(...) OVER (ORDER BY <sort> DESC)`` exposes the maximum
+        visible sort-key columns next to every row.  Because window
+        functions are evaluated over the full filtered row set before LIMIT,
+        the page and the bound cannot come from different snapshots.
+        """
+
+        statement = self._first_page_statement(spec, run_id, filters)
+        executed = list(self.session.execute(statement.limit(limit + 1)))
+        rows = [row[0] for row in executed]
+        # Re-sort defensively so tie handling stays observable in Python.
+        rows.sort(key=lambda row: self._row_sort_key(spec, row))
+        has_more = len(rows) > limit
+        items = tuple(rows[:limit])
         if not items:
             return CursorPage(items=(), next_cursor=None, has_more=False)
 
         next_cursor: str | None = None
         if has_more:
-            last_key = self._row_sort_key(spec, items[-1])
-            if parsed is not None:
-                # Continuation pages must keep the snapshot upper bound of the
-                # original first page; recomputing it would admit rows that
-                # were appended after the walk began.
-                bound = tuple(
-                    parsed.query_upper_bound[column] for column in spec.sort_columns
-                )
-            else:
-                bound = self._upper_bound(spec, run_uuid, filters)
+            bound = self._bound_from_window_row(spec, executed[0])
+            encoded_bound = self._encode_bound(spec, dict(zip(spec.sort_columns, bound)))
+            digest = compute_query_digest({**payload, "query_upper_bound": encoded_bound})
             next_cursor = build_cursor(
+                signing_key=self._signing_key,
                 query_digest=digest,
                 key_kinds=spec.key_kinds,
-                last_sort_key=last_key,
+                last_sort_key=self._row_sort_key(spec, items[-1]),
                 upper_bound_columns=spec.upper_bound_columns,
                 query_upper_bound=dict(zip(spec.sort_columns, bound)),
             )
         return CursorPage(items=items, next_cursor=next_cursor, has_more=has_more)
 
-    # -- internals ---------------------------------------------------------
+    def _read_continuation_page(
+        self,
+        spec: ResultKindSpec,
+        payload: Mapping[str, Any],
+        run_id: UUID,
+        filters: Mapping[str, str],
+        limit: int,
+        cursor: str,
+    ) -> CursorPage:
+        parsed = parse_cursor(
+            cursor,
+            signing_key=self._signing_key,
+            key_kinds=spec.key_kinds,
+            upper_bound_columns=spec.upper_bound_columns,
+        )
+        # The snapshot upper bound of the original first page is reused;
+        # recomputing it would admit rows appended after the walk began.
+        bound_values = tuple(
+            parsed.query_upper_bound[column] for column in spec.sort_columns
+        )
+        encoded_bound = self._encode_bound(
+            spec, dict(zip(spec.sort_columns, bound_values))
+        )
+        expected_digest = compute_query_digest(
+            {**payload, "query_upper_bound": encoded_bound}
+        )
+        if not hmac_compare(parsed.query_digest, expected_digest):
+            raise CursorQueryMismatchError(
+                "cursor belongs to a different query; restart from the first page"
+            )
+
+        statement = self._base_statement(spec, run_id, filters).where(
+            self._keyset_predicate(spec, parsed.last_sort_key, mode="after")
+        ).where(
+            # Inclusive bound: the maximum row visible at snapshot time must
+            # stay readable; appended rows sort strictly beyond it.
+            self._keyset_predicate(spec, bound_values, mode="at_or_before")
+        )
+        rows = list(self.session.scalars(statement.limit(limit + 1)))
+        rows.sort(key=lambda row: self._row_sort_key(spec, row))
+        has_more = len(rows) > limit
+        items = tuple(rows[:limit])
+        if not items:
+            return CursorPage(items=(), next_cursor=None, has_more=False)
+
+        next_cursor: str | None = None
+        if has_more:
+            next_cursor = build_cursor(
+                signing_key=self._signing_key,
+                query_digest=expected_digest,
+                key_kinds=spec.key_kinds,
+                last_sort_key=self._row_sort_key(spec, items[-1]),
+                upper_bound_columns=spec.upper_bound_columns,
+                query_upper_bound=dict(zip(spec.sort_columns, bound_values)),
+            )
+        return CursorPage(items=items, next_cursor=next_cursor, has_more=has_more)
+
+    def _first_page_statement(
+        self,
+        spec: ResultKindSpec,
+        run_id: UUID,
+        filters: Mapping[str, str],
+    ):
+        record_cls = spec.record_cls
+        conditions: list[Any] = [record_cls.run_id == run_id]
+        conditions.extend(
+            self._filter_condition(spec, name, value) for name, value in filters.items()
+        )
+        window_columns = []
+        for position, column_name in enumerate(spec.sort_columns):
+            column = getattr(record_cls, column_name)
+            # Carry the column type into the function expression so the
+            # dialect's result processor still converts raw DB values.
+            first_value = func.first_value(column, type_=column.type)
+            window_columns.append(
+                first_value.over(order_by=column.desc()).label(
+                    f"__upper_bound_{position}"
+                )
+            )
+        return (
+            select(record_cls, *window_columns)
+            .where(*conditions)
+            .order_by(*[getattr(record_cls, column).asc() for column in spec.sort_columns])
+        )
+
+    def _encode_bound(self, spec: ResultKindSpec, bound: Mapping[str, Any]) -> dict[str, Any]:
+        """Canonical wire form of an upper bound, feeding the query digest.
+
+        Binding the digest to the bound means a cursor can only be paired
+        with the exact query state it was issued for.
+        """
+
+        return {
+            column: encode_sort_element(spec.upper_bound_columns[column], bound[column])
+            for column in sorted(bound)
+        }
+
+    def _bound_from_window_row(self, spec: ResultKindSpec, row: Any) -> tuple[Any, ...]:
+        values: list[Any] = []
+        for position, kind in enumerate(spec.key_kinds):
+            raw = getattr(row, f"__upper_bound_{position}")
+            values.append(_normalize_sort_value(kind, raw))
+        return tuple(values)
 
     def _base_statement(
         self,
@@ -680,55 +816,12 @@ class BacktestResultRepository:
             conditions.append(and_(*conjunction))
         return or_(*conditions)
 
-    def _fetch_page(self, statement: Any, spec: ResultKindSpec, limit: int):
-        rows = list(self.session.scalars(statement.limit(limit + 1)))
-        # Re-sort defensively: SQLite stores timestamps lexicographically and
-        # multi-column ordering matches the SQL ORDER BY, but keeping the
-        # Python-side guarantee explicit makes tie handling observable.
-        rows.sort(key=lambda row: self._row_sort_key(spec, row))
-        return rows
-
     def _row_sort_key(self, spec: ResultKindSpec, row: Any) -> tuple[Any, ...]:
         """Typed, comparable sort-key tuple of one ORM row."""
 
-        key: list[Any] = []
-        for column, kind in zip(spec.sort_columns, spec.key_kinds):
-            value = getattr(row, column)
-            if kind == "ts":
-                value = _aware(value)
-            elif kind == "uuid":
-                value = value if isinstance(value, UUID) else UUID(str(value))
-            elif kind == "dec":
-                value = value if isinstance(value, Decimal) else Decimal(str(value))
-            key.append(value)
-        return tuple(key)
-
-    def _upper_bound(
-        self,
-        spec: ResultKindSpec,
-        run_id: UUID,
-        filters: Mapping[str, str],
-    ) -> tuple[Any, ...]:
-        """Maximum sort-key tuple currently visible for this exact query."""
-
-        # A fresh statement is required: appending a second order_by() would
-        # combine both orderings instead of reversing the first one.
-        statement = self._base_statement(
-            spec, run_id, filters, descending=True
-        ).limit(1)
-        top = self.session.scalar(statement)
-        if top is None:
-            return ()
-        return self._row_sort_key(spec, top)
-
-    def _parse_cursor(self, spec: ResultKindSpec, token: str, digest: str):
-        # parse_cursor raises the specific CursorError subclasses directly;
-        # the router maps them to an explicit parameter error.
-        return parse_cursor(
-            token,
-            expected_query_digest=digest,
-            key_kinds=spec.key_kinds,
-            upper_bound_columns=spec.upper_bound_columns,
+        return tuple(
+            _normalize_sort_value(kind, getattr(row, column))
+            for column, kind in zip(spec.sort_columns, spec.key_kinds)
         )
 
 

--- a/backend/app/backtesting/result_repository.py
+++ b/backend/app/backtesting/result_repository.py
@@ -1,0 +1,743 @@
+"""Persistence and cursor-paginated queries for backtest results.
+
+The repository owns three responsibilities:
+
+1. writing validated result DTOs into the append-only result tables,
+   rejecting duplicate business keys inside a run;
+2. building stable keyset-paginated reads whose sort keys match the
+   result specification exactly (time ties are broken by entity id or
+   in-run sequence, never by mutable display fields);
+3. issuing opaque cursors bound to a canonicalized query digest and a
+   snapshot upper bound so appended rows never leak into an existing page
+   walk.
+
+The repository depends on validated DTOs and SQLAlchemy records only; it
+never resolves instruments itself, so no market-data client can leak in.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from decimal import Decimal
+from types import MappingProxyType
+from typing import Any, Callable, Mapping, Sequence
+from uuid import UUID
+
+from sqlalchemy import and_, or_, select
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.orm import Session
+
+from app.backtesting.pagination import (
+    DEFAULT_PAGE_SIZE,
+    MAX_PAGE_SIZE,
+    CursorPage,
+    build_cursor,
+    compute_query_digest,
+    normalize_limit,
+    parse_cursor,
+)
+from app.backtesting.result_models import (
+    BacktestDataChunkRecord as BacktestDataChunkDto,
+    BacktestDataPreflightRecord as BacktestDataPreflightDto,
+    BacktestDecisionRecord as BacktestDecisionDto,
+    BacktestEquityCurveRecord as BacktestEquityCurveDto,
+    BacktestFillRecord as BacktestFillDto,
+    BacktestMetricRecord as BacktestMetricDto,
+    BacktestOrderRecord as BacktestOrderDto,
+    BacktestOrderUpdateRecord as BacktestOrderUpdateDto,
+    BacktestPositionRecord as BacktestPositionDto,
+    BacktestStepRecord as BacktestStepDto,
+)
+from app.backtesting.result_records import (
+    BacktestDataChunkRecord,
+    BacktestDataPreflightResultRecord,
+    BacktestDecisionRecord,
+    BacktestEquityCurveRecord,
+    BacktestFillResultRecord,
+    BacktestMetricRecord,
+    BacktestOrderResultRecord,
+    BacktestOrderUpdateRecord,
+    BacktestPositionResultRecord,
+    BacktestStepRecord,
+)
+
+
+class ResultRepositoryError(ValueError):
+    """Base class for repository usage errors."""
+
+
+class UnknownResultKindError(ResultRepositoryError):
+    """The requested result kind is not registered."""
+
+
+class ResultFilterError(ResultRepositoryError):
+    """A filter is not supported by the requested result kind."""
+
+
+class ResultRecordConflictError(Exception):
+    """The row violates the run-scoped uniqueness contract."""
+
+
+# ---------------------------------------------------------------------------
+# DTO -> record conversion helpers
+# ---------------------------------------------------------------------------
+
+
+def _thaw_json(value: Any) -> Any:
+    """Convert frozen containers back into JSON-serializable structures."""
+
+    if isinstance(value, MappingProxyType) or isinstance(value, Mapping):
+        return {key: _thaw_json(item) for key, item in value.items()}
+    if isinstance(value, (list, tuple)):
+        return [_thaw_json(item) for item in value]
+    return value
+
+
+def _aware(value: datetime) -> datetime:
+    """Reattach UTC to naive datetimes returned by non-tz databases.
+
+    PostgreSQL ``timestamptz`` always returns aware values; the UTC fallback
+    keeps SQLite-based tests deterministic without weakening production
+    semantics.
+    """
+
+    if value.tzinfo is None or value.utcoffset() is None:
+        return value.replace(tzinfo=timezone.utc)
+    return value
+
+
+def _step_record(dto: BacktestStepDto) -> dict[str, Any]:
+    return {
+        "run_id": dto.run_id,
+        "step_sequence": dto.step_sequence,
+        "time_start": dto.time_start,
+        "time_end": dto.time_end,
+        "data_cutoff_at": dto.data_cutoff_at,
+        "phase": dto.phase.value,
+        "data_quality": dto.data_quality.value,
+    }
+
+
+def _decision_record(dto: BacktestDecisionDto) -> dict[str, Any]:
+    return {
+        "run_id": dto.run_id,
+        "decision_id": dto.decision_id,
+        "step_sequence": dto.step_sequence,
+        "decision_time": dto.decision_time,
+        "mode": dto.mode,
+        "targets": _thaw_json(dict(dto.targets)),
+        "validation_status": dto.validation_status.value,
+        "validation_issues": list(dto.validation_issues),
+        "duration_ms": dto.duration_ms,
+        "error": dto.error,
+    }
+
+
+def _order_record(dto: BacktestOrderDto) -> dict[str, Any]:
+    return {
+        "run_id": dto.run_id,
+        "order_id": dto.order_id,
+        "intent_id": dto.intent_id,
+        "instrument_id": dto.instrument_id,
+        "event_trading_code": dto.display.event_trading_code,
+        "event_name": dto.display.event_name,
+        "event_display_name": dto.display.event_display_name,
+        "side": dto.side.value,
+        "order_type": dto.order_type,
+        "price": dto.price,
+        "quantity": dto.quantity,
+        "filled_quantity": dto.filled_quantity,
+        "status": dto.status.value,
+        "status_reason": dto.status_reason,
+        "submitted_at": dto.submitted_at,
+    }
+
+
+def _order_update_record(dto: BacktestOrderUpdateDto) -> dict[str, Any]:
+    return {
+        "run_id": dto.run_id,
+        "order_id": dto.order_id,
+        "update_sequence": dto.update_sequence,
+        "old_status": dto.old_status.value if dto.old_status else None,
+        "new_status": dto.new_status.value,
+        "updated_at": dto.updated_at,
+        "reason": dto.reason,
+    }
+
+
+def _fill_record(dto: BacktestFillDto) -> dict[str, Any]:
+    return {
+        "run_id": dto.run_id,
+        "fill_id": dto.fill_id,
+        "order_id": dto.order_id,
+        "instrument_id": dto.instrument_id,
+        "event_trading_code": dto.display.event_trading_code,
+        "event_name": dto.display.event_name,
+        "event_display_name": dto.display.event_display_name,
+        "side": dto.side.value,
+        "timestamp": dto.timestamp,
+        "reference_price": dto.reference_price,
+        "price": dto.price,
+        "quantity": dto.quantity,
+        "fees": dto.fees,
+        "slippage_bps": dto.slippage_bps,
+        "slippage_amount": dto.slippage_amount,
+        "slippage_model_key": dto.slippage_model_key,
+        "slippage_model_version": dto.slippage_model_version,
+    }
+
+
+def _position_record(dto: BacktestPositionDto) -> dict[str, Any]:
+    return {
+        "run_id": dto.run_id,
+        "as_of": dto.as_of,
+        "instrument_id": dto.instrument_id,
+        "event_trading_code": dto.display.event_trading_code,
+        "event_name": dto.display.event_name,
+        "event_display_name": dto.display.event_display_name,
+        "side": dto.side.value,
+        "quantity": dto.quantity,
+        "available_quantity": dto.available_quantity,
+        "average_price": dto.average_price,
+        "mark_price": dto.mark_price,
+        "realized_pnl": dto.realized_pnl,
+        "unrealized_pnl": dto.unrealized_pnl,
+    }
+
+
+def _equity_record(dto: BacktestEquityCurveDto) -> dict[str, Any]:
+    return {
+        "run_id": dto.run_id,
+        "sequence": dto.sequence,
+        "as_of": dto.as_of,
+        "valuation_status": dto.valuation_status.value,
+        "valuation_reason": dto.valuation_reason,
+        "cash": dto.cash,
+        "market_value": dto.market_value,
+        "equity": dto.equity,
+        "cumulative_return": dto.cumulative_return,
+        "drawdown": dto.drawdown,
+        "cumulative_fees": dto.cumulative_fees,
+    }
+
+
+def _metric_record(dto: BacktestMetricDto) -> dict[str, Any]:
+    return {
+        "run_id": dto.run_id,
+        "metric_key": dto.metric_key,
+        "formula_version": dto.formula_version,
+        "value": dto.value,
+        "unit": dto.unit,
+        "annualization_factor": dto.annualization_factor,
+        "risk_free_rate_note": dto.risk_free_rate_note,
+        "sample_count": dto.sample_count,
+        "unavailable_reason": dto.unavailable_reason,
+    }
+
+
+def _preflight_record(dto: BacktestDataPreflightDto) -> dict[str, Any]:
+    return {
+        "run_id": dto.run_id,
+        "phase": dto.phase.value,
+        "status": dto.status,
+        "report_hash": dto.report_hash,
+        "capabilities": _thaw_json(dict(dto.capabilities)),
+        "calendar_summary": _thaw_json(dict(dto.calendar_summary)),
+        "session_summary": _thaw_json(dict(dto.session_summary)),
+        "pit_status": dto.pit_status,
+        "coverage": _thaw_json(dict(dto.coverage)),
+        "source_revisions": _thaw_json(dict(dto.source_revisions)),
+    }
+
+
+def _chunk_record(dto: BacktestDataChunkDto) -> dict[str, Any]:
+    return {
+        "run_id": dto.run_id,
+        "phase": dto.phase.value,
+        "chunk_sequence": dto.chunk_sequence,
+        "time_start": dto.time_start,
+        "time_end": dto.time_end,
+        "chunk_strategy_version": dto.chunk_strategy_version,
+        "token_digest": dto.token_digest,
+        "validation_status": dto.validation_status.value,
+        "started_at": dto.started_at,
+        "finished_at": dto.finished_at,
+        "failure_reason": dto.failure_reason,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Result kind registry
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True, slots=True)
+class ResultKindSpec:
+    """Static description of one result type's persistence contract."""
+
+    kind: str
+    dto_cls: type
+    record_cls: type
+    to_record: Callable[[Any], dict[str, Any]]
+    # Pagination sort keys: ORM column name plus wire element kind.
+    sort_columns: tuple[str, ...]
+    key_kinds: tuple[str, ...]
+    # Business identity used for in-batch duplicate detection.
+    identity_fields: tuple[str, ...]
+    # Event timestamp used by inclusive start/end filters, when supported.
+    time_column: str | None = None
+    allowed_filters: frozenset[str] = frozenset()
+
+    @property
+    def upper_bound_columns(self) -> dict[str, str]:
+        """Column-to-kind map validated inside every cursor token."""
+
+        return dict(zip(self.sort_columns, self.key_kinds))
+
+
+_RESULT_KINDS: dict[str, ResultKindSpec] = {
+    spec.kind: spec
+    for spec in (
+        ResultKindSpec(
+            kind="steps",
+            dto_cls=BacktestStepDto,
+            record_cls=BacktestStepRecord,
+            to_record=_step_record,
+            sort_columns=("step_sequence",),
+            key_kinds=("int",),
+            identity_fields=("step_sequence",),
+            allowed_filters=frozenset({"phase"}),
+        ),
+        ResultKindSpec(
+            kind="decisions",
+            dto_cls=BacktestDecisionDto,
+            record_cls=BacktestDecisionRecord,
+            to_record=_decision_record,
+            sort_columns=("step_sequence", "decision_time", "decision_id"),
+            key_kinds=("int", "ts", "uuid"),
+            identity_fields=("decision_id",),
+            time_column="decision_time",
+            allowed_filters=frozenset({"mode", "start_time", "end_time"}),
+        ),
+        ResultKindSpec(
+            kind="orders",
+            dto_cls=BacktestOrderDto,
+            record_cls=BacktestOrderResultRecord,
+            to_record=_order_record,
+            sort_columns=("submitted_at", "order_id"),
+            key_kinds=("ts", "uuid"),
+            identity_fields=("order_id",),
+            time_column="submitted_at",
+            allowed_filters=frozenset(
+                {"instrument_id", "status", "side", "start_time", "end_time"}
+            ),
+        ),
+        ResultKindSpec(
+            kind="order_updates",
+            dto_cls=BacktestOrderUpdateDto,
+            record_cls=BacktestOrderUpdateRecord,
+            to_record=_order_update_record,
+            sort_columns=("updated_at", "order_id", "update_sequence"),
+            key_kinds=("ts", "uuid", "int"),
+            identity_fields=("order_id", "update_sequence"),
+            time_column="updated_at",
+            allowed_filters=frozenset({"status", "start_time", "end_time"}),
+        ),
+        ResultKindSpec(
+            kind="fills",
+            dto_cls=BacktestFillDto,
+            record_cls=BacktestFillResultRecord,
+            to_record=_fill_record,
+            sort_columns=("timestamp", "fill_id"),
+            key_kinds=("ts", "uuid"),
+            identity_fields=("fill_id",),
+            time_column="timestamp",
+            allowed_filters=frozenset(
+                {"instrument_id", "side", "start_time", "end_time"}
+            ),
+        ),
+        ResultKindSpec(
+            kind="positions",
+            dto_cls=BacktestPositionDto,
+            record_cls=BacktestPositionResultRecord,
+            to_record=_position_record,
+            sort_columns=("as_of", "instrument_id", "side"),
+            key_kinds=("ts", "uuid", "str"),
+            identity_fields=("as_of", "instrument_id", "side"),
+            time_column="as_of",
+            allowed_filters=frozenset(
+                {"instrument_id", "side", "start_time", "end_time"}
+            ),
+        ),
+        ResultKindSpec(
+            kind="equity_curve",
+            dto_cls=BacktestEquityCurveDto,
+            record_cls=BacktestEquityCurveRecord,
+            to_record=_equity_record,
+            sort_columns=("as_of", "sequence"),
+            key_kinds=("ts", "int"),
+            identity_fields=("sequence",),
+            time_column="as_of",
+            allowed_filters=frozenset({"start_time", "end_time"}),
+        ),
+        ResultKindSpec(
+            kind="metrics",
+            dto_cls=BacktestMetricDto,
+            record_cls=BacktestMetricRecord,
+            to_record=_metric_record,
+            sort_columns=("metric_key", "formula_version"),
+            key_kinds=("str", "str"),
+            identity_fields=("metric_key", "formula_version"),
+            allowed_filters=frozenset(),
+        ),
+        ResultKindSpec(
+            kind="data_preflight",
+            dto_cls=BacktestDataPreflightDto,
+            record_cls=BacktestDataPreflightResultRecord,
+            to_record=_preflight_record,
+            sort_columns=("phase",),
+            key_kinds=("str",),
+            identity_fields=("phase",),
+            allowed_filters=frozenset(),
+        ),
+        ResultKindSpec(
+            kind="data_chunks",
+            dto_cls=BacktestDataChunkDto,
+            record_cls=BacktestDataChunkRecord,
+            to_record=_chunk_record,
+            sort_columns=("phase", "chunk_sequence"),
+            key_kinds=("str", "int"),
+            identity_fields=("phase", "chunk_sequence"),
+            allowed_filters=frozenset({"phase"}),
+        ),
+    )
+}
+
+
+def get_result_kind_spec(kind: str) -> ResultKindSpec:
+    try:
+        return _RESULT_KINDS[kind]
+    except KeyError as exc:
+        raise UnknownResultKindError(f"unknown result kind: {kind!r}") from exc
+
+
+# ---------------------------------------------------------------------------
+# Query canonicalization
+# ---------------------------------------------------------------------------
+
+
+def _normalize_instant(value: datetime) -> str:
+    """Canonical string form of a filter boundary for digest purposes."""
+
+    if value.tzinfo is None or value.utcoffset() is None:
+        raise ResultFilterError("start_time/end_time must be timezone-aware")
+    return value.astimezone(timezone.utc).isoformat()
+
+
+def _normalize_filter_value(name: str, value: Any) -> str | None:
+    """Normalize one raw filter argument into its digest representation."""
+
+    if value is None:
+        return None
+    if name == "instrument_id":
+        return str(_require_uuid(name, value))
+    if name == "start_time" or name == "end_time":
+        return _normalize_instant(value)
+    if isinstance(value, str):
+        normalized = value.strip()
+        return normalized or None
+    raise ResultFilterError(f"unsupported filter value type for {name}")
+
+
+def _require_uuid(name: str, value: Any) -> UUID:
+    if isinstance(value, str):
+        try:
+            return UUID(value)
+        except ValueError as exc:
+            raise ResultFilterError(f"{name} must be a valid UUID") from exc
+    if not isinstance(value, UUID):
+        raise ResultFilterError(f"{name} must be a UUID")
+    return value
+
+
+def build_query_payload(
+    spec: ResultKindSpec,
+    *,
+    run_id: UUID,
+    limit: int,
+    filters: Mapping[str, str],
+) -> dict[str, Any]:
+    """Canonical query description feeding the cursor digest.
+
+    Every condition that can change the result set participates: run id,
+    each filter, the fixed ascending sort keys, the page-size policy, and
+    the concrete limit requested by the client.
+    """
+
+    return {
+        "kind": spec.kind,
+        "run_id": str(run_id),
+        "filters": dict(sorted(filters.items())),
+        "direction": "asc",
+        "sort_keys": list(spec.sort_columns),
+        "page_size_policy": {"default": DEFAULT_PAGE_SIZE, "max": MAX_PAGE_SIZE},
+        "limit": limit,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Repository
+# ---------------------------------------------------------------------------
+
+
+class BacktestResultRepository:
+    """Write result facts and read them back through stable cursor pages."""
+
+    def __init__(self, session: Session) -> None:
+        self.session = session
+
+    # -- writes ------------------------------------------------------------
+
+    def append(self, kind: str, *dtos: Any) -> int:
+        """Persist validated DTOs; return the number of rows written.
+
+        Duplicate business keys inside the batch or already persisted in the
+        same run raise :class:`ResultRecordConflictError`; the caller owns
+        the surrounding transaction.
+        """
+
+        spec = get_result_kind_spec(kind)
+        if not dtos:
+            return 0
+        seen: set[tuple[Any, ...]] = set()
+        payloads: list[dict[str, Any]] = []
+        for dto in dtos:
+            if not isinstance(dto, spec.dto_cls):
+                raise ResultRepositoryError(
+                    f"{kind} expects {spec.dto_cls.__name__}, got "
+                    f"{type(dto).__name__}"
+                )
+            identity = tuple(getattr(dto, name) for name in spec.identity_fields)
+            if identity in seen:
+                raise ResultRecordConflictError(
+                    f"duplicate {kind} identity {identity} within the batch"
+                )
+            seen.add(identity)
+            payloads.append(spec.to_record(dto))
+        try:
+            self.session.add_all([spec.record_cls(**payload) for payload in payloads])
+            self.session.flush()
+        except IntegrityError as exc:
+            raise ResultRecordConflictError(
+                f"{kind} row violates the run-scoped uniqueness contract"
+            ) from exc
+        return len(payloads)
+
+    # -- reads -------------------------------------------------------------
+
+    def read_page(
+        self,
+        kind: str,
+        *,
+        run_id: UUID | str,
+        limit: int = DEFAULT_PAGE_SIZE,
+        cursor: str | None = None,
+        **raw_filters: Any,
+    ) -> CursorPage:
+        """Return one stable page of results for a run.
+
+        The first call captures the maximum visible sort-key tuple as the
+        query's upper bound; every later page reached through the returned
+        cursor stays inside that bound, so rows appended while a client is
+        paging never create duplicates or shift earlier pages.
+        """
+
+        spec = get_result_kind_spec(kind)
+        run_uuid = _require_uuid("run_id", run_id)
+        checked_limit = normalize_limit(limit)
+
+        filters: dict[str, str] = {}
+        for name, value in raw_filters.items():
+            if name not in spec.allowed_filters:
+                raise ResultFilterError(f"{kind} does not support filter {name!r}")
+            normalized = _normalize_filter_value(name, value)
+            if normalized is not None:
+                filters[name] = normalized
+
+        payload = build_query_payload(spec, run_id=run_uuid, limit=checked_limit, filters=filters)
+        digest = compute_query_digest(payload)
+
+        statement = self._base_statement(spec, run_uuid, filters)
+        parsed = None
+        if cursor is not None:
+            parsed = self._parse_cursor(spec, cursor, digest)
+            statement = statement.where(
+                self._keyset_predicate(spec, parsed.last_sort_key, mode="after")
+            ).where(
+                self._keyset_predicate(
+                    spec,
+                    tuple(parsed.query_upper_bound[column] for column in spec.sort_columns),
+                    # Inclusive bound: the maximum row visible at snapshot time
+                    # must stay readable; appended rows sort strictly beyond it.
+                    mode="at_or_before",
+                )
+            )
+
+        rows = self._fetch_page(statement, spec, checked_limit)
+        has_more = len(rows) > checked_limit
+        items = tuple(rows[:checked_limit])
+        if not items:
+            return CursorPage(items=(), next_cursor=None, has_more=False)
+
+        next_cursor: str | None = None
+        if has_more:
+            last_key = self._row_sort_key(spec, items[-1])
+            if parsed is not None:
+                # Continuation pages must keep the snapshot upper bound of the
+                # original first page; recomputing it would admit rows that
+                # were appended after the walk began.
+                bound = tuple(
+                    parsed.query_upper_bound[column] for column in spec.sort_columns
+                )
+            else:
+                bound = self._upper_bound(spec, run_uuid, filters)
+            next_cursor = build_cursor(
+                query_digest=digest,
+                key_kinds=spec.key_kinds,
+                last_sort_key=last_key,
+                upper_bound_columns=spec.upper_bound_columns,
+                query_upper_bound=dict(zip(spec.sort_columns, bound)),
+            )
+        return CursorPage(items=items, next_cursor=next_cursor, has_more=has_more)
+
+    # -- internals ---------------------------------------------------------
+
+    def _base_statement(
+        self,
+        spec: ResultKindSpec,
+        run_id: UUID,
+        filters: Mapping[str, str],
+        *,
+        descending: bool = False,
+    ):
+        record_cls = spec.record_cls
+        statement = select(record_cls).where(record_cls.run_id == run_id)
+        for name, value in filters.items():
+            statement = statement.where(self._filter_condition(spec, name, value))
+        directions = (
+            [getattr(record_cls, column).desc() for column in spec.sort_columns]
+            if descending
+            else [getattr(record_cls, column).asc() for column in spec.sort_columns]
+        )
+        statement = statement.order_by(*directions)
+        return statement
+
+    def _filter_condition(self, spec: ResultKindSpec, name: str, value: str):
+        record_cls = spec.record_cls
+        if name == "instrument_id":
+            return record_cls.instrument_id == UUID(value)
+        if name == "start_time":
+            assert spec.time_column is not None
+            return getattr(record_cls, spec.time_column) >= datetime.fromisoformat(value)
+        if name == "end_time":
+            assert spec.time_column is not None
+            return getattr(record_cls, spec.time_column) <= datetime.fromisoformat(value)
+        # Remaining filters target a column named after the filter itself,
+        # except the order-update alias `status` -> `new_status`.
+        column_name = "new_status" if name == "status" and spec.kind == "order_updates" else name
+        return getattr(record_cls, column_name) == value
+
+    def _keyset_predicate(
+        self,
+        spec: ResultKindSpec,
+        values: Sequence[Any],
+        *,
+        mode: str,
+    ):
+        """Tuple comparison expanded into OR-of-ANDS for portability.
+
+        ``mode="after"`` selects tuples strictly greater than ``values``
+        (page continuation).  ``mode="at_or_before"`` selects tuples less
+        than or equal to ``values`` (the snapshot upper bound), so the
+        maximum row visible when pagination started stays readable.
+        """
+
+        columns = [getattr(spec.record_cls, column) for column in spec.sort_columns]
+        inclusive = mode == "at_or_before"
+        conditions = []
+        last_position = len(columns) - 1
+        for position in range(len(columns)):
+            conjunction = [columns[index] == values[index] for index in range(position)]
+            column = columns[position]
+            value = values[position]
+            if inclusive:
+                conjunction.append(
+                    column <= value if position == last_position else column < value
+                )
+            else:
+                conjunction.append(column > value)
+            conditions.append(and_(*conjunction))
+        return or_(*conditions)
+
+    def _fetch_page(self, statement: Any, spec: ResultKindSpec, limit: int):
+        rows = list(self.session.scalars(statement.limit(limit + 1)))
+        # Re-sort defensively: SQLite stores timestamps lexicographically and
+        # multi-column ordering matches the SQL ORDER BY, but keeping the
+        # Python-side guarantee explicit makes tie handling observable.
+        rows.sort(key=lambda row: self._row_sort_key(spec, row))
+        return rows
+
+    def _row_sort_key(self, spec: ResultKindSpec, row: Any) -> tuple[Any, ...]:
+        """Typed, comparable sort-key tuple of one ORM row."""
+
+        key: list[Any] = []
+        for column, kind in zip(spec.sort_columns, spec.key_kinds):
+            value = getattr(row, column)
+            if kind == "ts":
+                value = _aware(value)
+            elif kind == "uuid":
+                value = value if isinstance(value, UUID) else UUID(str(value))
+            elif kind == "dec":
+                value = value if isinstance(value, Decimal) else Decimal(str(value))
+            key.append(value)
+        return tuple(key)
+
+    def _upper_bound(
+        self,
+        spec: ResultKindSpec,
+        run_id: UUID,
+        filters: Mapping[str, str],
+    ) -> tuple[Any, ...]:
+        """Maximum sort-key tuple currently visible for this exact query."""
+
+        # A fresh statement is required: appending a second order_by() would
+        # combine both orderings instead of reversing the first one.
+        statement = self._base_statement(
+            spec, run_id, filters, descending=True
+        ).limit(1)
+        top = self.session.scalar(statement)
+        if top is None:
+            return ()
+        return self._row_sort_key(spec, top)
+
+    def _parse_cursor(self, spec: ResultKindSpec, token: str, digest: str):
+        # parse_cursor raises the specific CursorError subclasses directly;
+        # the router maps them to an explicit parameter error.
+        return parse_cursor(
+            token,
+            expected_query_digest=digest,
+            key_kinds=spec.key_kinds,
+            upper_bound_columns=spec.upper_bound_columns,
+        )
+
+
+__all__ = [
+    "BacktestResultRepository",
+    "ResultFilterError",
+    "ResultRecordConflictError",
+    "ResultRepositoryError",
+    "UnknownResultKindError",
+    "build_query_payload",
+    "get_result_kind_spec",
+]

--- a/backend/app/backtesting/result_router.py
+++ b/backend/app/backtesting/result_router.py
@@ -56,19 +56,21 @@ def _page_or_error(page: CursorPage) -> dict[str, object]:
 
 
 def _cursor_signing_key(request: Request) -> str:
-    """Resolve the cursor HMAC secret from the serving app instance.
+    """Resolve the server-only cursor HMAC secret for this app instance.
 
-    Reading ``request.app.state.settings`` (instead of the cached global
-    settings) keeps cursors signed with exactly the token of the deployment
-    that created them, including ``create_app(settings=...)`` and test
-    injections.
+    The signing key is a dedicated secret (``QF_CURSOR_SIGNING_KEY``) that
+    clients never hold; deriving it from the API token would let any
+    authenticated caller forge validly signed cursors.  Reading
+    ``request.app.state.settings`` keeps cursors signed with exactly the
+    configuration of the serving deployment, including
+    ``create_app(settings=...)`` and test injections.
     """
 
     settings = getattr(request.app.state, "settings", None)
-    api_token = getattr(settings, "api_token", None)
-    if api_token is None:
+    signing_key = getattr(settings, "cursor_signing_key", None)
+    if signing_key is None:
         raise RuntimeError("application settings are not attached to app.state")
-    return api_token.get_secret_value()
+    return signing_key.get_secret_value()
 
 
 CursorSigningKey = Annotated[str, Depends(_cursor_signing_key)]

--- a/backend/app/backtesting/result_router.py
+++ b/backend/app/backtesting/result_router.py
@@ -38,6 +38,7 @@ from app.backtesting.result_schemas import (
     BacktestStepItem,
     ResultCursorPage,
 )
+from app.core.config import get_settings
 from app.db.session import get_db_session
 
 
@@ -56,8 +57,14 @@ def _page_or_error(page: CursorPage) -> dict[str, object]:
 
 
 def _read_page(kind: str, *, run_id: UUID, limit: int, cursor: str | None, session: Session, **filters: object) -> dict[str, object]:
+    repository = BacktestResultRepository(
+        session,
+        # Reuse the deployment's API token as the cursor HMAC secret so no
+        # extra configuration key is required for the first version.
+        cursor_signing_key=get_settings().api_token.get_secret_value(),
+    )
     try:
-        page = BacktestResultRepository(session).read_page(
+        page = repository.read_page(
             kind, run_id=run_id, limit=limit, cursor=cursor, **filters
         )
     except ResultFilterError as exc:

--- a/backend/app/backtesting/result_router.py
+++ b/backend/app/backtesting/result_router.py
@@ -1,0 +1,288 @@
+"""Read-only HTTP APIs for backtest result lists.
+
+These endpoints only read results that a run has already persisted; they
+never create runs, execute backtests, or recompute any engine output.  All
+lists share one stable cursor-pagination contract: ``limit`` between 1 and
+500 (default 100), an optional opaque ``cursor``, inclusive time bounds,
+and kind-specific stable filters.  Invalid or mismatched cursors produce
+an explicit 400 parameter error instead of silently restarting pagination.
+"""
+
+from datetime import datetime
+from typing import Annotated
+from uuid import UUID
+
+from fastapi import APIRouter, Depends, HTTPException, Path, Query
+from sqlalchemy.orm import Session
+
+from app.backtesting.pagination import (
+    DEFAULT_PAGE_SIZE,
+    CursorError,
+    CursorPage,
+)
+from app.backtesting.result_repository import (
+    BacktestResultRepository,
+    ResultFilterError,
+    UnknownResultKindError,
+)
+from app.backtesting.result_schemas import (
+    BacktestDataChunkItem,
+    BacktestDataPreflightItem,
+    BacktestDecisionItem,
+    BacktestEquityCurveItem,
+    BacktestFillItem,
+    BacktestMetricItem,
+    BacktestOrderItem,
+    BacktestOrderUpdateItem,
+    BacktestPositionItem,
+    BacktestStepItem,
+    ResultCursorPage,
+)
+from app.db.session import get_db_session
+
+
+router = APIRouter(
+    prefix="/api/admin/backtest-runs/{run_id}/results",
+    tags=["backtest-results"],
+)
+
+
+def _page_or_error(page: CursorPage) -> dict[str, object]:
+    return {
+        "items": list(page.items),
+        "next_cursor": page.next_cursor,
+        "has_more": page.has_more,
+    }
+
+
+def _read_page(kind: str, *, run_id: UUID, limit: int, cursor: str | None, session: Session, **filters: object) -> dict[str, object]:
+    try:
+        page = BacktestResultRepository(session).read_page(
+            kind, run_id=run_id, limit=limit, cursor=cursor, **filters
+        )
+    except ResultFilterError as exc:
+        raise HTTPException(status_code=422, detail=str(exc)) from exc
+    except CursorError as exc:
+        # Invalid, tampered, version-mismatched, or query-incompatible
+        # cursors are explicit parameter errors; never restart silently.
+        raise HTTPException(
+            status_code=400,
+            detail=f"无效或不适配的游标：{exc}",
+        ) from exc
+    except UnknownResultKindError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+    except ValueError as exc:
+        # Covers the page-size policy and non-timezone-aware boundaries.
+        raise HTTPException(status_code=422, detail=str(exc)) from exc
+    return _page_or_error(page)
+
+
+@router.get("/steps", response_model=ResultCursorPage[BacktestStepItem])
+def list_steps(
+    run_id: Annotated[UUID, Path()],
+    limit: Annotated[int, Query(ge=1, le=500)] = DEFAULT_PAGE_SIZE,
+    cursor: Annotated[str | None, Query(min_length=1)] = None,
+    phase: Annotated[str | None, Query(min_length=1, max_length=32)] = None,
+    session: Session = Depends(get_db_session),
+) -> dict[str, object]:
+    """List time steps in stable step-sequence order."""
+
+    return _read_page(
+        "steps", run_id=run_id, limit=limit, cursor=cursor, session=session, phase=phase
+    )
+
+
+@router.get("/decisions", response_model=ResultCursorPage[BacktestDecisionItem])
+def list_decisions(
+    run_id: Annotated[UUID, Path()],
+    limit: Annotated[int, Query(ge=1, le=500)] = DEFAULT_PAGE_SIZE,
+    cursor: Annotated[str | None, Query(min_length=1)] = None,
+    mode: Annotated[str | None, Query(min_length=1, max_length=64)] = None,
+    start_time: Annotated[datetime | None, Query()] = None,
+    end_time: Annotated[datetime | None, Query()] = None,
+    session: Session = Depends(get_db_session),
+) -> dict[str, object]:
+    """List strategy decisions ordered by step, time, and decision id."""
+
+    return _read_page(
+        "decisions",
+        run_id=run_id,
+        limit=limit,
+        cursor=cursor,
+        session=session,
+        mode=mode,
+        start_time=start_time,
+        end_time=end_time,
+    )
+
+
+@router.get("/orders", response_model=ResultCursorPage[BacktestOrderItem])
+def list_orders(
+    run_id: Annotated[UUID, Path()],
+    limit: Annotated[int, Query(ge=1, le=500)] = DEFAULT_PAGE_SIZE,
+    cursor: Annotated[str | None, Query(min_length=1)] = None,
+    instrument_id: Annotated[UUID | None, Query()] = None,
+    status: Annotated[str | None, Query(min_length=1, max_length=24)] = None,
+    side: Annotated[str | None, Query(min_length=1, max_length=8)] = None,
+    start_time: Annotated[datetime | None, Query()] = None,
+    end_time: Annotated[datetime | None, Query()] = None,
+    session: Session = Depends(get_db_session),
+) -> dict[str, object]:
+    """List orders ordered by submission time with id tie-breaking."""
+
+    return _read_page(
+        "orders",
+        run_id=run_id,
+        limit=limit,
+        cursor=cursor,
+        session=session,
+        instrument_id=instrument_id,
+        status=status,
+        side=side,
+        start_time=start_time,
+        end_time=end_time,
+    )
+
+
+@router.get("/order-updates", response_model=ResultCursorPage[BacktestOrderUpdateItem])
+def list_order_updates(
+    run_id: Annotated[UUID, Path()],
+    limit: Annotated[int, Query(ge=1, le=500)] = DEFAULT_PAGE_SIZE,
+    cursor: Annotated[str | None, Query(min_length=1)] = None,
+    status: Annotated[str | None, Query(min_length=1, max_length=24)] = None,
+    start_time: Annotated[datetime | None, Query()] = None,
+    end_time: Annotated[datetime | None, Query()] = None,
+    session: Session = Depends(get_db_session),
+) -> dict[str, object]:
+    """List order state transitions in update order."""
+
+    return _read_page(
+        "order_updates",
+        run_id=run_id,
+        limit=limit,
+        cursor=cursor,
+        session=session,
+        status=status,
+        start_time=start_time,
+        end_time=end_time,
+    )
+
+
+@router.get("/fills", response_model=ResultCursorPage[BacktestFillItem])
+def list_fills(
+    run_id: Annotated[UUID, Path()],
+    limit: Annotated[int, Query(ge=1, le=500)] = DEFAULT_PAGE_SIZE,
+    cursor: Annotated[str | None, Query(min_length=1)] = None,
+    instrument_id: Annotated[UUID | None, Query()] = None,
+    side: Annotated[str | None, Query(min_length=1, max_length=8)] = None,
+    start_time: Annotated[datetime | None, Query()] = None,
+    end_time: Annotated[datetime | None, Query()] = None,
+    session: Session = Depends(get_db_session),
+) -> dict[str, object]:
+    """List simulated fills ordered by execution time and fill id."""
+
+    return _read_page(
+        "fills",
+        run_id=run_id,
+        limit=limit,
+        cursor=cursor,
+        session=session,
+        instrument_id=instrument_id,
+        side=side,
+        start_time=start_time,
+        end_time=end_time,
+    )
+
+
+@router.get("/positions", response_model=ResultCursorPage[BacktestPositionItem])
+def list_positions(
+    run_id: Annotated[UUID, Path()],
+    limit: Annotated[int, Query(ge=1, le=500)] = DEFAULT_PAGE_SIZE,
+    cursor: Annotated[str | None, Query(min_length=1)] = None,
+    instrument_id: Annotated[UUID | None, Query()] = None,
+    side: Annotated[str | None, Query(min_length=1, max_length=8)] = None,
+    start_time: Annotated[datetime | None, Query()] = None,
+    end_time: Annotated[datetime | None, Query()] = None,
+    session: Session = Depends(get_db_session),
+) -> dict[str, object]:
+    """List raw non-zero position snapshots; rows are never collapsed."""
+
+    return _read_page(
+        "positions",
+        run_id=run_id,
+        limit=limit,
+        cursor=cursor,
+        session=session,
+        instrument_id=instrument_id,
+        side=side,
+        start_time=start_time,
+        end_time=end_time,
+    )
+
+
+@router.get("/equity-curve", response_model=ResultCursorPage[BacktestEquityCurveItem])
+def list_equity_curve(
+    run_id: Annotated[UUID, Path()],
+    limit: Annotated[int, Query(ge=1, le=500)] = DEFAULT_PAGE_SIZE,
+    cursor: Annotated[str | None, Query(min_length=1)] = None,
+    start_time: Annotated[datetime | None, Query()] = None,
+    end_time: Annotated[datetime | None, Query()] = None,
+    session: Session = Depends(get_db_session),
+) -> dict[str, object]:
+    """List account valuation points ordered by valuation time and sequence."""
+
+    return _read_page(
+        "equity_curve",
+        run_id=run_id,
+        limit=limit,
+        cursor=cursor,
+        session=session,
+        start_time=start_time,
+        end_time=end_time,
+    )
+
+
+@router.get("/metrics", response_model=ResultCursorPage[BacktestMetricItem])
+def list_metrics(
+    run_id: Annotated[UUID, Path()],
+    limit: Annotated[int, Query(ge=1, le=500)] = DEFAULT_PAGE_SIZE,
+    cursor: Annotated[str | None, Query(min_length=1)] = None,
+    session: Session = Depends(get_db_session),
+) -> dict[str, object]:
+    """List metric values; unavailable metrics expose their reason."""
+
+    return _read_page("metrics", run_id=run_id, limit=limit, cursor=cursor, session=session)
+
+
+@router.get("/data-preflight", response_model=ResultCursorPage[BacktestDataPreflightItem])
+def list_data_preflight(
+    run_id: Annotated[UUID, Path()],
+    limit: Annotated[int, Query(ge=1, le=500)] = DEFAULT_PAGE_SIZE,
+    cursor: Annotated[str | None, Query(min_length=1)] = None,
+    session: Session = Depends(get_db_session),
+) -> dict[str, object]:
+    """List run-level data preflight reports by phase."""
+
+    return _read_page(
+        "data_preflight", run_id=run_id, limit=limit, cursor=cursor, session=session
+    )
+
+
+@router.get("/data-chunks", response_model=ResultCursorPage[BacktestDataChunkItem])
+def list_data_chunks(
+    run_id: Annotated[UUID, Path()],
+    limit: Annotated[int, Query(ge=1, le=500)] = DEFAULT_PAGE_SIZE,
+    cursor: Annotated[str | None, Query(min_length=1)] = None,
+    phase: Annotated[str | None, Query(min_length=1, max_length=16)] = None,
+    session: Session = Depends(get_db_session),
+) -> dict[str, object]:
+    """List bounded data chunks in phase and chunk-sequence order."""
+
+    return _read_page(
+        "data_chunks",
+        run_id=run_id,
+        limit=limit,
+        cursor=cursor,
+        session=session,
+        phase=phase,
+    )

--- a/backend/app/backtesting/result_router.py
+++ b/backend/app/backtesting/result_router.py
@@ -12,7 +12,7 @@ from datetime import datetime
 from typing import Annotated
 from uuid import UUID
 
-from fastapi import APIRouter, Depends, HTTPException, Path, Query
+from fastapi import APIRouter, Depends, HTTPException, Path, Query, Request
 from sqlalchemy.orm import Session
 
 from app.backtesting.pagination import (
@@ -38,7 +38,6 @@ from app.backtesting.result_schemas import (
     BacktestStepItem,
     ResultCursorPage,
 )
-from app.core.config import get_settings
 from app.db.session import get_db_session
 
 
@@ -56,12 +55,40 @@ def _page_or_error(page: CursorPage) -> dict[str, object]:
     }
 
 
-def _read_page(kind: str, *, run_id: UUID, limit: int, cursor: str | None, session: Session, **filters: object) -> dict[str, object]:
+def _cursor_signing_key(request: Request) -> str:
+    """Resolve the cursor HMAC secret from the serving app instance.
+
+    Reading ``request.app.state.settings`` (instead of the cached global
+    settings) keeps cursors signed with exactly the token of the deployment
+    that created them, including ``create_app(settings=...)`` and test
+    injections.
+    """
+
+    settings = getattr(request.app.state, "settings", None)
+    api_token = getattr(settings, "api_token", None)
+    if api_token is None:
+        raise RuntimeError("application settings are not attached to app.state")
+    return api_token.get_secret_value()
+
+
+CursorSigningKey = Annotated[str, Depends(_cursor_signing_key)]
+
+
+def _read_page(
+    kind: str,
+    *,
+    run_id: UUID,
+    limit: int,
+    cursor: str | None,
+    session: Session,
+    signing_key: str,
+    **filters: object,
+) -> dict[str, object]:
     repository = BacktestResultRepository(
         session,
         # Reuse the deployment's API token as the cursor HMAC secret so no
         # extra configuration key is required for the first version.
-        cursor_signing_key=get_settings().api_token.get_secret_value(),
+        cursor_signing_key=signing_key,
     )
     try:
         page = repository.read_page(
@@ -87,6 +114,7 @@ def _read_page(kind: str, *, run_id: UUID, limit: int, cursor: str | None, sessi
 @router.get("/steps", response_model=ResultCursorPage[BacktestStepItem])
 def list_steps(
     run_id: Annotated[UUID, Path()],
+    signing_key: CursorSigningKey,
     limit: Annotated[int, Query(ge=1, le=500)] = DEFAULT_PAGE_SIZE,
     cursor: Annotated[str | None, Query(min_length=1)] = None,
     phase: Annotated[str | None, Query(min_length=1, max_length=32)] = None,
@@ -95,13 +123,14 @@ def list_steps(
     """List time steps in stable step-sequence order."""
 
     return _read_page(
-        "steps", run_id=run_id, limit=limit, cursor=cursor, session=session, phase=phase
+        "steps", run_id=run_id, limit=limit, cursor=cursor, session=session, signing_key=signing_key, phase=phase
     )
 
 
 @router.get("/decisions", response_model=ResultCursorPage[BacktestDecisionItem])
 def list_decisions(
     run_id: Annotated[UUID, Path()],
+    signing_key: CursorSigningKey,
     limit: Annotated[int, Query(ge=1, le=500)] = DEFAULT_PAGE_SIZE,
     cursor: Annotated[str | None, Query(min_length=1)] = None,
     mode: Annotated[str | None, Query(min_length=1, max_length=64)] = None,
@@ -117,6 +146,7 @@ def list_decisions(
         limit=limit,
         cursor=cursor,
         session=session,
+        signing_key=signing_key,
         mode=mode,
         start_time=start_time,
         end_time=end_time,
@@ -126,6 +156,7 @@ def list_decisions(
 @router.get("/orders", response_model=ResultCursorPage[BacktestOrderItem])
 def list_orders(
     run_id: Annotated[UUID, Path()],
+    signing_key: CursorSigningKey,
     limit: Annotated[int, Query(ge=1, le=500)] = DEFAULT_PAGE_SIZE,
     cursor: Annotated[str | None, Query(min_length=1)] = None,
     instrument_id: Annotated[UUID | None, Query()] = None,
@@ -143,6 +174,7 @@ def list_orders(
         limit=limit,
         cursor=cursor,
         session=session,
+        signing_key=signing_key,
         instrument_id=instrument_id,
         status=status,
         side=side,
@@ -154,6 +186,7 @@ def list_orders(
 @router.get("/order-updates", response_model=ResultCursorPage[BacktestOrderUpdateItem])
 def list_order_updates(
     run_id: Annotated[UUID, Path()],
+    signing_key: CursorSigningKey,
     limit: Annotated[int, Query(ge=1, le=500)] = DEFAULT_PAGE_SIZE,
     cursor: Annotated[str | None, Query(min_length=1)] = None,
     status: Annotated[str | None, Query(min_length=1, max_length=24)] = None,
@@ -169,6 +202,7 @@ def list_order_updates(
         limit=limit,
         cursor=cursor,
         session=session,
+        signing_key=signing_key,
         status=status,
         start_time=start_time,
         end_time=end_time,
@@ -178,6 +212,7 @@ def list_order_updates(
 @router.get("/fills", response_model=ResultCursorPage[BacktestFillItem])
 def list_fills(
     run_id: Annotated[UUID, Path()],
+    signing_key: CursorSigningKey,
     limit: Annotated[int, Query(ge=1, le=500)] = DEFAULT_PAGE_SIZE,
     cursor: Annotated[str | None, Query(min_length=1)] = None,
     instrument_id: Annotated[UUID | None, Query()] = None,
@@ -194,6 +229,7 @@ def list_fills(
         limit=limit,
         cursor=cursor,
         session=session,
+        signing_key=signing_key,
         instrument_id=instrument_id,
         side=side,
         start_time=start_time,
@@ -204,6 +240,7 @@ def list_fills(
 @router.get("/positions", response_model=ResultCursorPage[BacktestPositionItem])
 def list_positions(
     run_id: Annotated[UUID, Path()],
+    signing_key: CursorSigningKey,
     limit: Annotated[int, Query(ge=1, le=500)] = DEFAULT_PAGE_SIZE,
     cursor: Annotated[str | None, Query(min_length=1)] = None,
     instrument_id: Annotated[UUID | None, Query()] = None,
@@ -220,6 +257,7 @@ def list_positions(
         limit=limit,
         cursor=cursor,
         session=session,
+        signing_key=signing_key,
         instrument_id=instrument_id,
         side=side,
         start_time=start_time,
@@ -230,6 +268,7 @@ def list_positions(
 @router.get("/equity-curve", response_model=ResultCursorPage[BacktestEquityCurveItem])
 def list_equity_curve(
     run_id: Annotated[UUID, Path()],
+    signing_key: CursorSigningKey,
     limit: Annotated[int, Query(ge=1, le=500)] = DEFAULT_PAGE_SIZE,
     cursor: Annotated[str | None, Query(min_length=1)] = None,
     start_time: Annotated[datetime | None, Query()] = None,
@@ -244,6 +283,7 @@ def list_equity_curve(
         limit=limit,
         cursor=cursor,
         session=session,
+        signing_key=signing_key,
         start_time=start_time,
         end_time=end_time,
     )
@@ -252,18 +292,27 @@ def list_equity_curve(
 @router.get("/metrics", response_model=ResultCursorPage[BacktestMetricItem])
 def list_metrics(
     run_id: Annotated[UUID, Path()],
+    signing_key: CursorSigningKey,
     limit: Annotated[int, Query(ge=1, le=500)] = DEFAULT_PAGE_SIZE,
     cursor: Annotated[str | None, Query(min_length=1)] = None,
     session: Session = Depends(get_db_session),
 ) -> dict[str, object]:
     """List metric values; unavailable metrics expose their reason."""
 
-    return _read_page("metrics", run_id=run_id, limit=limit, cursor=cursor, session=session)
+    return _read_page(
+        "metrics",
+        run_id=run_id,
+        limit=limit,
+        cursor=cursor,
+        session=session,
+        signing_key=signing_key,
+    )
 
 
 @router.get("/data-preflight", response_model=ResultCursorPage[BacktestDataPreflightItem])
 def list_data_preflight(
     run_id: Annotated[UUID, Path()],
+    signing_key: CursorSigningKey,
     limit: Annotated[int, Query(ge=1, le=500)] = DEFAULT_PAGE_SIZE,
     cursor: Annotated[str | None, Query(min_length=1)] = None,
     session: Session = Depends(get_db_session),
@@ -271,13 +320,19 @@ def list_data_preflight(
     """List run-level data preflight reports by phase."""
 
     return _read_page(
-        "data_preflight", run_id=run_id, limit=limit, cursor=cursor, session=session
+        "data_preflight",
+        run_id=run_id,
+        limit=limit,
+        cursor=cursor,
+        session=session,
+        signing_key=signing_key,
     )
 
 
 @router.get("/data-chunks", response_model=ResultCursorPage[BacktestDataChunkItem])
 def list_data_chunks(
     run_id: Annotated[UUID, Path()],
+    signing_key: CursorSigningKey,
     limit: Annotated[int, Query(ge=1, le=500)] = DEFAULT_PAGE_SIZE,
     cursor: Annotated[str | None, Query(min_length=1)] = None,
     phase: Annotated[str | None, Query(min_length=1, max_length=16)] = None,
@@ -291,5 +346,6 @@ def list_data_chunks(
         limit=limit,
         cursor=cursor,
         session=session,
+        signing_key=signing_key,
         phase=phase,
     )

--- a/backend/app/backtesting/result_schemas.py
+++ b/backend/app/backtesting/result_schemas.py
@@ -136,6 +136,8 @@ class BacktestEquityCurveItem(_ResultItem):
     cash: SerializedDecimal = None
     market_value: SerializedDecimal = None
     equity: SerializedDecimal = None
+    period_return: SerializedDecimal = None
+    total_pnl: SerializedDecimal = None
     cumulative_return: SerializedDecimal = None
     drawdown: SerializedDecimal = None
     cumulative_fees: SerializedDecimal = None

--- a/backend/app/backtesting/result_schemas.py
+++ b/backend/app/backtesting/result_schemas.py
@@ -38,6 +38,12 @@ SerializedDecimal = Annotated[
     PlainSerializer(_decimal_as_string, return_type=Optional[str]),
 ]
 
+# Same wire format, but the field itself is mandatory and non-null.
+RequiredDecimal = Annotated[
+    Decimal,
+    PlainSerializer(_decimal_as_string, return_type=str),
+]
+
 
 class _ResultItem(BaseModel):
     """Common read-only shape for every result row projection."""
@@ -133,7 +139,8 @@ class BacktestEquityCurveItem(_ResultItem):
     as_of: datetime
     valuation_status: str
     valuation_reason: str | None = None
-    cash: SerializedDecimal = None
+    # The DTO contract requires cash at every valuation point, blocked or not.
+    cash: RequiredDecimal
     market_value: SerializedDecimal = None
     equity: SerializedDecimal = None
     period_return: SerializedDecimal = None
@@ -201,6 +208,7 @@ __all__ = [
     "BacktestOrderUpdateItem",
     "BacktestPositionItem",
     "BacktestStepItem",
+    "RequiredDecimal",
     "ResultCursorPage",
     "SerializedDecimal",
 ]

--- a/backend/app/backtesting/result_schemas.py
+++ b/backend/app/backtesting/result_schemas.py
@@ -1,0 +1,204 @@
+"""HTTP response schemas for backtest result queries.
+
+Decimal values are serialized as strings so no precision is lost between
+the API boundary and browser or script clients.  Timestamps stay as
+timezone-aware datetimes rendered in ISO-8601.  Every list response uses
+one uniform cursor-page envelope; clients must treat ``next_cursor`` as
+opaque.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from decimal import Decimal
+from typing import Generic, Optional, TypeVar
+from uuid import UUID
+
+from pydantic import BaseModel, ConfigDict
+from pydantic import PlainSerializer
+from typing_extensions import Annotated
+
+
+def _decimal_as_string(value: Decimal | None) -> str | None:
+    """Render an exact, exponent-free decimal string.
+
+    ``normalize`` drops redundant trailing zeros from fixed-scale database
+    numerics; ``format(..., "f")`` keeps integral values from turning into
+    scientific notation (``1E+2``).
+    """
+
+    if value is None:
+        return None
+    return format(value.normalize(), "f")
+
+
+# Carries exact decimals internally, serializes as a string on the wire.
+SerializedDecimal = Annotated[
+    Optional[Decimal],
+    PlainSerializer(_decimal_as_string, return_type=Optional[str]),
+]
+
+
+class _ResultItem(BaseModel):
+    """Common read-only shape for every result row projection."""
+
+    model_config = ConfigDict(from_attributes=True)
+
+    run_id: UUID
+
+
+class BacktestStepItem(_ResultItem):
+    step_sequence: int
+    time_start: datetime
+    time_end: datetime
+    data_cutoff_at: datetime
+    phase: str
+    data_quality: str
+
+
+class BacktestDecisionItem(_ResultItem):
+    decision_id: UUID
+    step_sequence: int
+    decision_time: datetime
+    mode: str
+    targets: dict | list | None = None
+    validation_status: str
+    validation_issues: list | None = None
+    duration_ms: SerializedDecimal = None
+    error: str | None = None
+
+
+class BacktestOrderItem(_ResultItem):
+    order_id: UUID
+    intent_id: UUID | None = None
+    instrument_id: UUID
+    event_trading_code: str | None = None
+    event_name: str | None = None
+    event_display_name: str | None = None
+    side: str
+    order_type: str
+    price: SerializedDecimal = None
+    quantity: SerializedDecimal = None
+    filled_quantity: SerializedDecimal = None
+    status: str
+    status_reason: str | None = None
+    submitted_at: datetime
+
+
+class BacktestOrderUpdateItem(_ResultItem):
+    order_id: UUID
+    update_sequence: int
+    old_status: str | None = None
+    new_status: str
+    updated_at: datetime
+    reason: str | None = None
+
+
+class BacktestFillItem(_ResultItem):
+    fill_id: UUID
+    order_id: UUID
+    instrument_id: UUID
+    event_trading_code: str | None = None
+    event_name: str | None = None
+    event_display_name: str | None = None
+    side: str
+    timestamp: datetime
+    reference_price: SerializedDecimal = None
+    price: SerializedDecimal = None
+    quantity: SerializedDecimal = None
+    fees: SerializedDecimal = None
+    slippage_bps: SerializedDecimal = None
+    slippage_amount: SerializedDecimal = None
+    slippage_model_key: str | None = None
+    slippage_model_version: int | None = None
+
+
+class BacktestPositionItem(_ResultItem):
+    as_of: datetime
+    instrument_id: UUID
+    event_trading_code: str | None = None
+    event_name: str | None = None
+    event_display_name: str | None = None
+    side: str
+    quantity: SerializedDecimal = None
+    available_quantity: SerializedDecimal = None
+    average_price: SerializedDecimal = None
+    mark_price: SerializedDecimal = None
+    realized_pnl: SerializedDecimal = None
+    unrealized_pnl: SerializedDecimal = None
+
+
+class BacktestEquityCurveItem(_ResultItem):
+    sequence: int
+    as_of: datetime
+    valuation_status: str
+    valuation_reason: str | None = None
+    cash: SerializedDecimal = None
+    market_value: SerializedDecimal = None
+    equity: SerializedDecimal = None
+    cumulative_return: SerializedDecimal = None
+    drawdown: SerializedDecimal = None
+    cumulative_fees: SerializedDecimal = None
+
+
+class BacktestMetricItem(_ResultItem):
+    metric_key: str
+    formula_version: str
+    value: SerializedDecimal = None
+    unit: str | None = None
+    annualization_factor: SerializedDecimal = None
+    risk_free_rate_note: str | None = None
+    sample_count: int | None = None
+    unavailable_reason: str | None = None
+
+
+class BacktestDataPreflightItem(_ResultItem):
+    phase: str
+    status: str
+    report_hash: str
+    capabilities: dict | None = None
+    calendar_summary: dict | None = None
+    session_summary: dict | None = None
+    pit_status: str | None = None
+    coverage: dict | None = None
+    source_revisions: dict | None = None
+
+
+class BacktestDataChunkItem(_ResultItem):
+    phase: str
+    chunk_sequence: int
+    time_start: datetime
+    time_end: datetime
+    chunk_strategy_version: str
+    token_digest: str
+    validation_status: str
+    started_at: datetime | None = None
+    finished_at: datetime | None = None
+    failure_reason: str | None = None
+
+
+ItemT = TypeVar("ItemT", bound=_ResultItem)
+
+
+class ResultCursorPage(BaseModel, Generic[ItemT]):
+    """Uniform envelope for every long-range result list."""
+
+    items: list[ItemT]
+    next_cursor: str | None = None
+    has_more: bool = False
+
+
+__all__ = [
+    "BacktestDataChunkItem",
+    "BacktestDataPreflightItem",
+    "BacktestDecisionItem",
+    "BacktestEquityCurveItem",
+    "BacktestFillItem",
+    "BacktestMetricItem",
+    "BacktestOrderItem",
+    "BacktestOrderUpdateItem",
+    "BacktestPositionItem",
+    "BacktestStepItem",
+    "ResultCursorPage",
+    "SerializedDecimal",
+]

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -26,6 +26,10 @@ class Settings(BaseSettings):
     server_host: IPvAnyAddress = "127.0.0.1"
     server_port: int = Field(default=8000, ge=1, le=65535)
     api_token: SecretStr = Field(min_length=32)
+    # Server-only HMAC secret for opaque result cursors.  Unlike the API
+    # token, this value is never presented by clients, so a holder of the
+    # API token cannot forge validly signed cursors.
+    cursor_signing_key: SecretStr = Field(min_length=32)
     log_dir: Path = PROJECT_ROOT / "data" / "logs"
     log_level: Literal["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"] = "INFO"
     log_retention_days: int = Field(default=30, ge=1, le=365)

--- a/backend/app/db/migrations/versions/20260822_02_add_backtest_results.py
+++ b/backend/app/db/migrations/versions/20260822_02_add_backtest_results.py
@@ -500,6 +500,16 @@ def upgrade() -> None:
         ),
         _amount_column("equity", "Account equity; null for blocked points.", True),
         _amount_column(
+            "period_return",
+            "Period return versus the previous valid point; null for blocked points.",
+            True,
+        ),
+        _amount_column(
+            "total_pnl",
+            "Total profit and loss versus initial equity; null for blocked points.",
+            True,
+        ),
+        _amount_column(
             "cumulative_return",
             "Cumulative return versus initial equity; null for blocked points.",
             True,

--- a/backend/app/db/migrations/versions/20260822_02_add_backtest_results.py
+++ b/backend/app/db/migrations/versions/20260822_02_add_backtest_results.py
@@ -1,0 +1,728 @@
+"""Add backtest result tables for steps, decisions, orders, fills,
+positions, equity curve, metrics, data preflight reports, and data chunks.
+
+Revision ID: 20260822_02
+Revises: 20260822_01
+Create Date: 2026-08-22
+"""
+
+from collections.abc import Sequence
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+
+revision: str = "20260822_02"
+down_revision: str | None = "20260822_01"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+AMOUNT = sa.Numeric(38, 18)
+JSON_TYPE = postgresql.JSONB(astext_type=sa.Text())
+RUN_ID_COMMENT = (
+    "Owning backtest run; every result row is bound to exactly one run. "
+    "A foreign key to backtest_runs is added by the run-creation task."
+)
+
+
+def _id_column() -> sa.Column:
+    return sa.Column(
+        "id",
+        sa.Uuid(),
+        nullable=False,
+        comment="Surrogate primary key; business identity lives in the unique key.",
+    )
+
+
+def _run_id_column() -> sa.Column:
+    return sa.Column("run_id", sa.Uuid(), nullable=False, comment=RUN_ID_COMMENT)
+
+
+def _created_at_column() -> sa.Column:
+    return sa.Column(
+        "created_at",
+        sa.DateTime(timezone=True),
+        nullable=False,
+        comment="Row creation timestamp.",
+    )
+
+
+def _timestamp_column(name: str, comment: str, nullable: bool = False) -> sa.Column:
+    return sa.Column(
+        name,
+        sa.DateTime(timezone=True),
+        nullable=nullable,
+        comment=comment,
+    )
+
+
+def _amount_column(name: str, comment: str, nullable: bool = False) -> sa.Column:
+    return sa.Column(name, AMOUNT, nullable=nullable, comment=comment)
+
+
+def upgrade() -> None:
+    """Create the append-only result tables for backtest runs."""
+    op.create_table(
+        "backtest_steps",
+        _id_column(),
+        _run_id_column(),
+        sa.Column(
+            "step_sequence",
+            sa.Integer(),
+            nullable=False,
+            comment="Stable in-run step number used as the pagination sort key.",
+        ),
+        _timestamp_column("time_start", "Inclusive start of the step interval."),
+        _timestamp_column("time_end", "Inclusive end of the step interval."),
+        _timestamp_column(
+            "data_cutoff_at", "Point-in-time data cutoff observed by this step."
+        ),
+        sa.Column(
+            "phase",
+            sa.String(length=32),
+            nullable=False,
+            comment="Coarse step phase (stable persisted enum value).",
+        ),
+        sa.Column(
+            "data_quality",
+            sa.String(length=16),
+            nullable=False,
+            comment="Input data quality outcome for the step.",
+        ),
+        _created_at_column(),
+        sa.PrimaryKeyConstraint("id"),
+        sa.CheckConstraint(
+            "time_start <= time_end",
+            name="step_time_range_ordered",
+        ),
+    )
+    op.create_index(
+        "uq_backtest_steps_run_sequence",
+        "backtest_steps",
+        ["run_id", "step_sequence"],
+        unique=True,
+    )
+
+    op.create_table(
+        "backtest_decisions",
+        _id_column(),
+        _run_id_column(),
+        sa.Column(
+            "decision_id",
+            sa.Uuid(),
+            nullable=False,
+            comment="Business identity of the decision within the run.",
+        ),
+        sa.Column(
+            "step_sequence",
+            sa.Integer(),
+            nullable=False,
+            comment="Step that produced the decision.",
+        ),
+        _timestamp_column("decision_time", "Timezone-aware decision timestamp."),
+        sa.Column(
+            "mode",
+            sa.String(length=64),
+            nullable=False,
+            comment="Registered strategy decision mode.",
+        ),
+        sa.Column(
+            "targets",
+            JSON_TYPE,
+            nullable=False,
+            comment="Normalized decision targets (no binary floats).",
+        ),
+        sa.Column(
+            "validation_status",
+            sa.String(length=16),
+            nullable=False,
+            comment="Outcome of decision validation.",
+        ),
+        sa.Column(
+            "validation_issues",
+            JSON_TYPE,
+            nullable=False,
+            comment="Structured validation issues when the decision was rejected.",
+        ),
+        _amount_column("duration_ms", "Strategy wall-clock duration in milliseconds.", True),
+        sa.Column(
+            "error",
+            sa.String(length=1000),
+            nullable=True,
+            comment="Error summary when the decision failed.",
+        ),
+        _created_at_column(),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index(
+        "uq_backtest_decisions_run_decision",
+        "backtest_decisions",
+        ["run_id", "decision_id"],
+        unique=True,
+    )
+    op.create_index(
+        "ix_backtest_decisions_run_sort_key",
+        "backtest_decisions",
+        ["run_id", "step_sequence", "decision_time", "decision_id"],
+    )
+
+    op.create_table(
+        "backtest_orders",
+        _id_column(),
+        _run_id_column(),
+        sa.Column(
+            "order_id",
+            sa.Uuid(),
+            nullable=False,
+            comment="Business identity of the order within the run.",
+        ),
+        sa.Column(
+            "intent_id",
+            sa.Uuid(),
+            nullable=True,
+            comment="Originating order intent, when the pipeline recorded one.",
+        ),
+        sa.Column(
+            "instrument_id",
+            sa.Uuid(),
+            nullable=False,
+            comment="Stable instrument identity; never a trading code.",
+        ),
+        sa.Column(
+            "event_trading_code",
+            sa.String(length=64),
+            nullable=True,
+            comment="Trading code valid at the event time, frozen on write.",
+        ),
+        sa.Column(
+            "event_name",
+            sa.String(length=200),
+            nullable=True,
+            comment="Instrument name valid at the event time, frozen on write.",
+        ),
+        sa.Column(
+            "event_display_name",
+            sa.String(length=200),
+            nullable=True,
+            comment="Display name valid at the event time, frozen on write.",
+        ),
+        sa.Column(
+            "side",
+            sa.String(length=8),
+            nullable=False,
+            comment="Order direction (buy/sell).",
+        ),
+        sa.Column(
+            "order_type",
+            sa.String(length=32),
+            nullable=False,
+            comment="Standard order type identifier.",
+        ),
+        _amount_column("price", "Limit price; null for market orders.", True),
+        _amount_column("quantity", "Ordered quantity."),
+        _amount_column(
+            "filled_quantity", "Cumulative filled quantity at the latest update."
+        ),
+        sa.Column(
+            "status",
+            sa.String(length=24),
+            nullable=False,
+            comment="Latest persisted order status.",
+        ),
+        sa.Column(
+            "status_reason",
+            sa.String(length=500),
+            nullable=True,
+            comment="Human-readable reason attached to the latest status.",
+        ),
+        _timestamp_column(
+            "submitted_at",
+            "Order submission time; first half of the pagination sort key.",
+        ),
+        _created_at_column(),
+        sa.PrimaryKeyConstraint("id"),
+        sa.CheckConstraint(
+            "filled_quantity >= 0 AND filled_quantity <= quantity",
+            name="order_filled_within_quantity",
+        ),
+    )
+    op.create_index(
+        "uq_backtest_orders_run_order",
+        "backtest_orders",
+        ["run_id", "order_id"],
+        unique=True,
+    )
+    op.create_index(
+        "ix_backtest_orders_run_sort_key",
+        "backtest_orders",
+        ["run_id", "submitted_at", "order_id"],
+    )
+    op.create_index(
+        "ix_backtest_orders_run_instrument",
+        "backtest_orders",
+        ["run_id", "instrument_id"],
+    )
+
+    op.create_table(
+        "backtest_order_updates",
+        _id_column(),
+        _run_id_column(),
+        sa.Column(
+            "order_id",
+            sa.Uuid(),
+            nullable=False,
+            comment="Order whose state changed.",
+        ),
+        sa.Column(
+            "update_sequence",
+            sa.Integer(),
+            nullable=False,
+            comment="Monotonic update counter within the order.",
+        ),
+        sa.Column(
+            "old_status",
+            sa.String(length=24),
+            nullable=True,
+            comment="Status before the transition; null for the first update.",
+        ),
+        sa.Column(
+            "new_status",
+            sa.String(length=24),
+            nullable=False,
+            comment="Status after the transition.",
+        ),
+        _timestamp_column("updated_at", "Transition timestamp."),
+        sa.Column(
+            "reason",
+            sa.String(length=500),
+            nullable=True,
+            comment="Reason recorded with the transition.",
+        ),
+        _created_at_column(),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index(
+        "uq_backtest_order_updates_run_order_seq",
+        "backtest_order_updates",
+        ["run_id", "order_id", "update_sequence"],
+        unique=True,
+    )
+    op.create_index(
+        "ix_backtest_order_updates_run_sort_key",
+        "backtest_order_updates",
+        ["run_id", "updated_at", "order_id", "update_sequence"],
+    )
+
+    op.create_table(
+        "backtest_fills",
+        _id_column(),
+        _run_id_column(),
+        sa.Column(
+            "fill_id",
+            sa.Uuid(),
+            nullable=False,
+            comment="Business identity of the fill within the run.",
+        ),
+        sa.Column(
+            "order_id",
+            sa.Uuid(),
+            nullable=False,
+            comment="Order that produced this fill.",
+        ),
+        sa.Column(
+            "instrument_id",
+            sa.Uuid(),
+            nullable=False,
+            comment="Stable instrument identity; never a trading code.",
+        ),
+        sa.Column(
+            "event_trading_code",
+            sa.String(length=64),
+            nullable=True,
+            comment="Trading code valid at the event time, frozen on write.",
+        ),
+        sa.Column(
+            "event_name",
+            sa.String(length=200),
+            nullable=True,
+            comment="Instrument name valid at the event time, frozen on write.",
+        ),
+        sa.Column(
+            "event_display_name",
+            sa.String(length=200),
+            nullable=True,
+            comment="Display name valid at the event time, frozen on write.",
+        ),
+        sa.Column(
+            "side",
+            sa.String(length=8),
+            nullable=False,
+            comment="Fill direction (buy/sell).",
+        ),
+        _timestamp_column(
+            "timestamp",
+            "Execution timestamp; first half of the pagination sort key.",
+        ),
+        _amount_column(
+            "reference_price", "Pre-slippage reference price kept for auditability.", True
+        ),
+        _amount_column("price", "Final execution price."),
+        _amount_column("quantity", "Executed quantity."),
+        _amount_column("fees", "Total fees charged with this fill."),
+        _amount_column("slippage_bps", "Realized slippage in basis points.", True),
+        _amount_column(
+            "slippage_amount", "Realized slippage amount in currency units.", True
+        ),
+        sa.Column(
+            "slippage_model_key",
+            sa.String(length=100),
+            nullable=True,
+            comment="Slippage model identifier applied to this fill.",
+        ),
+        sa.Column(
+            "slippage_model_version",
+            sa.Integer(),
+            nullable=True,
+            comment="Version of the slippage model applied to this fill.",
+        ),
+        _created_at_column(),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index(
+        "uq_backtest_fills_run_fill",
+        "backtest_fills",
+        ["run_id", "fill_id"],
+        unique=True,
+    )
+    op.create_index(
+        "ix_backtest_fills_run_sort_key",
+        "backtest_fills",
+        ["run_id", "timestamp", "fill_id"],
+    )
+    op.create_index(
+        "ix_backtest_fills_run_instrument",
+        "backtest_fills",
+        ["run_id", "instrument_id"],
+    )
+
+    op.create_table(
+        "backtest_positions",
+        _id_column(),
+        _run_id_column(),
+        _timestamp_column(
+            "as_of",
+            "Valuation timestamp; first part of the pagination sort key.",
+        ),
+        sa.Column(
+            "instrument_id",
+            sa.Uuid(),
+            nullable=False,
+            comment="Stable instrument identity; never a trading code.",
+        ),
+        sa.Column(
+            "event_trading_code",
+            sa.String(length=64),
+            nullable=True,
+            comment="Trading code valid at the valuation point, frozen on write.",
+        ),
+        sa.Column(
+            "event_name",
+            sa.String(length=200),
+            nullable=True,
+            comment="Instrument name valid at the valuation point, frozen on write.",
+        ),
+        sa.Column(
+            "event_display_name",
+            sa.String(length=200),
+            nullable=True,
+            comment="Display name valid at the valuation point, frozen on write.",
+        ),
+        sa.Column(
+            "side",
+            sa.String(length=8),
+            nullable=False,
+            comment="Position side (long/short/net).",
+        ),
+        _amount_column("quantity", "Non-zero held quantity."),
+        _amount_column(
+            "available_quantity", "Quantity currently sellable under settlement rules."
+        ),
+        _amount_column("average_price", "Cost-basis average price."),
+        _amount_column(
+            "mark_price", "Valuation mark price; null when no valid mark existed.", True
+        ),
+        _amount_column("realized_pnl", "Realized profit and loss up to this point."),
+        _amount_column(
+            "unrealized_pnl", "Unrealized profit and loss at this valuation point."
+        ),
+        _created_at_column(),
+        sa.PrimaryKeyConstraint("id"),
+        sa.CheckConstraint("quantity > 0", name="position_quantity_non_zero"),
+        sa.CheckConstraint(
+            "available_quantity >= 0 AND available_quantity <= quantity",
+            name="position_available_within_quantity",
+        ),
+    )
+    op.create_index(
+        "uq_backtest_positions_run_point_instrument_side",
+        "backtest_positions",
+        ["run_id", "as_of", "instrument_id", "side"],
+        unique=True,
+    )
+
+    op.create_table(
+        "backtest_equity_curve",
+        _id_column(),
+        _run_id_column(),
+        sa.Column(
+            "sequence",
+            sa.Integer(),
+            nullable=False,
+            comment="Stable in-run valuation counter.",
+        ),
+        _timestamp_column("as_of", "Valuation timestamp."),
+        sa.Column(
+            "valuation_status",
+            sa.String(length=16),
+            nullable=False,
+            comment="Whether the valuation was complete, degraded, or blocked.",
+        ),
+        sa.Column(
+            "valuation_reason",
+            sa.String(length=500),
+            nullable=True,
+            comment="Reason attached to degraded or blocked valuations.",
+        ),
+        _amount_column("cash", "Cash balance; null only for blocked points.", True),
+        _amount_column(
+            "market_value", "Marked market value; null for blocked points.", True
+        ),
+        _amount_column("equity", "Account equity; null for blocked points.", True),
+        _amount_column(
+            "cumulative_return",
+            "Cumulative return versus initial equity; null for blocked points.",
+            True,
+        ),
+        _amount_column(
+            "drawdown", "Drawdown from peak equity; null for blocked points.", True
+        ),
+        _amount_column(
+            "cumulative_fees", "Total fees accumulated through this point."
+        ),
+        _created_at_column(),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index(
+        "uq_backtest_equity_curve_run_sequence",
+        "backtest_equity_curve",
+        ["run_id", "sequence"],
+        unique=True,
+    )
+    op.create_index(
+        "ix_backtest_equity_curve_run_sort_key",
+        "backtest_equity_curve",
+        ["run_id", "as_of", "sequence"],
+    )
+
+    op.create_table(
+        "backtest_metrics",
+        _id_column(),
+        _run_id_column(),
+        sa.Column(
+            "metric_key",
+            sa.String(length=100),
+            nullable=False,
+            comment="Stable metric key.",
+        ),
+        sa.Column(
+            "formula_version",
+            sa.String(length=32),
+            nullable=False,
+            comment="Version of the metric formula that produced the value.",
+        ),
+        _amount_column(
+            "value",
+            "Metric value; null together with unavailable_reason when missing.",
+            True,
+        ),
+        sa.Column(
+            "unit",
+            sa.String(length=32),
+            nullable=True,
+            comment="Unit of the metric value.",
+        ),
+        _amount_column(
+            "annualization_factor", "Annualization factor applied by the formula.", True
+        ),
+        sa.Column(
+            "risk_free_rate_note",
+            sa.String(length=200),
+            nullable=True,
+            comment="Risk-free rate convention used by the formula.",
+        ),
+        sa.Column(
+            "sample_count",
+            sa.Integer(),
+            nullable=True,
+            comment="Number of samples behind the value.",
+        ),
+        sa.Column(
+            "unavailable_reason",
+            sa.String(length=500),
+            nullable=True,
+            comment="Why the value is unavailable; required exactly when value is null.",
+        ),
+        _created_at_column(),
+        sa.PrimaryKeyConstraint("id"),
+        sa.CheckConstraint(
+            "(value IS NULL) = (unavailable_reason IS NOT NULL)",
+            name="metric_value_xor_reason",
+        ),
+    )
+    op.create_index(
+        "uq_backtest_metrics_run_key_version",
+        "backtest_metrics",
+        ["run_id", "metric_key", "formula_version"],
+        unique=True,
+    )
+
+    op.create_table(
+        "backtest_data_preflight",
+        _id_column(),
+        _run_id_column(),
+        sa.Column(
+            "phase",
+            sa.String(length=16),
+            nullable=False,
+            comment="Preflight phase (admission/session).",
+        ),
+        sa.Column(
+            "status",
+            sa.String(length=32),
+            nullable=False,
+            comment="Overall preflight outcome.",
+        ),
+        sa.Column(
+            "report_hash",
+            sa.String(length=128),
+            nullable=False,
+            comment="Hash over the preflight report content.",
+        ),
+        sa.Column(
+            "capabilities",
+            JSON_TYPE,
+            nullable=False,
+            comment="Capability checklist captured by the report.",
+        ),
+        sa.Column(
+            "calendar_summary",
+            JSON_TYPE,
+            nullable=False,
+            comment="Named calendar sets and their coverage summary.",
+        ),
+        sa.Column(
+            "session_summary",
+            JSON_TYPE,
+            nullable=False,
+            comment="Session compatibility and day-level differences summary.",
+        ),
+        sa.Column(
+            "pit_status",
+            sa.String(length=32),
+            nullable=True,
+            comment="Point-in-time readiness conclusion.",
+        ),
+        sa.Column(
+            "coverage",
+            JSON_TYPE,
+            nullable=False,
+            comment="Coverage statistics of the requested data.",
+        ),
+        sa.Column(
+            "source_revisions",
+            JSON_TYPE,
+            nullable=False,
+            comment="Source-data revisions observed by the report.",
+        ),
+        _created_at_column(),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index(
+        "uq_backtest_data_preflight_run_phase",
+        "backtest_data_preflight",
+        ["run_id", "phase"],
+        unique=True,
+    )
+
+    op.create_table(
+        "backtest_data_chunks",
+        _id_column(),
+        _run_id_column(),
+        sa.Column(
+            "phase",
+            sa.String(length=16),
+            nullable=False,
+            comment="Data phase owning the chunk (admission/session).",
+        ),
+        sa.Column(
+            "chunk_sequence",
+            sa.Integer(),
+            nullable=False,
+            comment="Chunk counter within the run and phase.",
+        ),
+        _timestamp_column("time_start", "Inclusive chunk start."),
+        _timestamp_column("time_end", "Inclusive chunk end."),
+        sa.Column(
+            "chunk_strategy_version",
+            sa.String(length=32),
+            nullable=False,
+            comment="Version of the chunking policy that produced boundaries.",
+        ),
+        sa.Column(
+            "token_digest",
+            sa.String(length=128),
+            nullable=False,
+            comment="Non-sensitive digest identifying the data token.",
+        ),
+        sa.Column(
+            "validation_status",
+            sa.String(length=16),
+            nullable=False,
+            comment="Chunk validation outcome.",
+        ),
+        _timestamp_column("started_at", "When chunk validation started.", True),
+        _timestamp_column("finished_at", "When chunk validation finished.", True),
+        sa.Column(
+            "failure_reason",
+            sa.String(length=1000),
+            nullable=True,
+            comment="Failure reason; required exactly for failed chunks.",
+        ),
+        _created_at_column(),
+        sa.PrimaryKeyConstraint("id"),
+        sa.CheckConstraint(
+            "time_start <= time_end",
+            name="chunk_time_range_ordered",
+        ),
+    )
+    op.create_index(
+        "uq_backtest_data_chunks_run_phase_seq",
+        "backtest_data_chunks",
+        ["run_id", "phase", "chunk_sequence"],
+        unique=True,
+    )
+
+
+def downgrade() -> None:
+    """Drop the backtest result tables in reverse dependency order."""
+    op.drop_table("backtest_data_chunks")
+    op.drop_table("backtest_data_preflight")
+    op.drop_table("backtest_metrics")
+    op.drop_table("backtest_equity_curve")
+    op.drop_table("backtest_positions")
+    op.drop_table("backtest_fills")
+    op.drop_table("backtest_order_updates")
+    op.drop_table("backtest_orders")
+    op.drop_table("backtest_decisions")
+    op.drop_table("backtest_steps")

--- a/backend/app/db/migrations/versions/20260822_02_add_backtest_results.py
+++ b/backend/app/db/migrations/versions/20260822_02_add_backtest_results.py
@@ -494,7 +494,7 @@ def upgrade() -> None:
             nullable=True,
             comment="Reason attached to degraded or blocked valuations.",
         ),
-        _amount_column("cash", "Cash balance; null only for blocked points.", True),
+        _amount_column("cash", "Cash balance; carried even by blocked valuation points."),
         _amount_column(
             "market_value", "Marked market value; null for blocked points.", True
         ),

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -12,6 +12,7 @@ from app.core.logging import configure_logging
 from app.core.request_logging import log_request
 from app.data_ingestion.router import router as data_ingestion_router
 from app.backtesting.router import router as backtesting_router
+from app.backtesting.result_router import router as backtest_result_router
 from app.core.version import get_release_version
 from app.db.session import dispose_engine, get_db_session
 from app.logging.router import router as log_router
@@ -61,6 +62,7 @@ def create_app(settings: Settings | None = None) -> FastAPI:
     protected_router.include_router(data_ingestion_router)
     protected_router.include_router(strategies_router)
     protected_router.include_router(backtesting_router)
+    protected_router.include_router(backtest_result_router)
 
     @protected_router.get(
         "/api/auth/verify",

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -12,11 +12,35 @@ from app.data_ingestion.models import (
 from app.scheduling.models import ScheduledTask, TaskRun
 from app.strategies.models import Strategy, StrategyDraft, StrategyRevision
 from app.backtesting.models import BacktestAccountProfileRecord
+from app.backtesting.result_records import (
+    RESULT_TABLE_NAMES,
+    BacktestDataChunkRecord,
+    BacktestDataPreflightResultRecord,
+    BacktestDecisionRecord,
+    BacktestEquityCurveRecord,
+    BacktestFillResultRecord,
+    BacktestMetricRecord,
+    BacktestOrderResultRecord,
+    BacktestOrderUpdateRecord,
+    BacktestPositionResultRecord,
+    BacktestStepRecord,
+)
 
 
 __all__ = [
     "DataSyncCheckpoint",
     "BacktestAccountProfileRecord",
+    "BacktestDataChunkRecord",
+    "BacktestDataPreflightResultRecord",
+    "BacktestDecisionRecord",
+    "BacktestEquityCurveRecord",
+    "BacktestFillResultRecord",
+    "BacktestMetricRecord",
+    "BacktestOrderResultRecord",
+    "BacktestOrderUpdateRecord",
+    "BacktestPositionResultRecord",
+    "BacktestStepRecord",
+    "RESULT_TABLE_NAMES",
     "EtfCode",
     "EtfCodeMappingAudit",
     "EtfEntity",

--- a/backend/app/strategies/service.py
+++ b/backend/app/strategies/service.py
@@ -18,13 +18,18 @@ from app.strategies.validation import (
     StrategyValidationResult,
     validate_strategy_draft,
 )
+from app.strategy_protocol.contract import STRATEGY_CONTRACT_VERSION
 
 
 MAX_STRATEGY_SOURCE_BYTES = 1_048_576
 """Maximum UTF-8 source size accepted for a single first-phase strategy module."""
 
-DEFAULT_RUNTIME_MANIFEST = {"strategy_contract_version": 1}
-"""Baseline compatibility marker snapshotted when a caller supplies no manifest."""
+DEFAULT_RUNTIME_MANIFEST = {"strategy_contract_version": STRATEGY_CONTRACT_VERSION}
+"""Protocol metadata snapshotted when a caller supplies no manifest.
+
+``strategy_contract_version`` identifies the current and only official page
+protocol; it is not a migration marker for historical protocol revisions.
+"""
 
 
 _UNSET = object()
@@ -273,6 +278,24 @@ class StrategyStorageService:
         if not validation.valid:
             raise StrategyDraftValidationError(validation.issues)
 
+        manifest = _normalize_json_object(
+            (
+                DEFAULT_RUNTIME_MANIFEST
+                if runtime_manifest is None
+                else runtime_manifest
+            ),
+            field_name="runtime_manifest",
+        )
+        # Publication-time protocol metadata check: the manifest must pin the
+        # current official contract version, otherwise the revision could not
+        # be interpreted by the backtest subprocess.
+        declared_version = manifest.get("strategy_contract_version")
+        if declared_version != STRATEGY_CONTRACT_VERSION:
+            raise StrategyStorageValidationError(
+                "runtime_manifest strategy_contract_version must equal "
+                f"{STRATEGY_CONTRACT_VERSION}"
+            )
+
         revision = StrategyRevision(
             id=uuid4(),
             strategy_id=strategy.id,
@@ -281,14 +304,7 @@ class StrategyStorageService:
             source_hash=computed_hash,
             parameter_schema=deepcopy(draft.parameter_schema),
             default_parameters=deepcopy(draft.default_parameters),
-            runtime_manifest=_normalize_json_object(
-                (
-                    DEFAULT_RUNTIME_MANIFEST
-                    if runtime_manifest is None
-                    else runtime_manifest
-                ),
-                field_name="runtime_manifest",
-            ),
+            runtime_manifest=manifest,
         )
         self.session.add(revision)
         # Flush the child first so the composite current-revision foreign key can

--- a/backend/app/strategy_protocol/__init__.py
+++ b/backend/app/strategy_protocol/__init__.py
@@ -1,0 +1,33 @@
+"""Page-strategy protocol: contract version 1 domain objects and checks.
+
+Public surface of the strategy protocol package:
+
+* :mod:`contract` — protocol version, lookback limit, failure phase, errors;
+* :mod:`decisions` — immutable ``StrategyDecision`` and the mode registry;
+* :mod:`context` — read-only ``DecisionContext`` and nested DTOs;
+* :mod:`data_view` — data/universe query contract with PIT boundaries;
+* :mod:`adapter` — ``FunctionStrategyAdapter`` for ``run(context, parameters)``;
+* :mod:`synthetic` — deterministic synthetic fixture for the contract check;
+* :mod:`checker` / :mod:`worker` — isolated subprocess contract check.
+"""
+
+from .contract import (
+    FAILURE_PHASE_STRATEGY_CONTRACT_CHECK,
+    MAX_LOOKBACK_SESSIONS,
+    STRATEGY_CONTRACT_VERSION,
+)
+from .context import DecisionContext
+from .data_view import StrategyDataDTO, UniverseQueryDTO
+from .decisions import DecisionModeRegistry, StrategyDecision, build_default_registry
+
+__all__ = [
+    "FAILURE_PHASE_STRATEGY_CONTRACT_CHECK",
+    "MAX_LOOKBACK_SESSIONS",
+    "STRATEGY_CONTRACT_VERSION",
+    "DecisionContext",
+    "DecisionModeRegistry",
+    "StrategyDataDTO",
+    "StrategyDecision",
+    "UniverseQueryDTO",
+    "build_default_registry",
+]

--- a/backend/app/strategy_protocol/adapter.py
+++ b/backend/app/strategy_protocol/adapter.py
@@ -13,8 +13,9 @@ imports user code.
 from __future__ import annotations
 
 import inspect
-from types import ModuleType
-from typing import Any, Mapping
+from collections.abc import Mapping
+from types import MappingProxyType, ModuleType
+from typing import Any
 from uuid import UUID
 
 from .contract import STRATEGY_CONTRACT_VERSION, StrategyProtocolError
@@ -24,6 +25,33 @@ from .decisions import DecisionModeRegistry, StrategyDecision, build_default_reg
 
 class StrategyLoadError(StrategyProtocolError):
     """Raised when the published source cannot provide the required entry."""
+
+
+ISOLATED_SUBPROCESS_SCOPE = "isolated_subprocess"
+"""Execution-scope acknowledgment required before user source is executed.
+
+Loading and running strategy source is only ever legitimate inside the
+isolated backtest subprocess (or its contract-check sibling).  Callers must
+pass this exact scope to :meth:`FunctionStrategyAdapter.from_source` so the
+API or any future Runner process cannot accidentally execute private code.
+"""
+
+
+def _freeze_parameters(value: object) -> object:
+    """Recursively convert parameters into immutable containers.
+
+    The strategy receives a read-only object: mappings become mapping proxies
+    and lists become tuples at every nesting level, so a mutated parameter can
+    never leak into later steps of the same run.
+    """
+
+    if isinstance(value, Mapping):
+        return MappingProxyType(
+            {str(key): _freeze_parameters(item) for key, item in value.items()}
+        )
+    if isinstance(value, list):
+        return tuple(_freeze_parameters(item) for item in value)
+    return value
 
 
 class FunctionStrategyAdapter:
@@ -43,8 +71,8 @@ class FunctionStrategyAdapter:
     ) -> None:
         self._registry = registry or build_default_registry()
         # Parameters come from the published revision (validated against its
-        # schema) and are fixed for the whole run.
-        self._parameters: Mapping[str, Any] = dict(parameters)
+        # schema) and are fixed, deeply read-only for the whole run.
+        self._parameters = _freeze_parameters(dict(parameters))
         self._run = self._require_entry_point(module)
 
     @classmethod
@@ -53,11 +81,23 @@ class FunctionStrategyAdapter:
         source_code: str,
         *,
         parameters: Mapping[str, Any],
+        execution_scope: str,
         module_name: str = "published_strategy",
         registry: DecisionModeRegistry | None = None,
     ) -> "FunctionStrategyAdapter":
-        """Load a published revision's source into a fresh module namespace."""
+        """Load a published revision's source into a fresh module namespace.
 
+        ``execution_scope`` must be exactly
+        :data:`ISOLATED_SUBPROCESS_SCOPE`.  Requiring the explicit
+        acknowledgment keeps ``exec`` out of reach of accidental callers such
+        as API request handlers; only the isolated worker passes it.
+        """
+
+        if execution_scope != ISOLATED_SUBPROCESS_SCOPE:
+            raise StrategyLoadError(
+                "strategy source may only be loaded inside the isolated "
+                "backtest subprocess"
+            )
         module = ModuleType(module_name)
         compiled = compile(source_code, module_name, "exec")
         exec(compiled, module.__dict__)  # noqa: S102 - isolated subprocess only

--- a/backend/app/strategy_protocol/adapter.py
+++ b/backend/app/strategy_protocol/adapter.py
@@ -33,9 +33,11 @@ class StrategyLoadError(StrategyProtocolError):
 def _freeze_parameters(value: object) -> object:
     """Recursively convert parameters into immutable containers.
 
-    The strategy receives a read-only object: mappings become mapping proxies
-    and sequences become tuples at every nesting level, so a mutated parameter
-    can never leak into later steps of the same run.
+    Parameters originate from the revision's JSONB storage, so mapping, list,
+    tuple, and scalar values are the supported inputs; mappings become
+    mapping proxies and sequences become tuples at every nesting level, so a
+    mutated parameter can never leak into later steps of the same run.
+    Arbitrary custom mutable Python objects are outside this JSON contract.
     """
 
     if isinstance(value, Mapping):

--- a/backend/app/strategy_protocol/adapter.py
+++ b/backend/app/strategy_protocol/adapter.py
@@ -1,13 +1,16 @@
-"""Adapter that connects a page ``run(context, parameters)`` function.
+"""Adapter that wraps an already-loaded page strategy module.
 
-The adapter implements the engine-internal lifecycle protocol: it loads the
-published strategy module exactly once per run, provides default no-op
-lifecycle callbacks, and converts each raw ``run`` return value into an
-immutable :class:`StrategyDecision` through the decision-mode registry.
+The adapter implements the engine-internal lifecycle protocol: it wraps a
+module holding the published strategy's ``run(context, parameters)`` entry
+point, provides default no-op lifecycle callbacks, and converts each raw
+``run`` return value into an immutable :class:`StrategyDecision` through the
+decision-mode registry.
 
-Loading and executing strategy source only ever happens inside the isolated
-backtest subprocess (or its contract-check sibling); the API process never
-imports user code.
+This module deliberately has no source-loading capability: compiling and
+executing strategy source only ever happens in the worker module that backs
+the isolated backtest subprocess.  Callers pass an already-loaded module
+object here, so the API process cannot accidentally execute private code
+through this adapter.
 """
 
 from __future__ import annotations
@@ -24,43 +27,37 @@ from .decisions import DecisionModeRegistry, StrategyDecision, build_default_reg
 
 
 class StrategyLoadError(StrategyProtocolError):
-    """Raised when the published source cannot provide the required entry."""
-
-
-ISOLATED_SUBPROCESS_SCOPE = "isolated_subprocess"
-"""Execution-scope acknowledgment required before user source is executed.
-
-Loading and running strategy source is only ever legitimate inside the
-isolated backtest subprocess (or its contract-check sibling).  Callers must
-pass this exact scope to :meth:`FunctionStrategyAdapter.from_source` so the
-API or any future Runner process cannot accidentally execute private code.
-"""
+    """Raised when a strategy module cannot provide the required entry."""
 
 
 def _freeze_parameters(value: object) -> object:
     """Recursively convert parameters into immutable containers.
 
     The strategy receives a read-only object: mappings become mapping proxies
-    and lists become tuples at every nesting level, so a mutated parameter can
-    never leak into later steps of the same run.
+    and sequences become tuples at every nesting level, so a mutated parameter
+    can never leak into later steps of the same run.
     """
 
     if isinstance(value, Mapping):
         return MappingProxyType(
             {str(key): _freeze_parameters(item) for key, item in value.items()}
         )
-    if isinstance(value, list):
+    if isinstance(value, (list, tuple)):
         return tuple(_freeze_parameters(item) for item in value)
+    if isinstance(value, (str, int, float, bool)) or value is None:
+        return value
     return value
 
 
 class FunctionStrategyAdapter:
-    """Wrap one module-level ``run(context, parameters)`` function.
+    """Wrap one already-loaded module-level ``run(context, parameters)`` function.
 
     The adapter satisfies the internal :class:`StrategyProgram` protocol:
     ``on_step`` performs the decision while the remaining callbacks default to
     no-ops so page functions never need to implement them.
     """
+
+    __slots__ = ("_registry", "_parameters", "_run")
 
     def __init__(
         self,
@@ -69,39 +66,14 @@ class FunctionStrategyAdapter:
         parameters: Mapping[str, Any],
         registry: DecisionModeRegistry | None = None,
     ) -> None:
-        self._registry = registry or build_default_registry()
+        object.__setattr__(self, "_registry", registry or build_default_registry())
         # Parameters come from the published revision (validated against its
         # schema) and are fixed, deeply read-only for the whole run.
-        self._parameters = _freeze_parameters(dict(parameters))
-        self._run = self._require_entry_point(module)
+        object.__setattr__(self, "_parameters", _freeze_parameters(dict(parameters)))
+        object.__setattr__(self, "_run", self._require_entry_point(module))
 
-    @classmethod
-    def from_source(
-        cls,
-        source_code: str,
-        *,
-        parameters: Mapping[str, Any],
-        execution_scope: str,
-        module_name: str = "published_strategy",
-        registry: DecisionModeRegistry | None = None,
-    ) -> "FunctionStrategyAdapter":
-        """Load a published revision's source into a fresh module namespace.
-
-        ``execution_scope`` must be exactly
-        :data:`ISOLATED_SUBPROCESS_SCOPE`.  Requiring the explicit
-        acknowledgment keeps ``exec`` out of reach of accidental callers such
-        as API request handlers; only the isolated worker passes it.
-        """
-
-        if execution_scope != ISOLATED_SUBPROCESS_SCOPE:
-            raise StrategyLoadError(
-                "strategy source may only be loaded inside the isolated "
-                "backtest subprocess"
-            )
-        module = ModuleType(module_name)
-        compiled = compile(source_code, module_name, "exec")
-        exec(compiled, module.__dict__)  # noqa: S102 - isolated subprocess only
-        return cls(module, parameters=parameters, registry=registry)
+    def __setattr__(self, name: str, value: object) -> None:
+        raise AttributeError("the strategy adapter is read-only once constructed")
 
     @staticmethod
     def _require_entry_point(module: ModuleType):

--- a/backend/app/strategy_protocol/adapter.py
+++ b/backend/app/strategy_protocol/adapter.py
@@ -1,0 +1,160 @@
+"""Adapter that connects a page ``run(context, parameters)`` function.
+
+The adapter implements the engine-internal lifecycle protocol: it loads the
+published strategy module exactly once per run, provides default no-op
+lifecycle callbacks, and converts each raw ``run`` return value into an
+immutable :class:`StrategyDecision` through the decision-mode registry.
+
+Loading and executing strategy source only ever happens inside the isolated
+backtest subprocess (or its contract-check sibling); the API process never
+imports user code.
+"""
+
+from __future__ import annotations
+
+import inspect
+from types import ModuleType
+from typing import Any, Mapping
+from uuid import UUID
+
+from .contract import STRATEGY_CONTRACT_VERSION, StrategyProtocolError
+from .context import DecisionContext
+from .decisions import DecisionModeRegistry, StrategyDecision, build_default_registry
+
+
+class StrategyLoadError(StrategyProtocolError):
+    """Raised when the published source cannot provide the required entry."""
+
+
+class FunctionStrategyAdapter:
+    """Wrap one module-level ``run(context, parameters)`` function.
+
+    The adapter satisfies the internal :class:`StrategyProgram` protocol:
+    ``on_step`` performs the decision while the remaining callbacks default to
+    no-ops so page functions never need to implement them.
+    """
+
+    def __init__(
+        self,
+        module: ModuleType,
+        *,
+        parameters: Mapping[str, Any],
+        registry: DecisionModeRegistry | None = None,
+    ) -> None:
+        self._registry = registry or build_default_registry()
+        # Parameters come from the published revision (validated against its
+        # schema) and are fixed for the whole run.
+        self._parameters: Mapping[str, Any] = dict(parameters)
+        self._run = self._require_entry_point(module)
+
+    @classmethod
+    def from_source(
+        cls,
+        source_code: str,
+        *,
+        parameters: Mapping[str, Any],
+        module_name: str = "published_strategy",
+        registry: DecisionModeRegistry | None = None,
+    ) -> "FunctionStrategyAdapter":
+        """Load a published revision's source into a fresh module namespace."""
+
+        module = ModuleType(module_name)
+        compiled = compile(source_code, module_name, "exec")
+        exec(compiled, module.__dict__)  # noqa: S102 - isolated subprocess only
+        return cls(module, parameters=parameters, registry=registry)
+
+    @staticmethod
+    def _require_entry_point(module: ModuleType):
+        """Return the single module-level synchronous ``run`` function."""
+
+        run = getattr(module, "run", None)
+        if run is None or not callable(run):
+            raise StrategyLoadError(
+                "策略模块必须定义模块级 run(context, parameters) 函数。"
+            )
+        try:
+            signature = inspect.signature(run)
+        except (TypeError, ValueError) as exc:
+            raise StrategyLoadError("无法解析 run 函数签名。") from exc
+        parameters = list(signature.parameters.values())
+        if len(parameters) != 2 or [
+            parameter.name for parameter in parameters
+        ] != ["context", "parameters"]:
+            raise StrategyLoadError("run 函数签名必须为 run(context, parameters)。")
+        if inspect.iscoroutinefunction(run):
+            raise StrategyLoadError("run 函数必须是同步函数。")
+        return run
+
+    # ------------------------------------------------------------------
+    # StrategyProgram lifecycle protocol
+    # ------------------------------------------------------------------
+
+    def on_start(self, context: Any) -> None:
+        """Default no-op; page functions have no start hook."""
+
+    def on_step(self, context: DecisionContext) -> StrategyDecision:
+        """Run one decision and validate the returned payload."""
+
+        raw = self._run(context, self._parameters)
+        return self.build_decision(
+            raw,
+            step_sequence=context.step_sequence,
+            decision_time=context.decision_time,
+            known_instrument_ids=known_instrument_ids(context),
+        )
+
+    def on_order_update(self, update: Any) -> None:
+        """Default no-op; page functions cannot observe order updates yet."""
+
+    def on_fill(self, fill: Any) -> None:
+        """Default no-op; page functions cannot observe fills."""
+
+    def on_finish(self, context: Any) -> None:
+        """Default no-op; page functions have no finish hook."""
+
+    # ------------------------------------------------------------------
+
+    def build_decision(
+        self,
+        payload: Any,
+        *,
+        step_sequence: int,
+        decision_time,
+        known_instrument_ids: set[UUID],
+    ) -> StrategyDecision:
+        """Validate a raw return value and build the immutable decision."""
+
+        mode, targets = self._registry.validate(
+            payload, known_instrument_ids=known_instrument_ids
+        )
+        reason = None
+        if isinstance(payload, Mapping):
+            raw_reason = payload.get("reason")
+            if raw_reason is not None:
+                if not isinstance(raw_reason, str):
+                    from .contract import InvalidDecisionPayloadError
+
+                    raise InvalidDecisionPayloadError("reason must be a string")
+                reason = raw_reason
+        return StrategyDecision(
+            step_sequence=step_sequence,
+            decision_time=decision_time,
+            mode=mode,
+            targets=targets,
+            reason=reason,
+            contract_version=STRATEGY_CONTRACT_VERSION,
+        )
+
+
+def known_instrument_ids(context: DecisionContext) -> set[UUID]:
+    """Collect the identities a decision may reference in this step.
+
+    The set combines the portfolio's non-zero positions with the candidate
+    universe visible at ``data_cutoff``.  Targets outside this set fail the
+    run instead of being silently accepted.
+    """
+
+    ids = {position.instrument_id for position in context.portfolio.positions}
+    for candidate in context.universe.query():
+        ids.add(candidate.instrument_id)
+    return ids

--- a/backend/app/strategy_protocol/checker.py
+++ b/backend/app/strategy_protocol/checker.py
@@ -4,9 +4,14 @@ This module spawns ``python -m app.strategy_protocol.worker`` as a separate
 process, feeds it one JSON request, and enforces the run protections the
 design approved for this phase:
 
-* wall-clock timeout with kill;
-* a cancel signal hook;
-* a bounded result document (stdout is capped, oversized output fails);
+* wall-clock timeout that kills the whole worker process tree (the worker
+  starts in its own POSIX session so grandchildren die with it);
+* a cancel signal hook with the same tree-kill guarantee;
+* streaming byte caps on the result document and stderr, so neither the
+  strategy nor a noisy child can grow the parent's memory without bound;
+* a dedicated result file descriptor separate from the strategy-visible
+  stdout/stderr pipes, plus strict validation of the complete result
+  protocol and the worker exit code;
 * an optional platform-supported address-space cap passed to the worker.
 
 The checker never executes strategy source inside the caller's process.  A
@@ -19,6 +24,8 @@ from __future__ import annotations
 
 import json
 import os
+import select
+import signal
 import subprocess
 import sys
 import time
@@ -29,11 +36,15 @@ from decimal import Decimal
 from typing import Any
 from uuid import UUID
 
-from .contract import FAILURE_PHASE_STRATEGY_CONTRACT_CHECK
+from .contract import STRATEGY_CONTRACT_VERSION, FAILURE_PHASE_STRATEGY_CONTRACT_CHECK
 
 DEFAULT_CONTRACT_CHECK_TIMEOUT_SECONDS = 10.0
 DEFAULT_MAX_RESULT_BYTES = 1_048_576
+MAX_STDERR_BYTES = 262_144
+"""Streaming cap on captured worker stderr before the check is failed."""
 _CANCEL_POLL_INTERVAL_SECONDS = 0.05
+_CLEANUP_JOIN_SECONDS = 2.0
+"""Wall-clock budget for reaping a killed process tree during cleanup."""
 
 
 @dataclass(frozen=True, slots=True)
@@ -138,13 +149,17 @@ def run_strategy_contract_check(
 ) -> ContractCheckResult:
     """Run the isolated worker once and return its structured outcome.
 
-    Timeout, cancellation, output overflow, and worker crashes all map to a
-    failed :class:`ContractCheckResult` carrying the
+    Timeout, cancellation, output overflow, protocol violations, and worker
+    crashes all map to a failed :class:`ContractCheckResult` carrying the
     ``strategy_contract_check`` phase; none of them raise into the caller.
     """
 
     payload = build_worker_payload(request)
-    environment = dict(_worker_environment(memory_limit_mb))
+    # The worker returns its result on a dedicated descriptor that is not the
+    # strategy-visible stdout, so stray writes to fd 1 cannot forge results.
+    result_read_fd, result_write_fd = os.pipe()
+    environment = _worker_environment(memory_limit_mb)
+    environment["QF_CONTRACT_CHECK_RESULT_FD"] = str(result_write_fd)
     process = subprocess.Popen(
         [
             python_executable or sys.executable,
@@ -154,42 +169,108 @@ def run_strategy_contract_check(
         stdin=subprocess.PIPE,
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
+        pass_fds=(result_write_fd,),
         env=environment,
         cwd=_backend_root(),
+        start_new_session=(os.name == "posix"),
     )
+    os.close(result_write_fd)
+    return _supervise_worker(
+        process,
+        request_payload=payload,
+        result_read_fd=result_read_fd,
+        environment=environment,
+        timeout_seconds=timeout_seconds,
+        max_result_bytes=max_result_bytes,
+        should_cancel=should_cancel,
+    )
+
+
+def _supervise_worker(
+    process: subprocess.Popen,
+    *,
+    request_payload: bytes,
+    result_read_fd: int,
+    environment: dict[str, str],
+    timeout_seconds: float,
+    max_result_bytes: int,
+    should_cancel: Callable[[], bool] | None,
+) -> ContractCheckResult:
+    """Stream the worker's pipes under byte caps until a terminal condition.
+
+    All reads are non-blocking and size-capped, so neither the strategy nor a
+    grandchild process holding the inherited descriptors can block the parent
+    indefinitely or grow its memory without bound.
+    """
+
     deadline = time.monotonic() + timeout_seconds
-    stdout_bytes: bytes = b""
-    stderr_bytes: bytes = b""
+    os.set_blocking(result_read_fd, False)
+    assert process.stdout is not None
+    assert process.stderr is not None
+    os.set_blocking(process.stdout.fileno(), False)
+    os.set_blocking(process.stderr.fileno(), False)
+
+    result_chunks: list[bytes] = []
+    stderr_chunks: list[bytes] = []
+    result_bytes = 0
+    stderr_bytes = 0
+    stdin_written = False
     timed_out = False
     cancelled = False
-    input_sent = False
+    result_overflow = False
+    stderr_overflow = False
+    result_open = True
+    stderr_open = True
     try:
         while True:
             if should_cancel is not None and should_cancel():
                 cancelled = True
-                process.kill()
                 break
             remaining = deadline - time.monotonic()
             if remaining <= 0:
                 timed_out = True
-                process.kill()
                 break
-            try:
-                # stdin is written by the first communicate call only; retries
-                # after a poll-level timeout must not resend the payload.
-                stdout_bytes, stderr_bytes = process.communicate(
-                    input=payload if not input_sent else None,
-                    timeout=min(_CANCEL_POLL_INTERVAL_SECONDS, remaining),
-                )
-                input_sent = True
+            if not stdin_written:
+                try:
+                    process.stdin.write(request_payload)  # type: ignore[union-attr]
+                    process.stdin.close()  # type: ignore[union-attr]
+                    stdin_written = True
+                except BrokenPipeError:
+                    # Worker died before reading stdin; the exit-code check
+                    # below reports the crash.
+                    stdin_written = True
+            watch_fds: list[int] = []
+            if result_open and not result_overflow:
+                watch_fds.append(result_read_fd)
+            if stderr_open and not stderr_overflow:
+                watch_fds.append(process.stderr.fileno())  # type: ignore[union-attr]
+            if process.poll() is not None and not watch_fds:
                 break
-            except subprocess.TimeoutExpired:
-                input_sent = True
-                continue
+            readable, _, _ = select.select(
+                watch_fds, [], [], min(_CANCEL_POLL_INTERVAL_SECONDS, remaining)
+            )
+            for readable_fd in readable:
+                if readable_fd == result_read_fd:
+                    result_bytes, result_overflow, result_open = _drain_fd(
+                        readable_fd, result_chunks, result_bytes, max_result_bytes, result_open
+                    )
+                else:
+                    stderr_bytes, stderr_overflow, stderr_open = _drain_fd(
+                        readable_fd, stderr_chunks, stderr_bytes, MAX_STDERR_BYTES, stderr_open
+                    )
+            if result_overflow or stderr_overflow:
+                break
+            if (
+                process.poll() is not None
+                and stdin_written
+                and not result_open
+                and not stderr_open
+            ):
+                break
     finally:
-        if process.poll() is None:  # defensive: never leak the worker
-            process.kill()
-            process.communicate()
+        exit_code = _terminate_process_tree(process)
+
+    stderr_tail = _stderr_tail(b"".join(stderr_chunks))
 
     if cancelled:
         return ContractCheckResult(
@@ -197,6 +278,7 @@ def run_strategy_contract_check(
             failure_phase=FAILURE_PHASE_STRATEGY_CONTRACT_CHECK,
             error_type="ContractCheckCancelled",
             message="运行契约检查已被取消。",
+            technical=stderr_tail,
         )
     if timed_out:
         return ContractCheckResult(
@@ -204,38 +286,171 @@ def run_strategy_contract_check(
             failure_phase=FAILURE_PHASE_STRATEGY_CONTRACT_CHECK,
             error_type="ContractCheckTimeout",
             message=f"运行契约检查超过 {timeout_seconds} 秒超时限制，已终止。",
-            technical=_stderr_tail(stderr_bytes),
+            technical=stderr_tail,
         )
-
-    if len(stdout_bytes) > max_result_bytes:
+    if result_overflow:
         return ContractCheckResult(
             ok=False,
             failure_phase=FAILURE_PHASE_STRATEGY_CONTRACT_CHECK,
             error_type="ContractCheckOutputLimit",
-            message="运行契约检查输出超过上限，已终止。",
-            technical=_stderr_tail(stderr_bytes),
+            message="运行契约检查结果超过上限，已终止。",
+            technical=stderr_tail,
         )
-    try:
-        decoded = json.loads(stdout_bytes.decode("utf-8"))
-    except (UnicodeDecodeError, json.JSONDecodeError):
+    if stderr_overflow:
+        return ContractCheckResult(
+            ok=False,
+            failure_phase=FAILURE_PHASE_STRATEGY_CONTRACT_CHECK,
+            error_type="ContractCheckOutputLimit",
+            message="运行契约检查 stderr 超过上限，已终止。",
+            technical=stderr_tail,
+        )
+
+    # A worker that exits nonzero never produced a trustworthy result, even
+    # if a partial document arrived on the result channel.
+    if exit_code != 0:
         return ContractCheckResult(
             ok=False,
             failure_phase=FAILURE_PHASE_STRATEGY_CONTRACT_CHECK,
             error_type="ContractCheckCrashed",
             message="运行契约检查进程异常退出。",
-            technical=_stderr_tail(stderr_bytes),
+            technical=stderr_tail,
         )
-    if decoded.get("ok") is True:
-        evidence = decoded.get("evidence", {})
-        return ContractCheckResult(ok=True, evidence=evidence)
-    failure = decoded.get("failure", {})
+    try:
+        decoded = json.loads(b"".join(result_chunks).decode("utf-8"))
+    except (UnicodeDecodeError, json.JSONDecodeError):
+        return ContractCheckResult(
+            ok=False,
+            failure_phase=FAILURE_PHASE_STRATEGY_CONTRACT_CHECK,
+            error_type="ContractCheckCrashed",
+            message="运行契约检查未返回有效的结果文档。",
+            technical=stderr_tail,
+        )
+    return _validate_result_document(decoded, stderr_tail)
+
+
+def _drain_fd(
+    fd: int, chunks: list[bytes], total: int, cap: int, is_open: bool
+) -> tuple[int, bool, bool]:
+    """Read whatever is available from one non-blocking fd under a cap.
+
+    Returns the running byte total, whether the cap was exceeded, and whether
+    the descriptor is still open (EOF marks it closed so the supervisor never
+    busy-loops on an exhausted pipe).
+    """
+
+    if not is_open:
+        return total, False, False
+    while True:
+        try:
+            chunk = os.read(fd, 65_536)
+        except (BlockingIOError, InterruptedError):
+            return total, False, True
+        except OSError:
+            return total, False, False
+        if not chunk:
+            # EOF: the writer closed its end.
+            try:
+                os.close(fd)
+            except OSError:
+                pass
+            return total, False, False
+        total += len(chunk)
+        if total > cap:
+            return total, True, True
+        chunks.append(chunk)
+
+
+def _terminate_process_tree(process: subprocess.Popen) -> int | None:
+    """Kill the worker and any inherited-descriptor grandchildren, then reap.
+
+    The worker runs in its own POSIX session, so killing the process group
+    takes down grandchildren that would otherwise keep the pipes open.  The
+    reaping phase itself is bounded so cleanup can never block the caller.
+    """
+
+    if os.name == "posix":
+        try:
+            os.killpg(os.getpgid(process.pid), signal.SIGKILL)
+        except (ProcessLookupError, PermissionError):
+            process.kill()
+    else:  # pragma: no cover - Windows path
+        process.kill()
+    try:
+        return process.wait(timeout=_CLEANUP_JOIN_SECONDS)
+    except subprocess.TimeoutExpired:  # pragma: no cover - defensive
+        process.kill()
+        try:
+            return process.wait(timeout=_CLEANUP_JOIN_SECONDS)
+        except subprocess.TimeoutExpired:
+            return None
+    finally:
+        for stream in (process.stdin, process.stdout, process.stderr):
+            try:
+                if stream is not None and not stream.closed:
+                    stream.close()
+            except (OSError, ValueError):
+                pass
+
+
+def _validate_result_document(
+    decoded: object, stderr_tail: str | None
+) -> ContractCheckResult:
+    """Enforce the complete worker result protocol before trusting it.
+
+    A success verdict is only accepted from a fully shaped document with the
+    required evidence fields; anything else is treated as a crashed check.
+    """
+
+    if not isinstance(decoded, dict) or not isinstance(decoded.get("ok"), bool):
+        return _protocol_violation(stderr_tail)
+    if decoded["ok"] is False:
+        failure = decoded.get("failure")
+        if not isinstance(failure, dict) or not isinstance(
+            failure.get("error_type"), str
+        ):
+            return _protocol_violation(stderr_tail)
+        return ContractCheckResult(
+            ok=False,
+            failure_phase=FAILURE_PHASE_STRATEGY_CONTRACT_CHECK,
+            error_type=failure.get("error_type"),
+            message=failure.get("message"),
+            line=failure.get("line"),
+            technical=failure.get("traceback") or stderr_tail,
+        )
+
+    evidence = decoded.get("evidence")
+    if not isinstance(evidence, dict):
+        return _protocol_violation(stderr_tail)
+    if evidence.get("contract_version") != STRATEGY_CONTRACT_VERSION:
+        return _protocol_violation(stderr_tail)
+    if not isinstance(evidence.get("mode"), str) or not evidence["mode"]:
+        return _protocol_violation(stderr_tail)
+    target_count = evidence.get("target_count")
+    if isinstance(target_count, bool) or not isinstance(target_count, int) or target_count < 0:
+        return _protocol_violation(stderr_tail)
+    if not isinstance(evidence.get("session_dates"), list):
+        return _protocol_violation(stderr_tail)
+    identity_rows = evidence.get("identity_rows")
+    if not isinstance(identity_rows, list):
+        return _protocol_violation(stderr_tail)
+    for row in identity_rows:
+        if not isinstance(row, dict) or not all(
+            isinstance(row.get(field_name), str)
+            for field_name in ("instrument_id", "trading_code", "name", "display_name")
+        ):
+            return _protocol_violation(stderr_tail)
+    return ContractCheckResult(ok=True, evidence=evidence)
+
+
+def _protocol_violation(stderr_tail: str | None) -> ContractCheckResult:
+    """Map a malformed result document to a failed check."""
+
     return ContractCheckResult(
         ok=False,
         failure_phase=FAILURE_PHASE_STRATEGY_CONTRACT_CHECK,
-        error_type=failure.get("error_type"),
-        message=failure.get("message"),
-        line=failure.get("line"),
-        technical=failure.get("traceback") or _stderr_tail(stderr_bytes),
+        error_type="ContractCheckCrashed",
+        message="运行契约检查结果协议不完整，已拒绝。",
+        technical=stderr_tail,
     )
 
 

--- a/backend/app/strategy_protocol/checker.py
+++ b/backend/app/strategy_protocol/checker.py
@@ -157,23 +157,31 @@ def run_strategy_contract_check(
     payload = build_worker_payload(request)
     # The worker returns its result on a dedicated descriptor that is not the
     # strategy-visible stdout, so stray writes to fd 1 cannot forge results.
+    # Worker stdout itself carries nothing the parent needs (the strategy's
+    # prints are forwarded to stderr by the bounded redirect), so it goes to
+    # DEVNULL: an unwritten pipe can never block a noisy strategy.
     result_read_fd, result_write_fd = os.pipe()
     environment = _worker_environment(memory_limit_mb)
     environment["QF_CONTRACT_CHECK_RESULT_FD"] = str(result_write_fd)
-    process = subprocess.Popen(
-        [
-            python_executable or sys.executable,
-            "-m",
-            "app.strategy_protocol.worker",
-        ],
-        stdin=subprocess.PIPE,
-        stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE,
-        pass_fds=(result_write_fd,),
-        env=environment,
-        cwd=_backend_root(),
-        start_new_session=(os.name == "posix"),
-    )
+    try:
+        process = subprocess.Popen(
+            [
+                python_executable or sys.executable,
+                "-m",
+                "app.strategy_protocol.worker",
+            ],
+            stdin=subprocess.PIPE,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.PIPE,
+            pass_fds=(result_write_fd,),
+            env=environment,
+            cwd=_backend_root(),
+            start_new_session=(os.name == "posix"),
+        )
+    except BaseException:
+        os.close(result_read_fd)
+        os.close(result_write_fd)
+        raise
     os.close(result_write_fd)
     return _supervise_worker(
         process,
@@ -205,9 +213,7 @@ def _supervise_worker(
 
     deadline = time.monotonic() + timeout_seconds
     os.set_blocking(result_read_fd, False)
-    assert process.stdout is not None
     assert process.stderr is not None
-    os.set_blocking(process.stdout.fileno(), False)
     os.set_blocking(process.stderr.fileno(), False)
 
     result_chunks: list[bytes] = []
@@ -269,6 +275,14 @@ def _supervise_worker(
                 break
     finally:
         exit_code = _terminate_process_tree(process)
+        # The result channel must close on every exit path; EOF-driven
+        # closing only happens when the loop drains it to the end, so early
+        # exits (timeout, cancel, overflow) would otherwise leak the fd.
+        if result_open:
+            try:
+                os.close(result_read_fd)
+            except OSError:
+                pass
 
     stderr_tail = _stderr_tail(b"".join(stderr_chunks))
 

--- a/backend/app/strategy_protocol/checker.py
+++ b/backend/app/strategy_protocol/checker.py
@@ -60,6 +60,7 @@ class ContractCheckResult:
     error_type: str | None = None
     message: str | None = None
     line: int | None = None
+    technical: str | None = None
 
 
 SYNTHETIC_FALLBACK_TIMEZONE = timezone(timedelta(hours=8))
@@ -203,6 +204,7 @@ def run_strategy_contract_check(
             failure_phase=FAILURE_PHASE_STRATEGY_CONTRACT_CHECK,
             error_type="ContractCheckTimeout",
             message=f"运行契约检查超过 {timeout_seconds} 秒超时限制，已终止。",
+            technical=_stderr_tail(stderr_bytes),
         )
 
     if len(stdout_bytes) > max_result_bytes:
@@ -211,6 +213,7 @@ def run_strategy_contract_check(
             failure_phase=FAILURE_PHASE_STRATEGY_CONTRACT_CHECK,
             error_type="ContractCheckOutputLimit",
             message="运行契约检查输出超过上限，已终止。",
+            technical=_stderr_tail(stderr_bytes),
         )
     try:
         decoded = json.loads(stdout_bytes.decode("utf-8"))
@@ -220,6 +223,7 @@ def run_strategy_contract_check(
             failure_phase=FAILURE_PHASE_STRATEGY_CONTRACT_CHECK,
             error_type="ContractCheckCrashed",
             message="运行契约检查进程异常退出。",
+            technical=_stderr_tail(stderr_bytes),
         )
     if decoded.get("ok") is True:
         evidence = decoded.get("evidence", {})
@@ -231,7 +235,23 @@ def run_strategy_contract_check(
         error_type=failure.get("error_type"),
         message=failure.get("message"),
         line=failure.get("line"),
+        technical=failure.get("traceback") or _stderr_tail(stderr_bytes),
     )
+
+
+MAX_TECHNICAL_DETAIL_CHARS = 4_000
+"""Upper bound on stderr/traceback detail kept in a check result."""
+
+
+def _stderr_tail(stderr_bytes: bytes) -> str | None:
+    """Return a bounded worker stderr tail as expandable technical detail."""
+
+    if not stderr_bytes:
+        return None
+    rendered = stderr_bytes.decode("utf-8", errors="replace").strip()
+    if len(rendered) > MAX_TECHNICAL_DETAIL_CHARS:
+        rendered = rendered[-MAX_TECHNICAL_DETAIL_CHARS:]
+    return rendered or None
 
 
 def _worker_environment(memory_limit_mb: int | None) -> dict[str, str]:

--- a/backend/app/strategy_protocol/checker.py
+++ b/backend/app/strategy_protocol/checker.py
@@ -265,6 +265,9 @@ def _worker_environment(memory_limit_mb: int | None) -> dict[str, str]:
     environment = dict(os.environ)
     environment["PYTHONNOUSERSITE"] = "1"
     environment["PYTHONHASHSEED"] = "0"
+    # Marks the child as a real contract-check worker; the worker refuses to
+    # compile strategy source without this marker plus its __main__ role.
+    environment["QF_CONTRACT_CHECK_WORKER"] = "1"
     if memory_limit_mb is not None:
         environment["QF_CONTRACT_CHECK_MEM_MB"] = str(memory_limit_mb)
     return environment

--- a/backend/app/strategy_protocol/checker.py
+++ b/backend/app/strategy_protocol/checker.py
@@ -1,0 +1,267 @@
+"""Parent-side runner for the isolated startup contract check.
+
+This module spawns ``python -m app.strategy_protocol.worker`` as a separate
+process, feeds it one JSON request, and enforces the run protections the
+design approved for this phase:
+
+* wall-clock timeout with kill;
+* a cancel signal hook;
+* a bounded result document (stdout is capped, oversized output fails);
+* an optional platform-supported address-space cap passed to the worker.
+
+The checker never executes strategy source inside the caller's process.  A
+failed check produces a locatable failure record and the
+``strategy_contract_check`` failure phase; it never modifies or rolls back a
+published revision.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+import time
+from collections.abc import Callable, Mapping
+from dataclasses import dataclass, field
+from datetime import date, datetime, timedelta, timezone
+from decimal import Decimal
+from typing import Any
+from uuid import UUID
+
+from .contract import FAILURE_PHASE_STRATEGY_CONTRACT_CHECK
+
+DEFAULT_CONTRACT_CHECK_TIMEOUT_SECONDS = 10.0
+DEFAULT_MAX_RESULT_BYTES = 1_048_576
+_CANCEL_POLL_INTERVAL_SECONDS = 0.05
+
+
+@dataclass(frozen=True, slots=True)
+class ContractCheckRequest:
+    """Everything the isolated worker needs for one deterministic check."""
+
+    source_code: str
+    parameter_schema: Mapping[str, Any]
+    default_parameters: Mapping[str, Any]
+    static_instrument_ids: tuple[str, ...] = ()
+    initial_positions: tuple[Mapping[str, Any], ...] = ()
+    session_date: date | None = None
+    decision_time: datetime | None = None
+    data_cutoff: datetime | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class ContractCheckResult:
+    """Outcome of one contract check, safe to persist as run evidence."""
+
+    ok: bool
+    evidence: Mapping[str, Any] = field(default_factory=dict)
+    failure_phase: str | None = None
+    error_type: str | None = None
+    message: str | None = None
+    line: int | None = None
+
+
+SYNTHETIC_FALLBACK_TIMEZONE = timezone(timedelta(hours=8))
+"""Fixed fallback timezone; never derived from the host clock or locale."""
+
+
+def _default_session_dates() -> tuple[date, datetime]:
+    """Deterministic fallback session built from fixed constants.
+
+    The default uses a fixed synthetic date instead of the wall clock so the
+    check inputs stay reproducible even when callers omit explicit dates.
+    """
+
+    fixed_day = date(2030, 1, 15)
+    fixed_time = datetime(2030, 1, 15, 15, 0, 0, tzinfo=SYNTHETIC_FALLBACK_TIMEZONE)
+    return fixed_day, fixed_time
+
+
+def _jsonify(value: Any) -> Any:
+    """Convert domain values (UUID, Decimal, date) into JSON-safe forms."""
+
+    if isinstance(value, UUID):
+        return str(value)
+    if isinstance(value, Decimal):
+        # Decimal crosses the boundary as an exact decimal string.
+        return format(value, "f")
+    if isinstance(value, (date, datetime)):
+        return value.isoformat()
+    if isinstance(value, Mapping):
+        return {str(key): _jsonify(item) for key, item in value.items()}
+    if isinstance(value, (list, tuple)):
+        return [_jsonify(item) for item in value]
+    return value
+
+
+def build_worker_payload(request: ContractCheckRequest) -> bytes:
+    """Serialize the request into the worker's stdin JSON document."""
+
+    if request.session_date is not None:
+        session_date = request.session_date
+    else:
+        session_date, _ = _default_session_dates()
+    decision_time = request.decision_time or datetime(
+        session_date.year,
+        session_date.month,
+        session_date.day,
+        15,
+        0,
+        0,
+        tzinfo=SYNTHETIC_FALLBACK_TIMEZONE,
+    )
+    data_cutoff = request.data_cutoff or decision_time
+    payload = {
+        "source_code": request.source_code,
+        "parameter_schema": _jsonify(dict(request.parameter_schema)),
+        "default_parameters": _jsonify(dict(request.default_parameters)),
+        "static_instrument_ids": [str(value) for value in request.static_instrument_ids],
+        "initial_positions": [_jsonify(dict(row)) for row in request.initial_positions],
+        "session_date": session_date.isoformat(),
+        # Serialized with offset so the worker receives tz-aware timestamps.
+        "decision_time": decision_time.isoformat(),
+        "data_cutoff": data_cutoff.isoformat(),
+    }
+    return json.dumps(payload, ensure_ascii=False).encode("utf-8")
+
+
+def run_strategy_contract_check(
+    request: ContractCheckRequest,
+    *,
+    timeout_seconds: float = DEFAULT_CONTRACT_CHECK_TIMEOUT_SECONDS,
+    max_result_bytes: int = DEFAULT_MAX_RESULT_BYTES,
+    memory_limit_mb: int | None = None,
+    should_cancel: Callable[[], bool] | None = None,
+    python_executable: str | None = None,
+) -> ContractCheckResult:
+    """Run the isolated worker once and return its structured outcome.
+
+    Timeout, cancellation, output overflow, and worker crashes all map to a
+    failed :class:`ContractCheckResult` carrying the
+    ``strategy_contract_check`` phase; none of them raise into the caller.
+    """
+
+    payload = build_worker_payload(request)
+    environment = dict(_worker_environment(memory_limit_mb))
+    process = subprocess.Popen(
+        [
+            python_executable or sys.executable,
+            "-m",
+            "app.strategy_protocol.worker",
+        ],
+        stdin=subprocess.PIPE,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        env=environment,
+        cwd=_backend_root(),
+    )
+    deadline = time.monotonic() + timeout_seconds
+    stdout_bytes: bytes = b""
+    stderr_bytes: bytes = b""
+    timed_out = False
+    cancelled = False
+    input_sent = False
+    try:
+        while True:
+            if should_cancel is not None and should_cancel():
+                cancelled = True
+                process.kill()
+                break
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                timed_out = True
+                process.kill()
+                break
+            try:
+                # stdin is written by the first communicate call only; retries
+                # after a poll-level timeout must not resend the payload.
+                stdout_bytes, stderr_bytes = process.communicate(
+                    input=payload if not input_sent else None,
+                    timeout=min(_CANCEL_POLL_INTERVAL_SECONDS, remaining),
+                )
+                input_sent = True
+                break
+            except subprocess.TimeoutExpired:
+                input_sent = True
+                continue
+    finally:
+        if process.poll() is None:  # defensive: never leak the worker
+            process.kill()
+            process.communicate()
+
+    if cancelled:
+        return ContractCheckResult(
+            ok=False,
+            failure_phase=FAILURE_PHASE_STRATEGY_CONTRACT_CHECK,
+            error_type="ContractCheckCancelled",
+            message="运行契约检查已被取消。",
+        )
+    if timed_out:
+        return ContractCheckResult(
+            ok=False,
+            failure_phase=FAILURE_PHASE_STRATEGY_CONTRACT_CHECK,
+            error_type="ContractCheckTimeout",
+            message=f"运行契约检查超过 {timeout_seconds} 秒超时限制，已终止。",
+        )
+
+    if len(stdout_bytes) > max_result_bytes:
+        return ContractCheckResult(
+            ok=False,
+            failure_phase=FAILURE_PHASE_STRATEGY_CONTRACT_CHECK,
+            error_type="ContractCheckOutputLimit",
+            message="运行契约检查输出超过上限，已终止。",
+        )
+    try:
+        decoded = json.loads(stdout_bytes.decode("utf-8"))
+    except (UnicodeDecodeError, json.JSONDecodeError):
+        return ContractCheckResult(
+            ok=False,
+            failure_phase=FAILURE_PHASE_STRATEGY_CONTRACT_CHECK,
+            error_type="ContractCheckCrashed",
+            message="运行契约检查进程异常退出。",
+        )
+    if decoded.get("ok") is True:
+        evidence = decoded.get("evidence", {})
+        return ContractCheckResult(ok=True, evidence=evidence)
+    failure = decoded.get("failure", {})
+    return ContractCheckResult(
+        ok=False,
+        failure_phase=FAILURE_PHASE_STRATEGY_CONTRACT_CHECK,
+        error_type=failure.get("error_type"),
+        message=failure.get("message"),
+        line=failure.get("line"),
+    )
+
+
+def _worker_environment(memory_limit_mb: int | None) -> dict[str, str]:
+    """Environment for the worker; carries the optional memory cap.
+
+    The parent's full environment is inherited so ``uv run``-style virtualenv
+    resolution keeps working; only the determinism and limit overrides are
+    added on top.
+    """
+
+    environment = dict(os.environ)
+    environment["PYTHONNOUSERSITE"] = "1"
+    environment["PYTHONHASHSEED"] = "0"
+    if memory_limit_mb is not None:
+        environment["QF_CONTRACT_CHECK_MEM_MB"] = str(memory_limit_mb)
+    return environment
+
+
+def _backend_root() -> str:
+    """Working directory that makes ``app.*`` importable in the worker."""
+
+    # checker.py lives at <backend>/app/strategy_protocol/checker.py.
+    return os.path.dirname(
+        os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+    )
+
+
+__all__ = [
+    "ContractCheckRequest",
+    "ContractCheckResult",
+    "build_worker_payload",
+    "run_strategy_contract_check",
+]

--- a/backend/app/strategy_protocol/checker.py
+++ b/backend/app/strategy_protocol/checker.py
@@ -377,15 +377,22 @@ def _drain_fd(
 def _terminate_process_tree(process: subprocess.Popen) -> int | None:
     """Kill the worker and any inherited-descriptor grandchildren, then reap.
 
-    The worker runs in its own POSIX session, so killing the process group
-    takes down grandchildren that would otherwise keep the pipes open.  The
-    reaping phase itself is bounded so cleanup can never block the caller.
+    The worker runs in its own POSIX session whose group id equals the
+    worker's pid, captured at spawn time.  Killing that fixed group also
+    takes down grandchildren even when the worker itself already exited and
+    was reaped by ``poll()`` — the cleanup must never depend on querying the
+    (possibly gone) group leader.  Reaping is bounded so cleanup can never
+    block the caller.
     """
 
     if os.name == "posix":
         try:
-            os.killpg(os.getpgid(process.pid), signal.SIGKILL)
+            # start_new_session=True makes the worker the group leader, so
+            # its pid is the group id for the whole (possibly surviving)
+            # tree.
+            os.killpg(process.pid, signal.SIGKILL)
         except (ProcessLookupError, PermissionError):
+            # Whole tree already gone; make sure the leader itself is reaped.
             process.kill()
     else:  # pragma: no cover - Windows path
         process.kill()

--- a/backend/app/strategy_protocol/context.py
+++ b/backend/app/strategy_protocol/context.py
@@ -210,14 +210,26 @@ class FillSummaryDTO:
 class PreviousStepDTO:
     """Read-only digest of the previous step's order and fill outcomes.
 
-    The DTO intentionally offers no method to resubmit orders or rewrite
-    history; it exists purely so a strategy can observe what happened.
+    Sequences are normalized to tuples at construction so mutable lists can
+    never leak into the strategy-facing snapshot.  The DTO intentionally
+    offers no method to resubmit orders or rewrite history; it exists purely
+    so a strategy can observe what happened.
     """
 
     step_sequence: int
     orders: tuple[OrderSummaryDTO, ...] = field(default_factory=tuple)
     fills: tuple[FillSummaryDTO, ...] = field(default_factory=tuple)
     order_statuses: tuple[str, ...] = field(default_factory=tuple)
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "orders", tuple(self.orders))
+        object.__setattr__(self, "fills", tuple(self.fills))
+        statuses = tuple(self.order_statuses)
+        if any(not isinstance(status, str) for status in statuses):
+            raise InvalidDecisionPayloadError(
+                "order_statuses must contain strings"
+            )
+        object.__setattr__(self, "order_statuses", statuses)
 
 
 @dataclass(frozen=True, slots=True)

--- a/backend/app/strategy_protocol/context.py
+++ b/backend/app/strategy_protocol/context.py
@@ -1,0 +1,202 @@
+"""Read-only ``DecisionContext`` and its nested DTOs.
+
+Every object in this module is an immutable value object.  Strategies may read
+them but cannot modify the account, positions, orders, fills, or query
+conditions: mappings are wrapped in ``MappingProxyType`` and sequences become
+tuples.  Monetary amounts, quantities, prices, and weights use ``Decimal``
+inside one process and decimal strings across process boundaries; binary
+floats are never accepted.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import date, datetime
+from decimal import Decimal
+from types import MappingProxyType
+from typing import TYPE_CHECKING, Mapping
+from uuid import UUID
+
+from app.backtesting.domain import PositionSide
+
+from .contract import InvalidDecisionPayloadError
+
+if TYPE_CHECKING:  # pragma: no cover - import used only for type hints
+    from .data_view import StrategyDataDTO, UniverseQueryDTO
+
+
+def _frozen_mapping(value: Mapping[str, Decimal], field_name: str) -> Mapping[str, Decimal]:
+    """Copy a mapping into a read-only proxy with validated decimals."""
+
+    if not isinstance(value, Mapping):
+        raise InvalidDecisionPayloadError(f"{field_name} must be a mapping")
+    return MappingProxyType(dict(value))
+
+
+@dataclass(frozen=True, slots=True)
+class DeterministicClockDTO:
+    """Fixed clock for exactly one decision step.
+
+    ``now()`` always returns this step's ``decision_time`` and ``today()``
+    returns its ``session_date``.  The clock never reads the operating-system
+    wall clock, so repeated calls inside one step are identical and results do
+    not depend on real execution speed.
+    """
+
+    decision_time: datetime
+    session_date: date
+
+    def __post_init__(self) -> None:
+        if self.decision_time.tzinfo is None or self.decision_time.utcoffset() is None:
+            raise InvalidDecisionPayloadError(
+                "decision_time must be timezone-aware"
+            )
+        if not isinstance(self.session_date, date) or isinstance(
+            self.session_date, datetime
+        ):
+            raise InvalidDecisionPayloadError("session_date must be a calendar date")
+
+    def now(self) -> datetime:
+        """Return the fixed decision time of the current step."""
+
+        return self.decision_time
+
+    def today(self) -> date:
+        """Return the fixed session date of the current step."""
+
+        return self.session_date
+
+
+@dataclass(frozen=True, slots=True)
+class PositionDTO:
+    """Read-only view of one non-zero position at decision time."""
+
+    instrument_id: UUID
+    trading_code: str
+    name: str
+    display_name: str
+    side: PositionSide
+    quantity: Decimal
+    available_quantity: Decimal
+    average_price: Decimal
+    mark_price: Decimal | None
+    realized_pnl: Decimal
+    unrealized_pnl: Decimal
+
+    def __post_init__(self) -> None:
+        try:
+            object.__setattr__(self, "side", PositionSide(self.side))
+        except ValueError as exc:
+            raise InvalidDecisionPayloadError("side is not a supported position side") from exc
+
+
+@dataclass(frozen=True, slots=True)
+class PortfolioDTO:
+    """Read-only account and non-zero position snapshot."""
+
+    cash_balances: Mapping[str, Decimal]
+    available_cash: Decimal
+    frozen_cash: Decimal
+    margin_used: Decimal
+    margin_available: Decimal
+    equity: Decimal
+    positions: tuple[PositionDTO, ...] = field(default_factory=tuple)
+
+    def __post_init__(self) -> None:
+        object.__setattr__(
+            self, "cash_balances", _frozen_mapping(self.cash_balances, "cash_balances")
+        )
+        normalized_positions = tuple(self.positions)
+        ids = [position.instrument_id for position in normalized_positions]
+        if len(ids) != len(set(ids)):
+            raise InvalidDecisionPayloadError(
+                "portfolio cannot contain duplicate instrument_id values"
+            )
+        # Stable ordering keeps serialized contexts deterministic.
+        object.__setattr__(
+            self,
+            "positions",
+            tuple(sorted(normalized_positions, key=lambda p: str(p.instrument_id))),
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class OrderSummaryDTO:
+    """Read-only summary of one order from the previous step."""
+
+    instrument_id: UUID
+    side: str
+    quantity: Decimal
+    status: str
+
+
+@dataclass(frozen=True, slots=True)
+class FillSummaryDTO:
+    """Read-only summary of one fill from the previous step."""
+
+    instrument_id: UUID
+    side: str
+    quantity: Decimal
+    price: Decimal
+
+
+@dataclass(frozen=True, slots=True)
+class PreviousStepDTO:
+    """Read-only digest of the previous step's order and fill outcomes.
+
+    The DTO intentionally offers no method to resubmit orders or rewrite
+    history; it exists purely so a strategy can observe what happened.
+    """
+
+    step_sequence: int
+    orders: tuple[OrderSummaryDTO, ...] = field(default_factory=tuple)
+    fills: tuple[FillSummaryDTO, ...] = field(default_factory=tuple)
+    order_statuses: tuple[str, ...] = field(default_factory=tuple)
+
+
+@dataclass(frozen=True, slots=True)
+class DecisionContext:
+    """Complete read-only context handed to one strategy decision.
+
+    The shape is fixed by the official protocol; implementations do not trim
+    fields.  ``data`` and ``universe`` expose guarded query facades whose
+    conditions strategies cannot change.
+    """
+
+    step_sequence: int
+    session_date: date
+    decision_time: datetime
+    data_cutoff: datetime
+    timezone: str
+    clock: DeterministicClockDTO
+    portfolio: PortfolioDTO
+    previous_step: PreviousStepDTO
+    data: "StrategyDataDTO"
+    universe: "UniverseQueryDTO"
+
+    def __post_init__(self) -> None:
+        for field_name in ("decision_time", "data_cutoff"):
+            value = getattr(self, field_name)
+            if value.tzinfo is None or value.utcoffset() is None:
+                raise InvalidDecisionPayloadError(
+                    f"{field_name} must be timezone-aware"
+                )
+        if self.clock.now() != self.decision_time:
+            raise InvalidDecisionPayloadError(
+                "clock decision_time must match the context decision_time"
+            )
+        if self.clock.today() != self.session_date:
+            raise InvalidDecisionPayloadError(
+                "clock session_date must match the context session_date"
+            )
+
+
+__all__ = [
+    "DecisionContext",
+    "DeterministicClockDTO",
+    "FillSummaryDTO",
+    "OrderSummaryDTO",
+    "PortfolioDTO",
+    "PositionDTO",
+    "PreviousStepDTO",
+]

--- a/backend/app/strategy_protocol/context.py
+++ b/backend/app/strategy_protocol/context.py
@@ -101,6 +101,14 @@ class PositionDTO:
     unrealized_pnl: Decimal
 
     def __post_init__(self) -> None:
+        if not isinstance(self.instrument_id, UUID):
+            raise InvalidDecisionPayloadError("instrument_id must be a UUID")
+        for field_name in ("trading_code", "name", "display_name"):
+            value = getattr(self, field_name)
+            if not isinstance(value, str) or not value.strip():
+                raise InvalidDecisionPayloadError(
+                    f"{field_name} must be a non-blank string"
+                )
         try:
             object.__setattr__(self, "side", PositionSide(self.side))
         except ValueError as exc:
@@ -162,6 +170,10 @@ class PortfolioDTO:
             )
         object.__setattr__(self, "equity", _decimal(self.equity, "equity"))
         normalized_positions = tuple(self.positions)
+        if any(not isinstance(p, PositionDTO) for p in normalized_positions):
+            raise InvalidDecisionPayloadError(
+                "positions must contain PositionDTO instances only"
+            )
         ids = [position.instrument_id for position in normalized_positions]
         if len(ids) != len(set(ids)):
             raise InvalidDecisionPayloadError(
@@ -185,6 +197,14 @@ class OrderSummaryDTO:
     status: str
 
     def __post_init__(self) -> None:
+        if not isinstance(self.instrument_id, UUID):
+            raise InvalidDecisionPayloadError("instrument_id must be a UUID")
+        for field_name in ("side", "status"):
+            value = getattr(self, field_name)
+            if not isinstance(value, str) or not value.strip():
+                raise InvalidDecisionPayloadError(
+                    f"{field_name} must be a non-blank string"
+                )
         object.__setattr__(
             self, "quantity", _positive(self.quantity, "order quantity")
         )
@@ -200,6 +220,10 @@ class FillSummaryDTO:
     price: Decimal
 
     def __post_init__(self) -> None:
+        if not isinstance(self.instrument_id, UUID):
+            raise InvalidDecisionPayloadError("instrument_id must be a UUID")
+        if not isinstance(self.side, str) or not self.side.strip():
+            raise InvalidDecisionPayloadError("side must be a non-blank string")
         object.__setattr__(
             self, "quantity", _positive(self.quantity, "fill quantity")
         )

--- a/backend/app/strategy_protocol/context.py
+++ b/backend/app/strategy_protocol/context.py
@@ -17,7 +17,14 @@ from types import MappingProxyType
 from typing import TYPE_CHECKING, Mapping
 from uuid import UUID
 
-from app.backtesting.domain import PositionSide
+from app.backtesting.domain import (
+    PositionSide,
+    _decimal,
+    _non_negative,
+    _optional_price,
+    _positive,
+    _validate_available_quantity,
+)
 
 from .contract import InvalidDecisionPayloadError
 
@@ -26,11 +33,16 @@ if TYPE_CHECKING:  # pragma: no cover - import used only for type hints
 
 
 def _frozen_mapping(value: Mapping[str, Decimal], field_name: str) -> Mapping[str, Decimal]:
-    """Copy a mapping into a read-only proxy with validated decimals."""
+    """Copy a mapping into a read-only proxy with engine-normalized decimals."""
 
     if not isinstance(value, Mapping):
         raise InvalidDecisionPayloadError(f"{field_name} must be a mapping")
-    return MappingProxyType(dict(value))
+    return MappingProxyType(
+        {
+            str(key): _decimal(item, f"{field_name}[{key!r}]")
+            for key, item in value.items()
+        }
+    )
 
 
 @dataclass(frozen=True, slots=True)
@@ -69,7 +81,12 @@ class DeterministicClockDTO:
 
 @dataclass(frozen=True, slots=True)
 class PositionDTO:
-    """Read-only view of one non-zero position at decision time."""
+    """Read-only view of one non-zero position at decision time.
+
+    Quantities and prices reuse the engine-wide ``Decimal`` normalization:
+    binary floats, booleans, non-finite values, negative amounts, and
+    available quantities above the owned quantity are rejected.
+    """
 
     instrument_id: UUID
     trading_code: str
@@ -88,11 +105,37 @@ class PositionDTO:
             object.__setattr__(self, "side", PositionSide(self.side))
         except ValueError as exc:
             raise InvalidDecisionPayloadError("side is not a supported position side") from exc
+        quantity = _positive(self.quantity, "quantity")
+        available_quantity = _non_negative(
+            self.available_quantity, "available_quantity"
+        )
+        _validate_available_quantity(quantity, available_quantity)
+        object.__setattr__(self, "quantity", quantity)
+        object.__setattr__(self, "available_quantity", available_quantity)
+        object.__setattr__(
+            self, "average_price", _positive(self.average_price, "average_price")
+        )
+        object.__setattr__(
+            self,
+            "mark_price",
+            _optional_price(self.mark_price, "mark_price"),
+        )
+        object.__setattr__(
+            self, "realized_pnl", _decimal(self.realized_pnl, "realized_pnl")
+        )
+        object.__setattr__(
+            self, "unrealized_pnl", _decimal(self.unrealized_pnl, "unrealized_pnl")
+        )
 
 
 @dataclass(frozen=True, slots=True)
 class PortfolioDTO:
-    """Read-only account and non-zero position snapshot."""
+    """Read-only account and non-zero position snapshot.
+
+    All monetary amounts reuse the engine-wide ``Decimal`` normalization, so
+    floats, booleans, non-finite values, and negative cash/margin fields are
+    rejected at construction.
+    """
 
     cash_balances: Mapping[str, Decimal]
     available_cash: Decimal
@@ -106,6 +149,18 @@ class PortfolioDTO:
         object.__setattr__(
             self, "cash_balances", _frozen_mapping(self.cash_balances, "cash_balances")
         )
+        for field_name in (
+            "available_cash",
+            "frozen_cash",
+            "margin_used",
+            "margin_available",
+        ):
+            object.__setattr__(
+                self,
+                field_name,
+                _non_negative(getattr(self, field_name), field_name),
+            )
+        object.__setattr__(self, "equity", _decimal(self.equity, "equity"))
         normalized_positions = tuple(self.positions)
         ids = [position.instrument_id for position in normalized_positions]
         if len(ids) != len(set(ids)):
@@ -129,6 +184,11 @@ class OrderSummaryDTO:
     quantity: Decimal
     status: str
 
+    def __post_init__(self) -> None:
+        object.__setattr__(
+            self, "quantity", _positive(self.quantity, "order quantity")
+        )
+
 
 @dataclass(frozen=True, slots=True)
 class FillSummaryDTO:
@@ -138,6 +198,12 @@ class FillSummaryDTO:
     side: str
     quantity: Decimal
     price: Decimal
+
+    def __post_init__(self) -> None:
+        object.__setattr__(
+            self, "quantity", _positive(self.quantity, "fill quantity")
+        )
+        object.__setattr__(self, "price", _positive(self.price, "fill price"))
 
 
 @dataclass(frozen=True, slots=True)

--- a/backend/app/strategy_protocol/context.py
+++ b/backend/app/strategy_protocol/context.py
@@ -222,13 +222,23 @@ class PreviousStepDTO:
     order_statuses: tuple[str, ...] = field(default_factory=tuple)
 
     def __post_init__(self) -> None:
-        object.__setattr__(self, "orders", tuple(self.orders))
-        object.__setattr__(self, "fills", tuple(self.fills))
+        orders = tuple(self.orders)
+        fills = tuple(self.fills)
+        if any(not isinstance(order, OrderSummaryDTO) for order in orders):
+            raise InvalidDecisionPayloadError(
+                "orders must contain OrderSummaryDTO instances only"
+            )
+        if any(not isinstance(fill, FillSummaryDTO) for fill in fills):
+            raise InvalidDecisionPayloadError(
+                "fills must contain FillSummaryDTO instances only"
+            )
         statuses = tuple(self.order_statuses)
         if any(not isinstance(status, str) for status in statuses):
             raise InvalidDecisionPayloadError(
                 "order_statuses must contain strings"
             )
+        object.__setattr__(self, "orders", orders)
+        object.__setattr__(self, "fills", fills)
         object.__setattr__(self, "order_statuses", statuses)
 
 

--- a/backend/app/strategy_protocol/contract.py
+++ b/backend/app/strategy_protocol/contract.py
@@ -101,6 +101,14 @@ class IncompleteHistoryError(DataQueryContractError):
     """
 
 
+class InvalidProviderResultError(DataQueryContractError):
+    """Raised when a data provider returns rows violating the read contract.
+
+    Examples include bars past ``data_cutoff``, rows keyed by a different
+    ``instrument_id``, out-of-order results, or mutable/float payloads.
+    """
+
+
 class AdjustmentNotActiveError(DataQueryContractError):
     """Raised when qfq/hfq series are requested while adjustment is unverified.
 

--- a/backend/app/strategy_protocol/contract.py
+++ b/backend/app/strategy_protocol/contract.py
@@ -1,0 +1,109 @@
+"""Strategy protocol domain objects for the page-strategy contract.
+
+This module defines the machine identity of the only official page-strategy
+protocol (``strategy_contract_version = 1``), the shared lookback limit, the
+run failure phase used by the startup contract check, and the protocol error
+hierarchy.  It deliberately contains no compatibility constants: the legacy
+``{"intents": []}`` return protocol was removed without a migration path.
+"""
+
+from __future__ import annotations
+
+STRATEGY_CONTRACT_VERSION = 1
+"""Machine identifier of the current and only official strategy protocol.
+
+This marker does not imply that historical v0/v1 protocols exist or that any
+migration path is provided.  Old revisions are never backfilled with a
+backtesting entry point.
+"""
+
+MAX_LOOKBACK_SESSIONS = 512
+"""First-version maximum for a single ``lookback_sessions`` data query.
+
+The limit is enforced before any data is read; exceeding it always fails.
+"""
+
+FAILURE_PHASE_STRATEGY_CONTRACT_CHECK = "strategy_contract_check"
+"""Run failure phase recorded when the startup contract check rejects a run.
+
+A failed contract check ends the run before the main backtest loop starts and
+never rolls back the published revision.
+"""
+
+
+class StrategyProtocolError(ValueError):
+    """Base error for every strategy-protocol violation.
+
+    The message must stay display-safe: it may be surfaced to operators as a
+    concise Chinese summary plus expandable technical details.
+    """
+
+
+class MissingDecisionModeError(StrategyProtocolError):
+    """Raised when a decision return value has no ``mode`` field."""
+
+
+class UnknownDecisionModeError(StrategyProtocolError):
+    """Raised when a decision uses a mode that is not registered."""
+
+
+class InvalidDecisionPayloadError(StrategyProtocolError):
+    """Raised when a decision return value is not a valid object."""
+
+
+class UnknownInstrumentError(StrategyProtocolError):
+    """Raised when an ``instrument_id`` is outside the run's known identities."""
+
+
+class DataQueryContractError(StrategyProtocolError):
+    """Base error for data-query boundary violations."""
+
+
+class DataCutoffViolationError(DataQueryContractError):
+    """Raised when a query would read past the strict ``data_cutoff``."""
+
+    def __init__(self, requested_end: object, cutoff: object) -> None:
+        super().__init__(
+            f"query end {requested_end} is later than data_cutoff {cutoff}"
+        )
+        self.requested_end = requested_end
+        self.cutoff = cutoff
+
+
+class LookbackLimitExceededError(DataQueryContractError):
+    """Raised when ``lookback_sessions`` exceeds the first-version maximum.
+
+    The check runs before any data access so oversized windows can never
+    trigger partial reads.
+    """
+
+    def __init__(self, requested: int, maximum: int = MAX_LOOKBACK_SESSIONS) -> None:
+        super().__init__(
+            f"lookback_sessions {requested} exceeds the maximum of {maximum}"
+        )
+        self.requested = requested
+        self.maximum = maximum
+
+
+class IdentityMappingMissingError(DataQueryContractError):
+    """Raised when PIT identity mapping evidence does not cover the window.
+
+    The query is blocked instead of guessing or silently returning a shorter
+    window.
+    """
+
+
+class IncompleteHistoryError(DataQueryContractError):
+    """Raised when required history bars are missing inside a mapped segment.
+
+    Missing bars block the query; they are never forward-filled or replaced
+    with fabricated short windows.
+    """
+
+
+class AdjustmentNotActiveError(DataQueryContractError):
+    """Raised when qfq/hfq series are requested while adjustment is unverified.
+
+    ``raw`` never applies adjustment factors.  Adjusted bases require the
+    native adjustment-factor source to pass verification and be marked active.
+    """

--- a/backend/app/strategy_protocol/data_view.py
+++ b/backend/app/strategy_protocol/data_view.py
@@ -147,27 +147,37 @@ class InstrumentCandidateDTO:
             value = getattr(self, field_name)
             if not isinstance(value, str) or not value.strip():
                 raise ValueError(f"{field_name} must be a non-blank string")
-        # Deep-freeze metadata so nested lists/dicts inside the mapping can
-        # never hand a mutable object to strategy code.
-        object.__setattr__(
-            self,
-            "metadata",
-            MappingProxyType(
-                {str(key): _freeze_meta(value) for key, value in self.metadata.items()}
-            ),
-        )
+        # Metadata accepts JSON values only: mappings and sequences are
+        # deep-frozen, scalars are kept, and non-JSON objects (sets, custom
+        # classes) are rejected so nothing mutable can reach strategy code.
+        if not isinstance(self.metadata, Mapping):
+            raise ValueError("metadata must be a mapping")
+        frozen: dict[str, object] = {}
+        for key, value in self.metadata.items():
+            if not isinstance(key, str):
+                # Silent str() conversion could collide distinct keys.
+                raise ValueError("metadata keys must be strings")
+            frozen[key] = _freeze_meta(value)
+        object.__setattr__(self, "metadata", MappingProxyType(frozen))
 
 
 def _freeze_meta(value: object) -> object:
-    """Recursively freeze one metadata value."""
+    """Recursively freeze one metadata value, rejecting non-JSON objects."""
 
     if isinstance(value, Mapping):
+        for key in value:
+            if not isinstance(key, str):
+                raise ValueError("metadata keys must be strings")
         return MappingProxyType(
-            {str(key): _freeze_meta(item) for key, item in value.items()}
+            {key: _freeze_meta(item) for key, item in value.items()}
         )
     if isinstance(value, (list, tuple)):
         return tuple(_freeze_meta(item) for item in value)
-    return value
+    if isinstance(value, (str, int, float, bool)) or value is None:
+        return value
+    raise ValueError(
+        "metadata values must be JSON scalars, mappings, or sequences"
+    )
 
 
 @runtime_checkable
@@ -651,6 +661,14 @@ def stitch_segmented_history(
         if not expected:
             continue
         rows = tuple(read_segment(segment.trading_code, expected[0], expected[-1]))
+        # Every segment row must be a real immutable BarDTO, mirroring the
+        # provider validation on the direct facade path.
+        for row in rows:
+            if not isinstance(row, BarDTO):
+                raise InvalidProviderResultError(
+                    f"segment reader for {segment.trading_code} returned a "
+                    "non-BarDTO row; only immutable bar DTOs are accepted"
+                )
         # Each segment must return exactly the requested sessions: no
         # duplicates, no out-of-range or non-session dates, and no short
         # windows.

--- a/backend/app/strategy_protocol/data_view.py
+++ b/backend/app/strategy_protocol/data_view.py
@@ -121,8 +121,9 @@ class AdjustedSeriesPointDTO:
 class InstrumentCandidateDTO:
     """Read-only candidate with its point-in-time display identity.
 
-    Trading code, name, and display name are for display and research only.
-    Strategies always submit targets using the stable ``instrument_id``.
+    ``instrument_id`` must be a real UUID (the stable identity strategies
+    submit targets with); trading code, name, and display name are non-blank
+    display-only strings.
     """
 
     instrument_id: UUID
@@ -134,6 +135,18 @@ class InstrumentCandidateDTO:
     metadata: Mapping[str, str] = MappingProxyType({})
 
     def __post_init__(self) -> None:
+        if not isinstance(self.instrument_id, UUID):
+            raise ValueError("instrument_id must be a UUID")
+        for field_name in (
+            "trading_code",
+            "name",
+            "display_name",
+            "asset_class",
+            "exchange",
+        ):
+            value = getattr(self, field_name)
+            if not isinstance(value, str) or not value.strip():
+                raise ValueError(f"{field_name} must be a non-blank string")
         object.__setattr__(self, "metadata", MappingProxyType(dict(self.metadata)))
 
 
@@ -611,23 +624,25 @@ def stitch_segmented_history(
         if not expected:
             continue
         rows = tuple(read_segment(segment.trading_code, expected[0], expected[-1]))
-        # Each segment must return exactly one bar per expected session: no
-        # duplicates, no out-of-range dates, no short windows.
+        # Each segment must return exactly the requested sessions: no
+        # duplicates, no out-of-range or non-session dates, and no short
+        # windows.
+        expected_set = set(expected)
         seen_dates: set[date] = set()
         for row in rows:
+            if row.trade_date not in expected_set:
+                raise IncompleteHistoryError(
+                    f"segment {segment.trading_code} returned a bar outside "
+                    f"the requested sessions on {row.trade_date}"
+                )
             if row.trade_date in seen_dates:
                 raise IncompleteHistoryError(
                     f"segment {segment.trading_code} returned duplicate bars "
                     f"for session {row.trade_date}"
                 )
             seen_dates.add(row.trade_date)
-            if not segment.covers(row.trade_date):
-                raise IncompleteHistoryError(
-                    f"segment {segment.trading_code} returned a bar outside "
-                    f"its mapped range on {row.trade_date}"
-                )
-        missing = [day for day in expected if day not in seen_dates]
-        if missing:
+        if len(rows) != len(expected):
+            missing = [day for day in expected if day not in seen_dates]
             raise IncompleteHistoryError(
                 f"history bars are missing for {len(missing)} sessions, "
                 f"first missing {missing[0]}"

--- a/backend/app/strategy_protocol/data_view.py
+++ b/backend/app/strategy_protocol/data_view.py
@@ -179,16 +179,25 @@ class UniverseQuery(Protocol):
 
 
 class AdjustmentPolicyGate:
-    """Boolean gate backed by a named, versioned adjustment-facts policy.
+    """Immutable boolean gate backed by a named, versioned policy fact.
 
     Adjusted series may only be served after the native adjustment-factor
-    source has passed real-source verification and been marked active.
+    source has passed real-source verification and been marked active.  The
+    gate rejects all attribute writes so strategy code cannot flip it open.
     """
 
     POLICY_KEY = "tushare_adj_factor_native@1"
 
+    __slots__ = ("_AdjustmentPolicyGate__active",)
+
     def __init__(self, active: bool) -> None:
-        self._active = active
+        object.__setattr__(self, "_AdjustmentPolicyGate__active", bool(active))
+
+    def __setattr__(self, name: str, value: object) -> None:
+        raise AttributeError("the adjustment policy gate is read-only")
+
+    def __delattr__(self, name: str) -> None:
+        raise AttributeError("the adjustment policy gate is read-only")
 
     @classmethod
     def from_policy_key(cls, policy_key: str | None) -> "AdjustmentPolicyGate":
@@ -209,7 +218,7 @@ class AdjustmentPolicyGate:
         return cls(active=False)
 
     def is_active(self) -> bool:
-        return self._active
+        return self._AdjustmentPolicyGate__active
 
 
 @dataclass(frozen=True, slots=True)
@@ -248,12 +257,22 @@ class StrategyDataDTO(_ReadOnlyFacade):
     requests can never reach a partial read.  Provider results are validated
     again on the way out (identity, cutoff, ordering, decimal types), so a
     broken provider cannot leak future rows or mutable floats to strategies.
-    The injected view and cutoff are fixed at construction; strategies cannot
-    widen them.  qfq/hfq requests are additionally gated on the adjustment
-    policy being active.
+    The injected view and cutoff are fixed at construction; the underlying
+    provider objects are stored under name-mangled attributes so they are not
+    part of the strategy-facing surface.  qfq/hfq requests are additionally
+    gated on the adjustment policy being active.
+
+    Note: this is the non-adversarial read-only boundary approved for this
+    phase.  CPython cannot hide objects from deliberate in-process
+    introspection; hostile-code isolation remains the subprocess boundary.
     """
 
-    __slots__ = ("_view", "_data_cutoff", "_max_lookback_sessions", "_adjustment_gate")
+    __slots__ = (
+        "__view",
+        "__data_cutoff",
+        "__max_lookback_sessions",
+        "__adjustment_gate",
+    )
 
     def __init__(
         self,
@@ -263,14 +282,27 @@ class StrategyDataDTO(_ReadOnlyFacade):
         max_lookback_sessions: int = MAX_LOOKBACK_SESSIONS,
         adjustment_gate: AdjustmentPolicyGate | None = None,
     ) -> None:
-        object.__setattr__(self, "_view", view)
-        object.__setattr__(self, "_data_cutoff", data_cutoff)
-        object.__setattr__(self, "_max_lookback_sessions", max_lookback_sessions)
+        if (
+            isinstance(max_lookback_sessions, bool)
+            or not isinstance(max_lookback_sessions, int)
+            or not 1 <= max_lookback_sessions <= MAX_LOOKBACK_SESSIONS
+        ):
+            # The protocol limit itself can never be raised by configuration;
+            # callers may only lower it.
+            raise ValueError(
+                "max_lookback_sessions must be between 1 and "
+                f"{MAX_LOOKBACK_SESSIONS}"
+            )
+        object.__setattr__(self, "_StrategyDataDTO__view", view)
+        object.__setattr__(self, "_StrategyDataDTO__data_cutoff", data_cutoff)
+        object.__setattr__(
+            self, "_StrategyDataDTO__max_lookback_sessions", max_lookback_sessions
+        )
         # Conservative default: without an explicit active gate, adjusted
         # series stay blocked so unverified factors can never be served.
         object.__setattr__(
             self,
-            "_adjustment_gate",
+            "_StrategyDataDTO__adjustment_gate",
             adjustment_gate or AdjustmentPolicyGate.inactive_gate(),
         )
 
@@ -291,7 +323,7 @@ class StrategyDataDTO(_ReadOnlyFacade):
             lookback_sessions=lookback_sessions,
         )
         result = tuple(
-            self._view.bars(
+            self.__view.bars(
                 resolved_id,
                 start_date=window.start_date,
                 end_date=window.end_date,
@@ -315,7 +347,7 @@ class StrategyDataDTO(_ReadOnlyFacade):
             resolved_basis = AdjustmentBasis(basis)
         except ValueError as exc:
             raise ValueError(f"unknown adjustment basis {basis!r}") from exc
-        if resolved_basis is not AdjustmentBasis.RAW and not self._adjustment_gate.is_active():
+        if resolved_basis is not AdjustmentBasis.RAW and not self.__adjustment_gate.is_active():
             raise AdjustmentNotActiveError(
                 "qfq/hfq series require tushare_adj_factor_native@1 to be "
                 "verified and active"
@@ -327,7 +359,7 @@ class StrategyDataDTO(_ReadOnlyFacade):
             lookback_sessions=lookback_sessions,
         )
         result = tuple(
-            self._view.adjusted_series(
+            self.__view.adjusted_series(
                 resolved_id,
                 start_date=window.start_date,
                 end_date=window.end_date,
@@ -342,7 +374,7 @@ class StrategyDataDTO(_ReadOnlyFacade):
     ) -> tuple[BarDTO, ...]:
         """Reject provider rows that violate the identity or cutoff contract."""
 
-        cutoff_date = self._data_cutoff.date()
+        cutoff_date = self.__data_cutoff.date()
         previous: date | None = None
         for bar in result:
             if bar.instrument_id != requested_id:
@@ -367,7 +399,7 @@ class StrategyDataDTO(_ReadOnlyFacade):
     ) -> tuple[AdjustedSeriesPointDTO, ...]:
         """Apply the same outbound checks to adjustment series."""
 
-        cutoff_date = self._data_cutoff.date()
+        cutoff_date = self.__data_cutoff.date()
         previous: date | None = None
         for point in result:
             if point.instrument_id != requested_id:
@@ -417,12 +449,12 @@ class StrategyDataDTO(_ReadOnlyFacade):
                 or lookback_sessions <= 0
             ):
                 raise ValueError("lookback_sessions must be a positive integer")
-            if lookback_sessions > self._max_lookback_sessions:
+            if lookback_sessions > self.__max_lookback_sessions:
                 # Fail before touching any data source.
                 raise LookbackLimitExceededError(
-                    lookback_sessions, self._max_lookback_sessions
+                    lookback_sessions, self.__max_lookback_sessions
                 )
-        cutoff_date = self._data_cutoff.date()
+        cutoff_date = self.__data_cutoff.date()
         if end_date is not None and end_date > cutoff_date:
             raise DataCutoffViolationError(end_date, cutoff_date)
         if start_date is not None and start_date > cutoff_date:
@@ -449,12 +481,17 @@ class StrategyDataDTO(_ReadOnlyFacade):
 
 
 class UniverseQueryDTO(_ReadOnlyFacade):
-    """Strategy-facing candidate-set facade returning immutable results."""
+    """Strategy-facing candidate-set facade returning validated results.
 
-    __slots__ = ("_query",)
+    Provider output is re-checked on the way out (type, duplicate identity)
+    and returned in stable ``instrument_id`` order as an immutable tuple, so
+    strategies can never receive mutable or duplicated candidates.
+    """
+
+    __slots__ = ("__query",)
 
     def __init__(self, query: UniverseQuery) -> None:
-        object.__setattr__(self, "_query", query)
+        object.__setattr__(self, "_UniverseQueryDTO__query", query)
 
     def query(
         self,
@@ -462,11 +499,25 @@ class UniverseQueryDTO(_ReadOnlyFacade):
         exchanges: Iterable[str] | None = None,
         asset_classes: Iterable[str] | None = None,
     ) -> tuple[InstrumentCandidateDTO, ...]:
-        """Return PIT-eligible candidates as an immutable tuple."""
+        """Return PIT-eligible candidates as an immutable sorted tuple."""
 
-        return tuple(
-            self._query.query(exchanges=exchanges, asset_classes=asset_classes)
+        result = self._UniverseQueryDTO__query.query(
+            exchanges=exchanges, asset_classes=asset_classes
         )
+        candidates = tuple(result)
+        seen: set[UUID] = set()
+        for candidate in candidates:
+            if not isinstance(candidate, InstrumentCandidateDTO):
+                raise InvalidProviderResultError(
+                    "universe provider returned a non-candidate row"
+                )
+            if candidate.instrument_id in seen:
+                raise InvalidProviderResultError(
+                    f"universe provider returned duplicate instrument_id "
+                    f"{candidate.instrument_id}"
+                )
+            seen.add(candidate.instrument_id)
+        return tuple(sorted(candidates, key=lambda c: str(c.instrument_id)))
 
 
 @dataclass(frozen=True, slots=True)
@@ -535,18 +586,9 @@ def stitch_segmented_history(
     if not ordered_sessions:
         return ()
 
-    collected: list[BarDTO] = []
-    for segment in segments:
-        lower, upper = segment.clamp_window(ordered_sessions[0], ordered_sessions[-1])
-        if lower > upper:
-            continue
-        segment_sessions = [day for day in ordered_sessions if segment.covers(day)]
-        if not segment_sessions:
-            continue
-        collected.extend(
-            read_segment(segment.trading_code, segment_sessions[0], segment_sessions[-1])
-        )
-
+    # Coverage is verified before any provider read so overlapping segments
+    # can never be queried twice, and gaps never trigger partial reads.
+    coverage: dict[date, list[PitSegment]] = {}
     for day in ordered_sessions:
         covering = [segment for segment in segments if segment.covers(day)]
         if not covering:
@@ -558,13 +600,39 @@ def stitch_segmented_history(
                 f"PIT identity mappings overlap on session {day}: "
                 f"{sorted(segment.trading_code for segment in covering)}"
             )
-    seen_dates = {bar.trade_date for bar in collected}
-    missing = [day for day in ordered_sessions if day not in seen_dates]
-    if missing:
-        raise IncompleteHistoryError(
-            f"history bars are missing for {len(missing)} sessions, "
-            f"first missing {missing[0]}"
-        )
+        coverage[day] = covering
+
+    collected: list[BarDTO] = []
+    for segment in segments:
+        lower, upper = segment.clamp_window(ordered_sessions[0], ordered_sessions[-1])
+        if lower > upper:
+            continue
+        expected = [day for day in ordered_sessions if segment.covers(day)]
+        if not expected:
+            continue
+        rows = tuple(read_segment(segment.trading_code, expected[0], expected[-1]))
+        # Each segment must return exactly one bar per expected session: no
+        # duplicates, no out-of-range dates, no short windows.
+        seen_dates: set[date] = set()
+        for row in rows:
+            if row.trade_date in seen_dates:
+                raise IncompleteHistoryError(
+                    f"segment {segment.trading_code} returned duplicate bars "
+                    f"for session {row.trade_date}"
+                )
+            seen_dates.add(row.trade_date)
+            if not segment.covers(row.trade_date):
+                raise IncompleteHistoryError(
+                    f"segment {segment.trading_code} returned a bar outside "
+                    f"its mapped range on {row.trade_date}"
+                )
+        missing = [day for day in expected if day not in seen_dates]
+        if missing:
+            raise IncompleteHistoryError(
+                f"history bars are missing for {len(missing)} sessions, "
+                f"first missing {missing[0]}"
+            )
+        collected.extend(rows)
     return tuple(sorted(collected, key=lambda bar: bar.trade_date))
 
 

--- a/backend/app/strategy_protocol/data_view.py
+++ b/backend/app/strategy_protocol/data_view.py
@@ -124,7 +124,7 @@ class InstrumentCandidateDTO:
 
     ``instrument_id`` must be a real UUID (the stable identity strategies
     submit targets with); trading code, name, and display name are non-blank
-    display-only strings.
+    display-only strings.  ``metadata`` holds deep-frozen JSON values.
     """
 
     instrument_id: UUID
@@ -133,7 +133,7 @@ class InstrumentCandidateDTO:
     display_name: str
     asset_class: str
     exchange: str
-    metadata: Mapping[str, str] = MappingProxyType({})
+    metadata: Mapping[str, object] = MappingProxyType({})
 
     def __post_init__(self) -> None:
         if not isinstance(self.instrument_id, UUID):
@@ -146,7 +146,9 @@ class InstrumentCandidateDTO:
             "exchange",
         ):
             value = getattr(self, field_name)
-            if not isinstance(value, str) or not value.strip():
+            # Exact str only: a str subclass could smuggle mutable attributes
+            # from the provider into strategy-visible objects.
+            if type(value) is not str or not value.strip():
                 raise ValueError(f"{field_name} must be a non-blank string")
         # Metadata accepts JSON values only: mappings and sequences are
         # deep-frozen, scalars are kept, and non-JSON objects (sets, custom
@@ -155,41 +157,44 @@ class InstrumentCandidateDTO:
             raise ValueError("metadata must be a mapping")
         frozen: dict[str, object] = {}
         for key, value in self.metadata.items():
-            if not isinstance(key, str):
-                # Silent str() conversion could collide distinct keys.
-                raise ValueError("metadata keys must be strings")
-            frozen[key] = _freeze_meta(value)
+            frozen[_freeze_key(key)] = _freeze_meta(value)
         object.__setattr__(self, "metadata", MappingProxyType(frozen))
 
 
 def _freeze_meta(value: object) -> object:
     """Recursively freeze one metadata value, rejecting non-JSON objects.
 
-    Floats must be finite: NaN and infinities are not standard JSON numbers
+    Only exact JSON scalar types are accepted: subclasses of ``int``/``str``
+    etc. can carry mutable attributes and must not pass through as scalars.
+    Floats must be finite — NaN and infinities are not standard JSON numbers
     and would break deterministic comparison and strict serialization.
     """
 
-    if isinstance(value, Mapping):
-        for key in value:
-            if not isinstance(key, str):
-                raise ValueError("metadata keys must be strings")
-        return MappingProxyType(
-            {key: _freeze_meta(item) for key, item in value.items()}
-        )
-    if isinstance(value, (list, tuple)):
-        return tuple(_freeze_meta(item) for item in value)
-    if value is None or isinstance(value, (str, bool)):
+    if value is None or type(value) in (str, bool, int):
         return value
-    if isinstance(value, int):
-        # bool is checked above so it never lands here as an int alias.
-        return value
-    if isinstance(value, float):
+    if type(value) is float:
         if not math.isfinite(value):
             raise ValueError("metadata float values must be finite")
         return value
+    if isinstance(value, Mapping):
+        return MappingProxyType(
+            {_freeze_key(key): _freeze_meta(item) for key, item in value.items()}
+        )
+    if isinstance(value, (list, tuple)):
+        return tuple(_freeze_meta(item) for item in value)
     raise ValueError(
         "metadata values must be JSON scalars, mappings, or sequences"
     )
+
+
+def _freeze_key(key: object) -> str:
+    """Validate one metadata key, rejecting str subclasses."""
+
+    if type(key) is not str:
+        # A str subclass could smuggle mutable attributes into the frozen
+        # mapping, so only exact strings are accepted.
+        raise ValueError("metadata keys must be plain strings")
+    return key
 
 
 @runtime_checkable

--- a/backend/app/strategy_protocol/data_view.py
+++ b/backend/app/strategy_protocol/data_view.py
@@ -1,0 +1,442 @@
+"""Data and candidate-set query contract for page strategies.
+
+The protocols are deliberately generic: they key every query by the stable
+``instrument_id`` and never expose ETF trading codes, ORM sessions, FastAPI
+types, or Tushare clients to strategy code.  Concrete adapters (including the
+synthetic fixture) implement the read side; this module owns the boundary
+rules that every implementation shares:
+
+* queries strictly respect ``data_cutoff`` and fail on overflow instead of
+  silently trimming;
+* ``lookback_sessions`` is capped before any data is read;
+* cross-code history is stitched from PIT identity segments in stable date
+  order, and incomplete mapping evidence or missing bars block the query;
+* ``raw`` never applies adjustment factors while ``qfq`` / ``hfq`` require an
+  active verified adjustment source.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Iterable, Mapping, Sequence
+from dataclasses import dataclass
+from datetime import date, datetime, timedelta
+from decimal import Decimal
+from enum import StrEnum
+from types import MappingProxyType
+from typing import Protocol, runtime_checkable
+from uuid import UUID
+
+from .contract import (
+    MAX_LOOKBACK_SESSIONS,
+    AdjustmentNotActiveError,
+    DataCutoffViolationError,
+    IdentityMappingMissingError,
+    IncompleteHistoryError,
+    LookbackLimitExceededError,
+)
+
+
+class AdjustmentBasis(StrEnum):
+    """Adjustment bases accepted by ``adjusted_series``."""
+
+    RAW = "raw"
+    QFQ = "qfq"
+    HFQ = "hfq"
+
+
+@dataclass(frozen=True, slots=True)
+class BarDTO:
+    """One immutable daily bar identified by the stable instrument id.
+
+    ``values`` holds only the requested fields as ``Decimal`` values; a missing
+    source bar stays absent instead of being forward-filled.
+    """
+
+    instrument_id: UUID
+    trade_date: date
+    values: Mapping[str, Decimal]
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.instrument_id, UUID):
+            raise ValueError("instrument_id must be a UUID")
+        object.__setattr__(self, "values", MappingProxyType(dict(self.values)))
+
+
+@dataclass(frozen=True, slots=True)
+class AdjustedSeriesPointDTO:
+    """One point of an adjustment series keyed by the stable instrument id."""
+
+    instrument_id: UUID
+    trade_date: date
+    adj_factor: Decimal
+
+
+@dataclass(frozen=True, slots=True)
+class InstrumentCandidateDTO:
+    """Read-only candidate with its point-in-time display identity.
+
+    Trading code, name, and display name are for display and research only.
+    Strategies always submit targets using the stable ``instrument_id``.
+    """
+
+    instrument_id: UUID
+    trading_code: str
+    name: str
+    display_name: str
+    asset_class: str
+    exchange: str
+    metadata: Mapping[str, str] = MappingProxyType({})
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "metadata", MappingProxyType(dict(self.metadata)))
+
+
+@runtime_checkable
+class StrategyDataView(Protocol):
+    """Raw read side implemented by real adapters and synthetic fixtures.
+
+    Implementations receive already-validated windows (never past
+    ``data_cutoff``, never over the lookback cap) and must return immutable
+    DTOs keyed by the queried ``instrument_id``.
+    """
+
+    def bars(
+        self,
+        instrument_id: UUID,
+        *,
+        start_date: date | None,
+        end_date: date | None,
+        lookback_sessions: int | None,
+    ) -> Sequence[BarDTO]: ...
+
+    def adjusted_series(
+        self,
+        instrument_id: UUID,
+        *,
+        start_date: date | None,
+        end_date: date | None,
+        lookback_sessions: int | None,
+        basis: AdjustmentBasis,
+    ) -> Sequence[AdjustedSeriesPointDTO]: ...
+
+
+@runtime_checkable
+class UniverseQuery(Protocol):
+    """Raw candidate-set read side bounded by permission and PIT eligibility."""
+
+    def query(
+        self,
+        *,
+        exchanges: Iterable[str] | None = None,
+        asset_classes: Iterable[str] | None = None,
+    ) -> Sequence[InstrumentCandidateDTO]: ...
+
+
+class AdjustmentPolicyGate:
+    """Boolean gate backed by a named, versioned adjustment-facts policy.
+
+    Adjusted series may only be served after the native adjustment-factor
+    source has passed real-source verification and been marked active.
+    """
+
+    POLICY_KEY = "tushare_adj_factor_native@1"
+
+    def __init__(self, active: bool) -> None:
+        self._active = active
+
+    @classmethod
+    def from_policy_key(cls, policy_key: str | None) -> "AdjustmentPolicyGate":
+        """Only the verified native adjustment source activates the gate."""
+
+        return cls(active=policy_key == cls.POLICY_KEY)
+
+    @classmethod
+    def active_gate(cls) -> "AdjustmentPolicyGate":
+        """Gate for a verified and active native adjustment policy."""
+
+        return cls(active=True)
+
+    @classmethod
+    def inactive_gate(cls) -> "AdjustmentPolicyGate":
+        """Gate used while the policy is unverified or inactive."""
+
+        return cls(active=False)
+
+    def is_active(self) -> bool:
+        return self._active
+
+
+@dataclass(frozen=True, slots=True)
+class _ResolvedWindow:
+    start_date: date | None
+    end_date: date | None
+    lookback_sessions: int | None
+
+
+class StrategyDataDTO:
+    """Strategy-facing facade that enforces the shared query boundaries.
+
+    The facade validates the window against ``data_cutoff`` and the lookback
+    cap *before* delegating to the injected view, so oversized or future-facing
+    requests can never reach a partial read.  The injected view and cutoff are
+    fixed at construction; strategies cannot widen them.  qfq/hfq requests are
+    additionally gated on the adjustment policy being active.
+    """
+
+    __slots__ = ("_view", "_data_cutoff", "_max_lookback_sessions", "_adjustment_gate")
+
+    def __init__(
+        self,
+        view: StrategyDataView,
+        *,
+        data_cutoff: datetime,
+        max_lookback_sessions: int = MAX_LOOKBACK_SESSIONS,
+        adjustment_gate: AdjustmentPolicyGate | None = None,
+    ) -> None:
+        self._view = view
+        self._data_cutoff = data_cutoff
+        self._max_lookback_sessions = max_lookback_sessions
+        # Conservative default: without an explicit active gate, adjusted
+        # series stay blocked so unverified factors can never be served.
+        self._adjustment_gate = adjustment_gate or AdjustmentPolicyGate.inactive_gate()
+
+    def bars(
+        self,
+        instrument_id: UUID | str,
+        *,
+        start_date: date | None = None,
+        end_date: date | None = None,
+        lookback_sessions: int | None = None,
+    ) -> tuple[BarDTO, ...]:
+        """Read raw bars ending no later than ``data_cutoff``."""
+
+        window = self._resolve_window(
+            start_date=start_date,
+            end_date=end_date,
+            lookback_sessions=lookback_sessions,
+        )
+        return tuple(
+            self._view.bars(
+                self._require_uuid(instrument_id),
+                start_date=window.start_date,
+                end_date=window.end_date,
+                lookback_sessions=window.lookback_sessions,
+            )
+        )
+
+    def adjusted_series(
+        self,
+        instrument_id: UUID | str,
+        *,
+        start_date: date | None = None,
+        end_date: date | None = None,
+        lookback_sessions: int | None = None,
+        basis: str | AdjustmentBasis = AdjustmentBasis.RAW,
+    ) -> tuple[AdjustedSeriesPointDTO, ...]:
+        """Read an adjustment-bounded series for one stable instrument id."""
+
+        try:
+            resolved_basis = AdjustmentBasis(basis)
+        except ValueError as exc:
+            raise ValueError(f"unknown adjustment basis {basis!r}") from exc
+        if resolved_basis is not AdjustmentBasis.RAW and not self._adjustment_gate.is_active():
+            raise AdjustmentNotActiveError(
+                "qfq/hfq series require tushare_adj_factor_native@1 to be "
+                "verified and active"
+            )
+        window = self._resolve_window(
+            start_date=start_date,
+            end_date=end_date,
+            lookback_sessions=lookback_sessions,
+        )
+        return tuple(
+            self._view.adjusted_series(
+                self._require_uuid(instrument_id),
+                start_date=window.start_date,
+                end_date=window.end_date,
+                lookback_sessions=window.lookback_sessions,
+                basis=resolved_basis,
+            )
+        )
+
+    def _require_uuid(self, instrument_id: UUID | str) -> UUID:
+        """Accept UUID or canonical string form, nothing else."""
+
+        if isinstance(instrument_id, UUID):
+            return instrument_id
+        if isinstance(instrument_id, str):
+            try:
+                return UUID(instrument_id)
+            except ValueError as exc:
+                raise ValueError(
+                    f"instrument_id {instrument_id!r} is not a valid UUID"
+                ) from exc
+        raise ValueError("instrument_id must be a UUID or UUID string")
+
+    def _resolve_window(
+        self,
+        *,
+        start_date: date | None,
+        end_date: date | None,
+        lookback_sessions: int | None,
+    ) -> _ResolvedWindow:
+        """Validate the requested window before any data access happens."""
+
+        if lookback_sessions is not None:
+            if (
+                isinstance(lookback_sessions, bool)
+                or not isinstance(lookback_sessions, int)
+                or lookback_sessions <= 0
+            ):
+                raise ValueError("lookback_sessions must be a positive integer")
+            if lookback_sessions > self._max_lookback_sessions:
+                # Fail before touching any data source.
+                raise LookbackLimitExceededError(
+                    lookback_sessions, self._max_lookback_sessions
+                )
+        cutoff_date = self._data_cutoff.date()
+        if end_date is not None and end_date > cutoff_date:
+            raise DataCutoffViolationError(end_date, cutoff_date)
+        if start_date is not None and start_date > cutoff_date:
+            raise DataCutoffViolationError(start_date, cutoff_date)
+        if start_date is not None and end_date is not None and start_date > end_date:
+            raise ValueError("start_date cannot be after end_date")
+        if lookback_sessions is not None:
+            # A lookback window counts back from the cutoff unless an explicit
+            # end is given; it never widens past an explicit start date.
+            anchor = end_date if end_date is not None else cutoff_date
+            implied_start = anchor - timedelta(days=lookback_sessions - 1)
+            if start_date is not None and implied_start < start_date:
+                lookback_sessions = None
+        return _ResolvedWindow(
+            start_date=start_date,
+            end_date=end_date,
+            lookback_sessions=lookback_sessions,
+        )
+
+
+class UniverseQueryDTO:
+    """Strategy-facing candidate-set facade returning immutable results."""
+
+    __slots__ = ("_query",)
+
+    def __init__(self, query: UniverseQuery) -> None:
+        self._query = query
+
+    def query(
+        self,
+        *,
+        exchanges: Iterable[str] | None = None,
+        asset_classes: Iterable[str] | None = None,
+    ) -> tuple[InstrumentCandidateDTO, ...]:
+        """Return PIT-eligible candidates as an immutable tuple."""
+
+        return tuple(
+            self._query.query(exchanges=exchanges, asset_classes=asset_classes)
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class PitSegment:
+    """One point-in-time identity segment of a stable instrument.
+
+    A stable ``instrument_id`` may have traded under several historical codes.
+    Each segment records which trading code was valid for which inclusive date
+    range, providing the mapping evidence required for cross-code reads.
+    """
+
+    trading_code: str
+    effective_from: date
+    effective_to: date
+
+    def __post_init__(self) -> None:
+        if self.effective_from > self.effective_to:
+            raise ValueError("segment effective_from cannot be after effective_to")
+
+    def covers(self, day: date) -> bool:
+        return self.effective_from <= day <= self.effective_to
+
+    def clamp_window(
+        self, start_date: date | None, end_date: date | None
+    ) -> tuple[date, date]:
+        """Intersect the segment validity with the requested window."""
+
+        lower = self.effective_from
+        upper = self.effective_to
+        if start_date is not None and start_date > lower:
+            lower = start_date
+        if end_date is not None and end_date < upper:
+            upper = end_date
+        return lower, upper
+
+
+SegmentReader = Callable[[str, date, date], Sequence[BarDTO]]
+
+
+def stitch_segmented_history(
+    segments: Sequence[PitSegment],
+    *,
+    sessions: Sequence[date],
+    read_segment: SegmentReader,
+) -> tuple[BarDTO, ...]:
+    """Read per-segment windows and stitch them back into one stable series.
+
+    ``sessions`` lists the tradable sessions of the requested window in
+    ascending order (resolved by the trading calendar).  Every requested
+    session must be covered by exactly one identity segment; coverage gaps
+    raise :class:`IdentityMappingMissingError` instead of silently returning a
+    shorter window.  Each segment reader must return a bar for every session
+    inside its clamped range; missing bars raise
+    :class:`IncompleteHistoryError` and are never forward-filled.  The result
+    is sorted by trade date regardless of segment order.
+    """
+
+    ordered_sessions = sorted(set(sessions))
+    if not ordered_sessions:
+        return ()
+    current = ordered_sessions[0]
+    for session in ordered_sessions[1:]:
+        if session <= current:
+            raise ValueError("sessions must contain distinct ascending dates")
+        current = session
+
+    collected: list[BarDTO] = []
+    for segment in segments:
+        lower, upper = segment.clamp_window(ordered_sessions[0], ordered_sessions[-1])
+        if lower > upper:
+            continue
+        segment_sessions = [day for day in ordered_sessions if segment.covers(day)]
+        if not segment_sessions:
+            continue
+        collected.extend(
+            read_segment(segment.trading_code, segment_sessions[0], segment_sessions[-1])
+        )
+
+    for day in ordered_sessions:
+        if not any(segment.covers(day) for segment in segments):
+            raise IdentityMappingMissingError(
+                f"no PIT identity mapping covers session {day}"
+            )
+    seen_dates = {bar.trade_date for bar in collected}
+    missing = [day for day in ordered_sessions if day not in seen_dates]
+    if missing:
+        raise IncompleteHistoryError(
+            f"history bars are missing for {len(missing)} sessions, "
+            f"first missing {missing[0]}"
+        )
+    return tuple(sorted(collected, key=lambda bar: bar.trade_date))
+
+
+__all__ = [
+    "AdjustmentBasis",
+    "AdjustmentPolicyGate",
+    "AdjustedSeriesPointDTO",
+    "BarDTO",
+    "InstrumentCandidateDTO",
+    "PitSegment",
+    "StrategyDataDTO",
+    "StrategyDataView",
+    "UniverseQuery",
+    "UniverseQueryDTO",
+    "stitch_segmented_history",
+]

--- a/backend/app/strategy_protocol/data_view.py
+++ b/backend/app/strategy_protocol/data_view.py
@@ -32,6 +32,7 @@ from .contract import (
     DataCutoffViolationError,
     IdentityMappingMissingError,
     IncompleteHistoryError,
+    InvalidProviderResultError,
     LookbackLimitExceededError,
 )
 
@@ -48,7 +49,8 @@ class AdjustmentBasis(StrEnum):
 class BarDTO:
     """One immutable daily bar identified by the stable instrument id.
 
-    ``values`` holds only the requested fields as ``Decimal`` values; a missing
+    ``values`` holds only the requested fields as finite ``Decimal`` values;
+    binary floats, booleans, and non-finite numbers are rejected.  A missing
     source bar stays absent instead of being forward-filled.
     """
 
@@ -59,7 +61,41 @@ class BarDTO:
     def __post_init__(self) -> None:
         if not isinstance(self.instrument_id, UUID):
             raise ValueError("instrument_id must be a UUID")
-        object.__setattr__(self, "values", MappingProxyType(dict(self.values)))
+        if isinstance(self.trade_date, datetime) or not isinstance(self.trade_date, date):
+            raise ValueError("trade_date must be a calendar date")
+        if not isinstance(self.values, Mapping):
+            raise ValueError("values must be a mapping")
+        normalized: dict[str, Decimal] = {}
+        for key, value in self.values.items():
+            if not isinstance(key, str):
+                raise ValueError("bar field names must be strings")
+            normalized[key] = _finite_decimal(value, f"bar values[{key!r}]")
+        object.__setattr__(self, "values", MappingProxyType(normalized))
+
+
+def _finite_decimal(value: object, field_name: str) -> Decimal:
+    """Normalize one numeric DTO value, rejecting float/bool/non-finite input."""
+
+    from decimal import Decimal as _Decimal, InvalidOperation
+
+    if isinstance(value, bool) or isinstance(value, float):
+        raise ValueError(
+            f"{field_name} must be a decimal string or Decimal; "
+            "binary floats are unsupported"
+        )
+    if isinstance(value, _Decimal):
+        if not value.is_finite():
+            raise ValueError(f"{field_name} must be finite")
+        return value
+    if not isinstance(value, (str, int)):
+        raise ValueError(f"{field_name} must be a decimal string or Decimal")
+    try:
+        normalized = _Decimal(str(value))
+    except (InvalidOperation, ValueError) as exc:
+        raise ValueError(f"{field_name} is not a valid decimal") from exc
+    if not normalized.is_finite():
+        raise ValueError(f"{field_name} must be finite")
+    return normalized
 
 
 @dataclass(frozen=True, slots=True)
@@ -69,6 +105,16 @@ class AdjustedSeriesPointDTO:
     instrument_id: UUID
     trade_date: date
     adj_factor: Decimal
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.instrument_id, UUID):
+            raise ValueError("instrument_id must be a UUID")
+        if isinstance(self.trade_date, datetime) or not isinstance(self.trade_date, date):
+            raise ValueError("trade_date must be a calendar date")
+        factor = _finite_decimal(self.adj_factor, "adj_factor")
+        if factor <= 0:
+            raise ValueError("adj_factor must be positive")
+        object.__setattr__(self, "adj_factor", factor)
 
 
 @dataclass(frozen=True, slots=True)
@@ -173,14 +219,38 @@ class _ResolvedWindow:
     lookback_sessions: int | None
 
 
-class StrategyDataDTO:
+class _ReadOnlyFacade:
+    """Base that makes the strategy-facing facades fully read-only.
+
+    Strategies must not be able to widen ``data_cutoff``, lift the lookback
+    cap, or swap the underlying data provider, so every attribute write is
+    rejected regardless of name mangling or slot availability.
+    """
+
+    __slots__ = ()
+
+    def __setattr__(self, name: str, value: object) -> None:
+        raise AttributeError(
+            "strategy query facades are read-only; query conditions cannot be modified"
+        )
+
+    def __delattr__(self, name: str) -> None:
+        raise AttributeError(
+            "strategy query facades are read-only; query conditions cannot be deleted"
+        )
+
+
+class StrategyDataDTO(_ReadOnlyFacade):
     """Strategy-facing facade that enforces the shared query boundaries.
 
     The facade validates the window against ``data_cutoff`` and the lookback
     cap *before* delegating to the injected view, so oversized or future-facing
-    requests can never reach a partial read.  The injected view and cutoff are
-    fixed at construction; strategies cannot widen them.  qfq/hfq requests are
-    additionally gated on the adjustment policy being active.
+    requests can never reach a partial read.  Provider results are validated
+    again on the way out (identity, cutoff, ordering, decimal types), so a
+    broken provider cannot leak future rows or mutable floats to strategies.
+    The injected view and cutoff are fixed at construction; strategies cannot
+    widen them.  qfq/hfq requests are additionally gated on the adjustment
+    policy being active.
     """
 
     __slots__ = ("_view", "_data_cutoff", "_max_lookback_sessions", "_adjustment_gate")
@@ -193,12 +263,16 @@ class StrategyDataDTO:
         max_lookback_sessions: int = MAX_LOOKBACK_SESSIONS,
         adjustment_gate: AdjustmentPolicyGate | None = None,
     ) -> None:
-        self._view = view
-        self._data_cutoff = data_cutoff
-        self._max_lookback_sessions = max_lookback_sessions
+        object.__setattr__(self, "_view", view)
+        object.__setattr__(self, "_data_cutoff", data_cutoff)
+        object.__setattr__(self, "_max_lookback_sessions", max_lookback_sessions)
         # Conservative default: without an explicit active gate, adjusted
         # series stay blocked so unverified factors can never be served.
-        self._adjustment_gate = adjustment_gate or AdjustmentPolicyGate.inactive_gate()
+        object.__setattr__(
+            self,
+            "_adjustment_gate",
+            adjustment_gate or AdjustmentPolicyGate.inactive_gate(),
+        )
 
     def bars(
         self,
@@ -210,19 +284,21 @@ class StrategyDataDTO:
     ) -> tuple[BarDTO, ...]:
         """Read raw bars ending no later than ``data_cutoff``."""
 
+        resolved_id = self._require_uuid(instrument_id)
         window = self._resolve_window(
             start_date=start_date,
             end_date=end_date,
             lookback_sessions=lookback_sessions,
         )
-        return tuple(
+        result = tuple(
             self._view.bars(
-                self._require_uuid(instrument_id),
+                resolved_id,
                 start_date=window.start_date,
                 end_date=window.end_date,
                 lookback_sessions=window.lookback_sessions,
             )
         )
+        return self._validate_bars_result(resolved_id, result)
 
     def adjusted_series(
         self,
@@ -244,20 +320,72 @@ class StrategyDataDTO:
                 "qfq/hfq series require tushare_adj_factor_native@1 to be "
                 "verified and active"
             )
+        resolved_id = self._require_uuid(instrument_id)
         window = self._resolve_window(
             start_date=start_date,
             end_date=end_date,
             lookback_sessions=lookback_sessions,
         )
-        return tuple(
+        result = tuple(
             self._view.adjusted_series(
-                self._require_uuid(instrument_id),
+                resolved_id,
                 start_date=window.start_date,
                 end_date=window.end_date,
                 lookback_sessions=window.lookback_sessions,
                 basis=resolved_basis,
             )
         )
+        return self._validate_series_result(resolved_id, result)
+
+    def _validate_bars_result(
+        self, requested_id: UUID, result: tuple[BarDTO, ...]
+    ) -> tuple[BarDTO, ...]:
+        """Reject provider rows that violate the identity or cutoff contract."""
+
+        cutoff_date = self._data_cutoff.date()
+        previous: date | None = None
+        for bar in result:
+            if bar.instrument_id != requested_id:
+                raise InvalidProviderResultError(
+                    f"provider returned instrument_id {bar.instrument_id} "
+                    f"for a query on {requested_id}"
+                )
+            if bar.trade_date > cutoff_date:
+                raise InvalidProviderResultError(
+                    f"provider returned bar {bar.trade_date} later than "
+                    f"data_cutoff {cutoff_date}"
+                )
+            if previous is not None and bar.trade_date <= previous:
+                raise InvalidProviderResultError(
+                    "provider returned bars out of ascending date order"
+                )
+            previous = bar.trade_date
+        return result
+
+    def _validate_series_result(
+        self, requested_id: UUID, result: tuple[AdjustedSeriesPointDTO, ...]
+    ) -> tuple[AdjustedSeriesPointDTO, ...]:
+        """Apply the same outbound checks to adjustment series."""
+
+        cutoff_date = self._data_cutoff.date()
+        previous: date | None = None
+        for point in result:
+            if point.instrument_id != requested_id:
+                raise InvalidProviderResultError(
+                    f"provider returned instrument_id {point.instrument_id} "
+                    f"for a query on {requested_id}"
+                )
+            if point.trade_date > cutoff_date:
+                raise InvalidProviderResultError(
+                    f"provider returned series point {point.trade_date} later "
+                    f"than data_cutoff {cutoff_date}"
+                )
+            if previous is not None and point.trade_date <= previous:
+                raise InvalidProviderResultError(
+                    "provider returned series points out of ascending date order"
+                )
+            previous = point.trade_date
+        return result
 
     def _require_uuid(self, instrument_id: UUID | str) -> UUID:
         """Accept UUID or canonical string form, nothing else."""
@@ -303,11 +431,16 @@ class StrategyDataDTO:
             raise ValueError("start_date cannot be after end_date")
         if lookback_sessions is not None:
             # A lookback window counts back from the cutoff unless an explicit
-            # end is given; it never widens past an explicit start date.
+            # end is given.  An explicit start that conflicts with the lookback
+            # window is a caller error, never silently widened into a longer
+            # full-range read.
             anchor = end_date if end_date is not None else cutoff_date
             implied_start = anchor - timedelta(days=lookback_sessions - 1)
             if start_date is not None and implied_start < start_date:
-                lookback_sessions = None
+                raise ValueError(
+                    "lookback_sessions conflicts with the explicit start_date; "
+                    "pass either a lookback window or an explicit range"
+                )
         return _ResolvedWindow(
             start_date=start_date,
             end_date=end_date,
@@ -315,13 +448,13 @@ class StrategyDataDTO:
         )
 
 
-class UniverseQueryDTO:
+class UniverseQueryDTO(_ReadOnlyFacade):
     """Strategy-facing candidate-set facade returning immutable results."""
 
     __slots__ = ("_query",)
 
     def __init__(self, query: UniverseQuery) -> None:
-        self._query = query
+        object.__setattr__(self, "_query", query)
 
     def query(
         self,
@@ -382,23 +515,25 @@ def stitch_segmented_history(
     """Read per-segment windows and stitch them back into one stable series.
 
     ``sessions`` lists the tradable sessions of the requested window in
-    ascending order (resolved by the trading calendar).  Every requested
-    session must be covered by exactly one identity segment; coverage gaps
-    raise :class:`IdentityMappingMissingError` instead of silently returning a
-    shorter window.  Each segment reader must return a bar for every session
-    inside its clamped range; missing bars raise
+    ascending order without duplicates (resolved by the trading calendar);
+    unsorted or duplicated input is rejected instead of silently normalized.
+    Every requested session must be covered by exactly one identity segment:
+    coverage gaps and overlapping segments both raise
+    :class:`IdentityMappingMissingError` instead of silently returning a
+    shorter window or duplicated bars.  Each segment reader must return a bar
+    for every session inside its clamped range; missing bars raise
     :class:`IncompleteHistoryError` and are never forward-filled.  The result
     is sorted by trade date regardless of segment order.
     """
 
-    ordered_sessions = sorted(set(sessions))
+    ordered_sessions = list(sessions)
+    if any(
+        later <= earlier
+        for earlier, later in zip(ordered_sessions, ordered_sessions[1:])
+    ):
+        raise ValueError("sessions must contain distinct ascending dates")
     if not ordered_sessions:
         return ()
-    current = ordered_sessions[0]
-    for session in ordered_sessions[1:]:
-        if session <= current:
-            raise ValueError("sessions must contain distinct ascending dates")
-        current = session
 
     collected: list[BarDTO] = []
     for segment in segments:
@@ -413,9 +548,15 @@ def stitch_segmented_history(
         )
 
     for day in ordered_sessions:
-        if not any(segment.covers(day) for segment in segments):
+        covering = [segment for segment in segments if segment.covers(day)]
+        if not covering:
             raise IdentityMappingMissingError(
                 f"no PIT identity mapping covers session {day}"
+            )
+        if len(covering) > 1:
+            raise IdentityMappingMissingError(
+                f"PIT identity mappings overlap on session {day}: "
+                f"{sorted(segment.trading_code for segment in covering)}"
             )
     seen_dates = {bar.trade_date for bar in collected}
     missing = [day for day in ordered_sessions if day not in seen_dates]

--- a/backend/app/strategy_protocol/data_view.py
+++ b/backend/app/strategy_protocol/data_view.py
@@ -17,6 +17,7 @@ rules that every implementation shares:
 
 from __future__ import annotations
 
+import math
 from collections.abc import Callable, Iterable, Mapping, Sequence
 from dataclasses import dataclass
 from datetime import date, datetime
@@ -162,7 +163,11 @@ class InstrumentCandidateDTO:
 
 
 def _freeze_meta(value: object) -> object:
-    """Recursively freeze one metadata value, rejecting non-JSON objects."""
+    """Recursively freeze one metadata value, rejecting non-JSON objects.
+
+    Floats must be finite: NaN and infinities are not standard JSON numbers
+    and would break deterministic comparison and strict serialization.
+    """
 
     if isinstance(value, Mapping):
         for key in value:
@@ -173,7 +178,14 @@ def _freeze_meta(value: object) -> object:
         )
     if isinstance(value, (list, tuple)):
         return tuple(_freeze_meta(item) for item in value)
-    if isinstance(value, (str, int, float, bool)) or value is None:
+    if value is None or isinstance(value, (str, bool)):
+        return value
+    if isinstance(value, int):
+        # bool is checked above so it never lands here as an int alias.
+        return value
+    if isinstance(value, float):
+        if not math.isfinite(value):
+            raise ValueError("metadata float values must be finite")
         return value
     raise ValueError(
         "metadata values must be JSON scalars, mappings, or sequences"

--- a/backend/app/strategy_protocol/data_view.py
+++ b/backend/app/strategy_protocol/data_view.py
@@ -19,7 +19,7 @@ from __future__ import annotations
 
 from collections.abc import Callable, Iterable, Mapping, Sequence
 from dataclasses import dataclass
-from datetime import date, datetime, timedelta
+from datetime import date, datetime
 from decimal import Decimal
 from enum import StrEnum
 from types import MappingProxyType
@@ -147,7 +147,27 @@ class InstrumentCandidateDTO:
             value = getattr(self, field_name)
             if not isinstance(value, str) or not value.strip():
                 raise ValueError(f"{field_name} must be a non-blank string")
-        object.__setattr__(self, "metadata", MappingProxyType(dict(self.metadata)))
+        # Deep-freeze metadata so nested lists/dicts inside the mapping can
+        # never hand a mutable object to strategy code.
+        object.__setattr__(
+            self,
+            "metadata",
+            MappingProxyType(
+                {str(key): _freeze_meta(value) for key, value in self.metadata.items()}
+            ),
+        )
+
+
+def _freeze_meta(value: object) -> object:
+    """Recursively freeze one metadata value."""
+
+    if isinstance(value, Mapping):
+        return MappingProxyType(
+            {str(key): _freeze_meta(item) for key, item in value.items()}
+        )
+    if isinstance(value, (list, tuple)):
+        return tuple(_freeze_meta(item) for item in value)
+    return value
 
 
 @runtime_checkable
@@ -390,6 +410,11 @@ class StrategyDataDTO(_ReadOnlyFacade):
         cutoff_date = self.__data_cutoff.date()
         previous: date | None = None
         for bar in result:
+            if not isinstance(bar, BarDTO):
+                raise InvalidProviderResultError(
+                    "provider returned a non-BarDTO row; only immutable bar "
+                    "DTOs may reach strategy code"
+                )
             if bar.instrument_id != requested_id:
                 raise InvalidProviderResultError(
                     f"provider returned instrument_id {bar.instrument_id} "
@@ -415,6 +440,11 @@ class StrategyDataDTO(_ReadOnlyFacade):
         cutoff_date = self.__data_cutoff.date()
         previous: date | None = None
         for point in result:
+            if not isinstance(point, AdjustedSeriesPointDTO):
+                raise InvalidProviderResultError(
+                    "provider returned a non-AdjustedSeriesPointDTO row; only "
+                    "immutable series DTOs may reach strategy code"
+                )
             if point.instrument_id != requested_id:
                 raise InvalidProviderResultError(
                     f"provider returned instrument_id {point.instrument_id} "
@@ -474,18 +504,15 @@ class StrategyDataDTO(_ReadOnlyFacade):
             raise DataCutoffViolationError(start_date, cutoff_date)
         if start_date is not None and end_date is not None and start_date > end_date:
             raise ValueError("start_date cannot be after end_date")
-        if lookback_sessions is not None:
-            # A lookback window counts back from the cutoff unless an explicit
-            # end is given.  An explicit start that conflicts with the lookback
-            # window is a caller error, never silently widened into a longer
-            # full-range read.
-            anchor = end_date if end_date is not None else cutoff_date
-            implied_start = anchor - timedelta(days=lookback_sessions - 1)
-            if start_date is not None and implied_start < start_date:
-                raise ValueError(
-                    "lookback_sessions conflicts with the explicit start_date; "
-                    "pass either a lookback window or an explicit range"
-                )
+        if lookback_sessions is not None and (start_date is not None or end_date is not None):
+            # Lookback windows are resolved by the trading calendar against
+            # the cutoff alone.  Mixing them with an explicit date range
+            # would let different providers interpret the combination
+            # differently, so the combination is a caller error, always.
+            raise ValueError(
+                "pass either lookback_sessions or an explicit date range, "
+                "never both"
+            )
         return _ResolvedWindow(
             start_date=start_date,
             end_date=end_date,

--- a/backend/app/strategy_protocol/decisions.py
+++ b/backend/app/strategy_protocol/decisions.py
@@ -1,0 +1,240 @@
+"""Immutable strategy decisions and the extensible decision-mode registry.
+
+The public :class:`StrategyDecision` value object and the
+:class:`DecisionModeRegistry` are intentionally not hard-coded to the two
+first-version modes.  Future modes such as ``target_positions`` or
+``order_intents`` can be registered without changing this module; only the
+registration site decides which modes exist today.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass, field
+from datetime import datetime
+from decimal import Decimal, InvalidOperation
+from types import MappingProxyType
+from typing import Callable
+from uuid import UUID, uuid4
+
+from app.backtesting.domain import DomainValidationError
+
+from .contract import (
+    STRATEGY_CONTRACT_VERSION,
+    InvalidDecisionPayloadError,
+    MissingDecisionModeError,
+    UnknownDecisionModeError,
+    UnknownInstrumentError,
+)
+
+TARGET_WEIGHTS_MODE = "target_weights"
+HOLD_MODE = "hold"
+
+
+def _require_aware_datetime(value: datetime, field_name: str) -> datetime:
+    """Reuse the engine-wide timezone-awareness rule for decision timestamps."""
+
+    if not isinstance(value, datetime) or value.tzinfo is None or value.utcoffset() is None:
+        raise InvalidDecisionPayloadError(
+            f"{field_name} must be a timezone-aware datetime"
+        )
+    return value
+
+
+def _decimal_target(value: object, key: str) -> Decimal:
+    """Convert one weight to ``Decimal``, rejecting float/bool/invalid input.
+
+    Weights cross the process boundary as decimal strings.  ``float`` and
+    ``bool`` are rejected outright because binary floats cannot represent the
+    weights exactly and would silently corrupt portfolio arithmetic.
+    """
+
+    if isinstance(value, bool) or isinstance(value, float):
+        raise InvalidDecisionPayloadError(
+            f"targets[{key!r}] must be a decimal string or Decimal; "
+            "float values are unsupported"
+        )
+    if isinstance(value, Decimal):
+        if not value.is_finite():
+            raise InvalidDecisionPayloadError(
+                f"targets[{key!r}] must be finite"
+            )
+        return value
+    if not isinstance(value, (str, int)):
+        raise InvalidDecisionPayloadError(
+            f"targets[{key!r}] must be a decimal string or Decimal"
+        )
+    try:
+        normalized = Decimal(str(value))
+    except (InvalidOperation, ValueError) as exc:
+        raise InvalidDecisionPayloadError(
+            f"targets[{key!r}] is not a valid decimal value"
+        ) from exc
+    if not normalized.is_finite():
+        raise InvalidDecisionPayloadError(f"targets[{key!r}] must be finite")
+    return normalized
+
+
+@dataclass(frozen=True, slots=True)
+class StrategyDecision:
+    """Immutable outcome of one strategy decision step.
+
+    The decision only expresses intent.  Orders, fills, fees, slippage, and
+    account updates are produced by later engine stages, never by this object.
+    """
+
+    step_sequence: int
+    decision_time: datetime
+    mode: str
+    targets: Mapping[str, Decimal] = field(default_factory=dict)
+    reason: str | None = None
+    decision_id: UUID = field(default_factory=uuid4)
+    contract_version: int = STRATEGY_CONTRACT_VERSION
+
+    def __post_init__(self) -> None:
+        if self.contract_version != STRATEGY_CONTRACT_VERSION:
+            raise InvalidDecisionPayloadError(
+                "contract_version must equal the current official protocol version"
+            )
+        if not isinstance(self.step_sequence, int) or isinstance(
+            self.step_sequence, bool
+        ):
+            raise InvalidDecisionPayloadError("step_sequence must be an integer")
+        _require_aware_datetime(self.decision_time, "decision_time")
+        if not isinstance(self.mode, str) or not self.mode:
+            raise InvalidDecisionPayloadError("mode must be a non-empty string")
+        normalized_targets = {
+            str(key): _decimal_target(value, str(key))
+            for key, value in dict(self.targets).items()
+        }
+        object.__setattr__(self, "targets", MappingProxyType(normalized_targets))
+
+
+TargetWeightsValidator = Callable[[Mapping[str, object], set[UUID]], dict[str, Decimal]]
+
+
+def validate_target_weights_payload(
+    targets: Mapping[str, object], known_instrument_ids: set[UUID]
+) -> dict[str, Decimal]:
+    """Validate a full target-weights mapping against the run's identities.
+
+    Existing positions that are absent from the mapping are interpreted as a
+    zero target by the interpreter stage; the payload itself does not need to
+    list them.  No weight-sum rule is enforced here: such a rule is a domain
+    contract that has not been approved yet.
+    """
+
+    if not isinstance(targets, Mapping):
+        raise InvalidDecisionPayloadError("targets must be an object")
+    normalized: dict[str, Decimal] = {}
+    for key, value in targets.items():
+        if not isinstance(key, str):
+            raise InvalidDecisionPayloadError("targets keys must be instrument_id strings")
+        try:
+            instrument_id = UUID(key)
+        except ValueError as exc:
+            raise UnknownInstrumentError(
+                f"targets key {key!r} is not a valid instrument_id"
+            ) from exc
+        if instrument_id not in known_instrument_ids:
+            raise UnknownInstrumentError(
+                f"targets reference unknown instrument_id {key!r}"
+            )
+        normalized[key] = _decimal_target(value, key)
+    return normalized
+
+
+def validate_hold_payload(
+    targets: object, known_instrument_ids: set[UUID]
+) -> dict[str, Decimal]:
+    """Require that a hold decision carries no non-empty target mapping."""
+
+    if targets is None:
+        return {}
+    if isinstance(targets, Mapping) and not targets:
+        return {}
+    raise InvalidDecisionPayloadError('mode "hold" must not carry targets')
+
+
+class DecisionModeRegistry:
+    """Registry of supported decision modes and their payload validators.
+
+    Keeping validators in a registry means adding ``target_positions`` or
+    ``order_intents`` later is a registration change, not an engine rewrite.
+    """
+
+    def __init__(self) -> None:
+        self._validators: dict[str, TargetWeightsValidator] = {}
+
+    def register(self, mode: str, validator: TargetWeightsValidator) -> None:
+        """Register one decision mode with its payload validator."""
+
+        if not isinstance(mode, str) or not mode:
+            raise ValueError("decision mode must be a non-empty string")
+        if mode in self._validators:
+            raise ValueError(f"decision mode {mode!r} is already registered")
+        self._validators[mode] = validator
+
+    def modes(self) -> tuple[str, ...]:
+        """Return the currently registered mode names."""
+
+        return tuple(sorted(self._validators))
+
+    def is_registered(self, mode: str) -> bool:
+        """Whether the mode can be used by a decision right now."""
+
+        return mode in self._validators
+
+    def validate(
+        self,
+        payload: Mapping[str, object],
+        *,
+        known_instrument_ids: set[UUID],
+    ) -> tuple[str, dict[str, Decimal]]:
+        """Validate a raw decision payload and return ``(mode, targets)``.
+
+        Raises the protocol errors from :mod:`contract` for every rejected
+        shape so callers can surface one consistent failure taxonomy.
+        """
+
+        if not isinstance(payload, Mapping):
+            raise InvalidDecisionPayloadError(
+                "decision must be an object; floats and other scalars are unsupported"
+            )
+        mode = payload.get("mode")
+        if mode is None:
+            raise MissingDecisionModeError('decision requires a "mode" field')
+        if not isinstance(mode, str):
+            raise InvalidDecisionPayloadError('"mode" must be a string')
+        if mode not in self._validators:
+            raise UnknownDecisionModeError(
+                f'unknown decision mode {mode!r}; registered modes: '
+                f'{", ".join(self.modes())}'
+            )
+        # Only the fields each mode understands are forwarded. Extra fields are
+        # ignored rather than silently treated as trading instructions.
+        targets = payload.get("targets")
+        validated = self._validators[mode](targets, known_instrument_ids)
+        return mode, validated
+
+
+def build_default_registry() -> DecisionModeRegistry:
+    """Create the first-version registry with exactly two registered modes."""
+
+    registry = DecisionModeRegistry()
+    registry.register(TARGET_WEIGHTS_MODE, validate_target_weights_payload)
+    registry.register(HOLD_MODE, validate_hold_payload)
+    return registry
+
+
+__all__ = [
+    "HOLD_MODE",
+    "TARGET_WEIGHTS_MODE",
+    "DecisionModeRegistry",
+    "StrategyDecision",
+    "build_default_registry",
+    "validate_hold_payload",
+    "validate_target_weights_payload",
+    # Re-exported so adapter code can catch one domain error type.
+    "DomainValidationError",
+]

--- a/backend/app/strategy_protocol/synthetic.py
+++ b/backend/app/strategy_protocol/synthetic.py
@@ -1,0 +1,331 @@
+"""Deterministic synthetic data fixture for the startup contract check.
+
+The fixture builds a minimal ``DecisionContext`` whose DTO shape is identical
+to a real run's context while depending on no real account, no real market
+data, no user files, no network services, or any other mutable external
+state.  Every value is derived from fixed constants so repeated checks are
+bit-for-bit reproducible.
+
+Per the approved design, the run's ``static_instrument_ids`` and every
+non-zero ``initial_position`` are injected as synthetic identity rows with
+valid bars, so legitimate strategies are never failed for "missing synthetic
+market data".  Identities outside this table keep the official unknown-
+identity error semantics.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable, Mapping, Sequence
+from dataclasses import dataclass, field
+from datetime import date, datetime, timedelta
+from decimal import Decimal
+from uuid import NAMESPACE_URL, UUID, uuid5
+
+from app.backtesting.domain import PositionSide
+
+from .context import (
+    DecisionContext,
+    DeterministicClockDTO,
+    PortfolioDTO,
+    PositionDTO,
+    PreviousStepDTO,
+)
+from .contract import UnknownInstrumentError
+from .data_view import (
+    AdjustmentBasis,
+    AdjustedSeriesPointDTO,
+    BarDTO,
+    InstrumentCandidateDTO,
+    StrategyDataDTO,
+    StrategyDataView,
+    UniverseQueryDTO,
+)
+
+SYNTHETIC_TIMEZONE = "Asia/Shanghai"
+"""Fixed timezone of the synthetic session; never read from the host."""
+
+SYNTHETIC_SESSION_OFFSETS = (4, 3, 2, 1, 0)
+"""Day offsets of the five synthetic sessions, ending at the decision day."""
+
+SYNTHETIC_BAR_CLOSE = Decimal("10.0000")
+SYNTHETIC_BAR_OPEN = Decimal("9.9000")
+SYNTHETIC_BAR_HIGH = Decimal("10.1000")
+SYNTHETIC_BAR_LOW = Decimal("9.8000")
+
+_VIRTUAL_CANDIDATE_NAMES = ("virtual-alpha", "virtual-beta", "virtual-gamma")
+
+
+def synthetic_instrument_id(name: str) -> UUID:
+    """Deterministically derive a stable synthetic instrument identity."""
+
+    return uuid5(NAMESPACE_URL, f"https://synthetic.quant-foundry.local/{name}")
+
+
+@dataclass(frozen=True, slots=True)
+class SyntheticIdentityRow:
+    """One injected synthetic identity with its display metadata."""
+
+    instrument_id: UUID
+    trading_code: str
+    name: str
+    display_name: str
+
+
+@dataclass(frozen=True, slots=True)
+class ContractCheckParameters:
+    """Frozen inputs of one synthetic contract-check scenario."""
+
+    session_date: date
+    decision_time: datetime
+    data_cutoff: datetime
+    static_instrument_ids: tuple[UUID, ...]
+    initial_positions: tuple[Mapping[str, object], ...]
+    parameters: Mapping[str, object] = field(default_factory=dict)
+
+
+class SyntheticDataView(StrategyDataView):
+    """In-memory read side serving only the injected synthetic bars."""
+
+    def __init__(self, bars_by_instrument: Mapping[UUID, Sequence[BarDTO]]) -> None:
+        self._bars = {
+            instrument_id: tuple(rows) for instrument_id, rows in bars_by_instrument.items()
+        }
+
+    def _require_known(self, instrument_id: UUID) -> tuple[BarDTO, ...]:
+        rows = self._bars.get(instrument_id)
+        if rows is None:
+            # Same error type and semantics as the real run path.
+            raise UnknownInstrumentError(
+                f"instrument_id {instrument_id} has no synthetic identity row"
+            )
+        return rows
+
+    def bars(
+        self,
+        instrument_id: UUID,
+        *,
+        start_date: date | None,
+        end_date: date | None,
+        lookback_sessions: int | None,
+    ) -> Sequence[BarDTO]:
+        rows = self._require_known(instrument_id)
+        selected = [
+            row
+            for row in rows
+            if (start_date is None or row.trade_date >= start_date)
+            and (end_date is None or row.trade_date <= end_date)
+        ]
+        if lookback_sessions is not None:
+            selected = selected[-lookback_sessions:]
+        return tuple(selected)
+
+    def adjusted_series(
+        self,
+        instrument_id: UUID,
+        *,
+        start_date: date | None,
+        end_date: date | None,
+        lookback_sessions: int | None,
+        basis: AdjustmentBasis,
+    ) -> Sequence[AdjustedSeriesPointDTO]:
+        rows = self._require_known(instrument_id)
+        if basis is AdjustmentBasis.RAW:
+            # Raw series carry no adjustment factors by definition.
+            return ()
+        selected = [
+            row
+            for row in rows
+            if (start_date is None or row.trade_date >= start_date)
+            and (end_date is None or row.trade_date <= end_date)
+        ]
+        if lookback_sessions is not None:
+            selected = selected[-lookback_sessions:]
+        return tuple(
+            AdjustedSeriesPointDTO(
+                instrument_id=row.instrument_id,
+                trade_date=row.trade_date,
+                adj_factor=Decimal("1"),
+            )
+            for row in selected
+        )
+
+
+class SyntheticUniverse:
+    """Fixed virtual candidates plus the injected synthetic identity rows."""
+
+    def __init__(self, candidates: Sequence[InstrumentCandidateDTO]) -> None:
+        self._candidates = tuple(candidates)
+
+    def query(
+        self,
+        *,
+        exchanges: Iterable[str] | None = None,
+        asset_classes: Iterable[str] | None = None,
+    ) -> Sequence[InstrumentCandidateDTO]:
+        selected = self._candidates
+        if exchanges is not None:
+            wanted = set(exchanges)
+            selected = [row for row in selected if row.exchange in wanted]
+        if asset_classes is not None:
+            wanted = set(asset_classes)
+            selected = [row for row in selected if row.asset_class in wanted]
+        return tuple(selected)
+
+
+def build_synthetic_context(
+    request: ContractCheckParameters,
+) -> tuple[DecisionContext, tuple[SyntheticIdentityRow, ...]]:
+    """Build the full synthetic decision context and its identity evidence.
+
+    Returns the context plus the injected identity-row summary that becomes
+    part of the contract-check evidence.
+    """
+
+    # Deterministic five-session calendar ending at the decision session.
+    base = request.session_date
+    sessions = [base - timedelta(days=offset) for offset in SYNTHETIC_SESSION_OFFSETS]
+
+    identities: list[SyntheticIdentityRow] = []
+    known_ids: set[UUID] = set()
+
+    def register_identity(instrument_id: UUID, label: str) -> SyntheticIdentityRow:
+        row = SyntheticIdentityRow(
+            instrument_id=instrument_id,
+            trading_code=f"SYN.{label}",
+            name=f"合成标的 {label}",
+            display_name=f"Synthetic {label}",
+        )
+        if instrument_id not in known_ids:
+            identities.append(row)
+            known_ids.add(instrument_id)
+        return row
+
+    for name in _VIRTUAL_CANDIDATE_NAMES:
+        register_identity(synthetic_instrument_id(name), name)
+    for instrument_id in request.static_instrument_ids:
+        register_identity(instrument_id, f"static-{str(instrument_id)[:8]}")
+
+    bars_by_instrument: dict[UUID, list[BarDTO]] = {}
+    for instrument_id in known_ids:
+        bars_by_instrument[instrument_id] = [
+            BarDTO(
+                instrument_id=instrument_id,
+                trade_date=day,
+                values={
+                    "open": SYNTHETIC_BAR_OPEN,
+                    "high": SYNTHETIC_BAR_HIGH,
+                    "low": SYNTHETIC_BAR_LOW,
+                    "close": SYNTHETIC_BAR_CLOSE,
+                },
+            )
+            for day in sessions
+        ]
+
+    # Non-zero initial positions become portfolio rows backed by synthetic
+    # identity rows and bars, per V5-1.
+    positions: list[PositionDTO] = []
+    for index, position in enumerate(request.initial_positions):
+        instrument_id = position.get("instrument_id")
+        if not isinstance(instrument_id, UUID):
+            raise ValueError("initial position instrument_id must be a UUID")
+        quantity = Decimal(str(position.get("quantity", "0")))
+        if quantity <= 0:
+            continue
+        row = register_identity(instrument_id, f"position-{index}")
+        positions.append(
+            PositionDTO(
+                instrument_id=instrument_id,
+                trading_code=row.trading_code,
+                name=row.name,
+                display_name=row.display_name,
+                side=PositionSide(position.get("side", PositionSide.LONG)),
+                quantity=quantity,
+                available_quantity=Decimal(str(position.get("available_quantity", quantity))),
+                average_price=Decimal(str(position.get("average_price", SYNTHETIC_BAR_CLOSE))),
+                mark_price=SYNTHETIC_BAR_CLOSE,
+                realized_pnl=Decimal("0"),
+                unrealized_pnl=Decimal("0"),
+            )
+        )
+        if instrument_id not in bars_by_instrument:
+            bars_by_instrument[instrument_id] = [
+                BarDTO(
+                    instrument_id=instrument_id,
+                    trade_date=day,
+                    values={
+                        "open": SYNTHETIC_BAR_OPEN,
+                        "high": SYNTHETIC_BAR_HIGH,
+                        "low": SYNTHETIC_BAR_LOW,
+                        "close": SYNTHETIC_BAR_CLOSE,
+                    },
+                )
+                for day in sessions
+            ]
+
+    clock = DeterministicClockDTO(
+        decision_time=request.decision_time,
+        session_date=request.session_date,
+    )
+    portfolio = PortfolioDTO(
+        cash_balances={"CNY": Decimal("1000000.00")},
+        available_cash=Decimal("1000000.00"),
+        frozen_cash=Decimal("0"),
+        margin_used=Decimal("0"),
+        margin_available=Decimal("1000000.00"),
+        equity=Decimal("1000000.00") + sum(p.quantity * p.mark_price for p in positions),
+        positions=tuple(positions),
+    )
+    candidates = tuple(
+        InstrumentCandidateDTO(
+            instrument_id=row.instrument_id,
+            trading_code=row.trading_code,
+            name=row.name,
+            display_name=row.display_name,
+            asset_class="etf",
+            exchange="SSE",
+        )
+        for row in identities
+    ) + tuple(
+        # The dynamic scope keeps using the fixed virtual candidates only;
+        # injected identity rows exist so static ids and held positions are
+        # never failed for missing synthetic market data (V5-1).
+        InstrumentCandidateDTO(
+            instrument_id=synthetic_instrument_id(name),
+            trading_code=f"SYN.{name.upper()}",
+            name=f"虚拟标的 {name}",
+            display_name=f"Virtual {name}",
+            asset_class="etf",
+            exchange="SSE",
+        )
+        for name in _VIRTUAL_CANDIDATE_NAMES
+        if synthetic_instrument_id(name) not in known_ids
+    )
+    context = DecisionContext(
+        step_sequence=1,
+        session_date=request.session_date,
+        decision_time=request.decision_time,
+        data_cutoff=request.data_cutoff,
+        timezone=SYNTHETIC_TIMEZONE,
+        clock=clock,
+        portfolio=portfolio,
+        previous_step=PreviousStepDTO(step_sequence=0),
+        data=StrategyDataDTO(
+            SyntheticDataView(bars_by_instrument),
+            data_cutoff=request.data_cutoff,
+            adjustment_gate=None,  # synthetic qfq/hfq stay blocked like an unverified policy
+        ),
+        universe=UniverseQueryDTO(SyntheticUniverse(candidates)),
+    )
+    evidence = tuple(identities)
+    return context, evidence
+
+
+__all__ = [
+    "ContractCheckParameters",
+    "SYNTHETIC_TIMEZONE",
+    "SyntheticDataView",
+    "SyntheticIdentityRow",
+    "SyntheticUniverse",
+    "build_synthetic_context",
+    "synthetic_instrument_id",
+]

--- a/backend/app/strategy_protocol/worker.py
+++ b/backend/app/strategy_protocol/worker.py
@@ -198,19 +198,24 @@ def perform_contract_check(request: dict) -> dict:
 
 
 def main() -> int:
-    """Read one request from stdin and emit exactly one result line."""
+    """Read one request from stdin and emit exactly one result document.
+
+    The result goes to the dedicated descriptor the parent passed via
+    ``QF_CONTRACT_CHECK_RESULT_FD``, never to the strategy-visible stdout.
+    """
 
     try:
         request = _parse_request(sys.stdin.buffer.read())
     except Exception as exc:  # noqa: BLE001 - reported as structured failure
-        _emit({"ok": False, "failure": _failure_payload(exc)})
+        _emit_result({"ok": False, "failure": _failure_payload(exc)})
         return 0
     try:
-        _emit(perform_contract_check(request))
+        _emit_result(perform_contract_check(request))
     except Exception as exc:  # noqa: BLE001 - every failure must be locatable
-        _emit({"ok": False, "failure": _failure_payload(exc)})
+        _emit_result({"ok": False, "failure": _failure_payload(exc)})
     finally:
         sys.stdout.flush()
+        sys.stderr.flush()
     return 0
 
 
@@ -255,9 +260,22 @@ def _bounded_traceback(exc: Exception) -> str:
     return rendered
 
 
-def _emit(result: dict) -> None:
-    sys.stdout.write(json.dumps(result, ensure_ascii=False))
-    sys.stdout.write("\n")
+def _emit_result(result: dict) -> None:
+    """Write the result document to the dedicated parent-only descriptor."""
+
+    document = json.dumps(result, ensure_ascii=False).encode("utf-8") + b"\n"
+    fd_name = os.environ.get("QF_CONTRACT_CHECK_RESULT_FD")
+    if fd_name is None:
+        # Manual/debug invocation without a parent checker: fall back to
+        # stdout, which real checks never parse.
+        sys.stdout.buffer.write(document)
+        sys.stdout.buffer.flush()
+        return
+    fd = int(fd_name)
+    written = 0
+    while written < len(document):
+        written += os.write(fd, document[written:])
+    os.close(fd)
 
 
 if __name__ == "__main__":

--- a/backend/app/strategy_protocol/worker.py
+++ b/backend/app/strategy_protocol/worker.py
@@ -8,6 +8,8 @@ exactly one JSON result line to stdout.
 
 The process is deliberately self-contained: it never touches the database,
 the network, or any mutable external state beyond what the request contains.
+Strategy output is redirected to stderr so stdout carries only the single
+machine-readable result document.
 """
 
 from __future__ import annotations
@@ -15,6 +17,7 @@ from __future__ import annotations
 import json
 import os
 import sys
+import traceback
 from datetime import date, datetime, timedelta
 from uuid import UUID
 
@@ -26,7 +29,10 @@ if os.name == "posix" and os.environ.get("QF_CONTRACT_CHECK_MEM_MB"):
     _limit_bytes = int(os.environ["QF_CONTRACT_CHECK_MEM_MB"]) * 1024 * 1024
     resource.setrlimit(resource.RLIMIT_AS, (_limit_bytes, _limit_bytes))
 
-from app.strategy_protocol.adapter import FunctionStrategyAdapter  # noqa: E402
+from app.strategy_protocol.adapter import (  # noqa: E402
+    ISOLATED_SUBPROCESS_SCOPE,
+    FunctionStrategyAdapter,
+)
 from app.strategy_protocol.contract import (  # noqa: E402
     STRATEGY_CONTRACT_VERSION,
 )
@@ -37,12 +43,23 @@ from app.strategy_protocol.synthetic import (  # noqa: E402
     build_synthetic_context,
 )
 
-MAX_STRATEGY_STDOUT_BYTES = 65_536
+MAX_STRATEGY_OUTPUT_BYTES = 65_536
 """Upper bound on bytes a strategy may print during the contract check."""
 
+MAX_TRACEBACK_CHARS = 4_000
+"""Upper bound on the technical traceback tail returned with a failure."""
 
-class _BoundedWriter:
-    """stdout replacement that fails once the byte budget is exhausted."""
+STRATEGY_MODULE_NAME = "published_strategy"
+"""Filename recorded for compiled strategy source, used for line lookups."""
+
+
+class _BoundedStderrWriter:
+    """Strategy-facing stdout replacement that forwards to stderr.
+
+    Strategy ``print`` output must never mix into the JSON result document on
+    real stdout, so it is redirected to stderr under a byte budget; exceeding
+    the budget fails the check instead of growing without bound.
+    """
 
     def __init__(self, underlying, limit: int) -> None:
         self._underlying = underlying
@@ -53,7 +70,7 @@ class _BoundedWriter:
         self._written += len(text.encode("utf-8"))
         if self._written > self._limit:
             raise RuntimeError(
-                f"strategy stdout exceeded {self._limit} bytes during the "
+                f"strategy output exceeded {self._limit} bytes during the "
                 "contract check"
             )
         return self._underlying.write(text)
@@ -69,6 +86,19 @@ def _parse_request(raw: bytes) -> dict:
     return request
 
 
+def _parse_initial_positions(rows: list) -> tuple[dict, ...]:
+    """Decode position rows whose instrument ids arrive as UUID strings."""
+
+    parsed: list[dict] = []
+    for row in rows:
+        if not isinstance(row, dict):
+            raise ValueError("each initial position must be a JSON object")
+        decoded = dict(row)
+        decoded["instrument_id"] = UUID(str(decoded.get("instrument_id")))
+        parsed.append(decoded)
+    return tuple(parsed)
+
+
 def _identity_row_to_evidence(row: SyntheticIdentityRow) -> dict:
     return {
         "instrument_id": str(row.instrument_id),
@@ -82,7 +112,7 @@ def perform_contract_check(request: dict) -> dict:
     """Execute the full check and return the JSON-serializable result."""
 
     static_ids = tuple(UUID(value) for value in request.get("static_instrument_ids", []))
-    initial_positions = tuple(request.get("initial_positions", []))
+    initial_positions = _parse_initial_positions(request.get("initial_positions", []))
     parameters = ContractCheckParameters(
         session_date=date.fromisoformat(request["session_date"]),
         decision_time=datetime.fromisoformat(request["decision_time"]),
@@ -95,10 +125,14 @@ def perform_contract_check(request: dict) -> dict:
     adapter = FunctionStrategyAdapter.from_source(
         request["source_code"],
         parameters=request.get("default_parameters", {}),
+        execution_scope=ISOLATED_SUBPROCESS_SCOPE,
+        module_name=STRATEGY_MODULE_NAME,
     )
 
     real_stdout = sys.stdout
-    sys.stdout = _BoundedWriter(real_stdout, MAX_STRATEGY_STDOUT_BYTES)
+    # stdout stays reserved for the one JSON result; strategy prints go to
+    # stderr under a bounded budget.
+    sys.stdout = _BoundedStderrWriter(sys.stderr, MAX_STRATEGY_OUTPUT_BYTES)
     try:
         decision = adapter.on_step(context)
     finally:
@@ -139,15 +173,44 @@ def main() -> int:
 
 
 def _failure_payload(exc: Exception) -> dict:
-    """Build a display-safe, locatable failure record."""
+    """Build a display-safe, locatable failure record.
 
+    ``line`` prefers an explicit syntax-error line number and otherwise falls
+    back to the deepest frame inside the strategy module, so runtime failures
+    stay locatable.  A bounded sanitized traceback is attached as the
+    expandable technical detail.
+    """
+
+    line = getattr(exc, "lineno", None)
+    if line is None:
+        line = _strategy_line(exc)
     return {
         "error_type": type(exc).__name__,
         "message": str(exc),
-        # Syntax errors carry a source line; runtime errors do not.
-        "line": getattr(exc, "lineno", None),
+        "line": line,
+        "traceback": _bounded_traceback(exc),
         "phase": "strategy_contract_check",
     }
+
+
+def _strategy_line(exc: Exception) -> int | None:
+    """Return the deepest strategy-source frame line, when available."""
+
+    for summary in reversed(traceback.extract_tb(exc.__traceback__)):
+        if summary.filename == STRATEGY_MODULE_NAME:
+            return summary.lineno
+    return None
+
+
+def _bounded_traceback(exc: Exception) -> str:
+    """Render the traceback tail without leaking unrelated internals."""
+
+    rendered = "".join(
+        traceback.format_exception(type(exc), exc, exc.__traceback__)
+    ).strip()
+    if len(rendered) > MAX_TRACEBACK_CHARS:
+        rendered = rendered[-MAX_TRACEBACK_CHARS:]
+    return rendered
 
 
 def _emit(result: dict) -> None:

--- a/backend/app/strategy_protocol/worker.py
+++ b/backend/app/strategy_protocol/worker.py
@@ -1,0 +1,159 @@
+"""Worker entry point for the isolated startup contract check.
+
+Run as ``python -m app.strategy_protocol.worker``.  The parent checker sends
+one JSON request document on stdin; this worker loads the published strategy
+source, builds the deterministic synthetic ``DecisionContext``, calls
+``run(context, parameters)`` once, validates the returned payload, and writes
+exactly one JSON result line to stdout.
+
+The process is deliberately self-contained: it never touches the database,
+the network, or any mutable external state beyond what the request contains.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+from datetime import date, datetime, timedelta
+from uuid import UUID
+
+if os.name == "posix" and os.environ.get("QF_CONTRACT_CHECK_MEM_MB"):
+    # Best-effort address-space cap; applied before importing app modules so
+    # even imports run under the limit where the platform supports it.
+    import resource
+
+    _limit_bytes = int(os.environ["QF_CONTRACT_CHECK_MEM_MB"]) * 1024 * 1024
+    resource.setrlimit(resource.RLIMIT_AS, (_limit_bytes, _limit_bytes))
+
+from app.strategy_protocol.adapter import FunctionStrategyAdapter  # noqa: E402
+from app.strategy_protocol.contract import (  # noqa: E402
+    STRATEGY_CONTRACT_VERSION,
+)
+from app.strategy_protocol.synthetic import (  # noqa: E402
+    SYNTHETIC_SESSION_OFFSETS,
+    ContractCheckParameters,
+    SyntheticIdentityRow,
+    build_synthetic_context,
+)
+
+MAX_STRATEGY_STDOUT_BYTES = 65_536
+"""Upper bound on bytes a strategy may print during the contract check."""
+
+
+class _BoundedWriter:
+    """stdout replacement that fails once the byte budget is exhausted."""
+
+    def __init__(self, underlying, limit: int) -> None:
+        self._underlying = underlying
+        self._limit = limit
+        self._written = 0
+
+    def write(self, text: str) -> int:
+        self._written += len(text.encode("utf-8"))
+        if self._written > self._limit:
+            raise RuntimeError(
+                f"strategy stdout exceeded {self._limit} bytes during the "
+                "contract check"
+            )
+        return self._underlying.write(text)
+
+    def flush(self) -> None:
+        self._underlying.flush()
+
+
+def _parse_request(raw: bytes) -> dict:
+    request = json.loads(raw.decode("utf-8"))
+    if not isinstance(request, dict):
+        raise ValueError("contract-check request must be a JSON object")
+    return request
+
+
+def _identity_row_to_evidence(row: SyntheticIdentityRow) -> dict:
+    return {
+        "instrument_id": str(row.instrument_id),
+        "trading_code": row.trading_code,
+        "name": row.name,
+        "display_name": row.display_name,
+    }
+
+
+def perform_contract_check(request: dict) -> dict:
+    """Execute the full check and return the JSON-serializable result."""
+
+    static_ids = tuple(UUID(value) for value in request.get("static_instrument_ids", []))
+    initial_positions = tuple(request.get("initial_positions", []))
+    parameters = ContractCheckParameters(
+        session_date=date.fromisoformat(request["session_date"]),
+        decision_time=datetime.fromisoformat(request["decision_time"]),
+        data_cutoff=datetime.fromisoformat(request["data_cutoff"]),
+        static_instrument_ids=static_ids,
+        initial_positions=initial_positions,
+        parameters=request.get("default_parameters", {}),
+    )
+    context, identity_rows = build_synthetic_context(parameters)
+    adapter = FunctionStrategyAdapter.from_source(
+        request["source_code"],
+        parameters=request.get("default_parameters", {}),
+    )
+
+    real_stdout = sys.stdout
+    sys.stdout = _BoundedWriter(real_stdout, MAX_STRATEGY_STDOUT_BYTES)
+    try:
+        decision = adapter.on_step(context)
+    finally:
+        sys.stdout = real_stdout
+
+    return {
+        "ok": True,
+        "evidence": {
+            "contract_version": STRATEGY_CONTRACT_VERSION,
+            "mode": decision.mode,
+            "target_count": len(decision.targets),
+            "session_dates": [
+                (context.session_date - timedelta(days=offset)).isoformat()
+                for offset in SYNTHETIC_SESSION_OFFSETS
+            ],
+            "identity_rows": [
+                _identity_row_to_evidence(row) for row in identity_rows
+            ],
+        },
+    }
+
+
+def main() -> int:
+    """Read one request from stdin and emit exactly one result line."""
+
+    try:
+        request = _parse_request(sys.stdin.buffer.read())
+    except Exception as exc:  # noqa: BLE001 - reported as structured failure
+        _emit({"ok": False, "failure": _failure_payload(exc)})
+        return 0
+    try:
+        _emit(perform_contract_check(request))
+    except Exception as exc:  # noqa: BLE001 - every failure must be locatable
+        _emit({"ok": False, "failure": _failure_payload(exc)})
+    finally:
+        sys.stdout.flush()
+    return 0
+
+
+def _failure_payload(exc: Exception) -> dict:
+    """Build a display-safe, locatable failure record."""
+
+    return {
+        "error_type": type(exc).__name__,
+        "message": str(exc),
+        # Syntax errors carry a source line; runtime errors do not.
+        "line": getattr(exc, "lineno", None),
+        "phase": "strategy_contract_check",
+    }
+
+
+def _emit(result: dict) -> None:
+    sys.stdout.write(json.dumps(result, ensure_ascii=False))
+    sys.stdout.write("\n")
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/backend/app/strategy_protocol/worker.py
+++ b/backend/app/strategy_protocol/worker.py
@@ -29,10 +29,9 @@ if os.name == "posix" and os.environ.get("QF_CONTRACT_CHECK_MEM_MB"):
     _limit_bytes = int(os.environ["QF_CONTRACT_CHECK_MEM_MB"]) * 1024 * 1024
     resource.setrlimit(resource.RLIMIT_AS, (_limit_bytes, _limit_bytes))
 
-from app.strategy_protocol.adapter import (  # noqa: E402
-    ISOLATED_SUBPROCESS_SCOPE,
-    FunctionStrategyAdapter,
-)
+from types import ModuleType
+
+from app.strategy_protocol.adapter import FunctionStrategyAdapter  # noqa: E402
 from app.strategy_protocol.contract import (  # noqa: E402
     STRATEGY_CONTRACT_VERSION,
 )
@@ -51,6 +50,21 @@ MAX_TRACEBACK_CHARS = 4_000
 
 STRATEGY_MODULE_NAME = "published_strategy"
 """Filename recorded for compiled strategy source, used for line lookups."""
+
+
+def load_published_module(source_code: str) -> ModuleType:
+    """Compile and execute published strategy source in this worker process.
+
+    This is the only source-loading path in the codebase: the adapter takes
+    an already-loaded module, so no API or Runner caller can accidentally
+    execute private code.  Callers must redirect stdout first so module-level
+    ``print`` output cannot mix into the JSON result document.
+    """
+
+    module = ModuleType(STRATEGY_MODULE_NAME)
+    compiled = compile(source_code, STRATEGY_MODULE_NAME, "exec")
+    exec(compiled, module.__dict__)  # noqa: S102 - isolated subprocess only
+    return module
 
 
 class _BoundedStderrWriter:
@@ -122,18 +136,17 @@ def perform_contract_check(request: dict) -> dict:
         parameters=request.get("default_parameters", {}),
     )
     context, identity_rows = build_synthetic_context(parameters)
-    adapter = FunctionStrategyAdapter.from_source(
-        request["source_code"],
-        parameters=request.get("default_parameters", {}),
-        execution_scope=ISOLATED_SUBPROCESS_SCOPE,
-        module_name=STRATEGY_MODULE_NAME,
-    )
 
     real_stdout = sys.stdout
-    # stdout stays reserved for the one JSON result; strategy prints go to
-    # stderr under a bounded budget.
+    # stdout stays reserved for the one JSON result for the entire strategy
+    # lifetime: module-level code, compilation, and the run() call all write
+    # to the bounded stderr forwarder instead.
     sys.stdout = _BoundedStderrWriter(sys.stderr, MAX_STRATEGY_OUTPUT_BYTES)
     try:
+        adapter = FunctionStrategyAdapter(
+            load_published_module(request["source_code"]),
+            parameters=request.get("default_parameters", {}),
+        )
         decision = adapter.on_step(context)
     finally:
         sys.stdout = real_stdout

--- a/backend/app/strategy_protocol/worker.py
+++ b/backend/app/strategy_protocol/worker.py
@@ -52,15 +52,44 @@ STRATEGY_MODULE_NAME = "published_strategy"
 """Filename recorded for compiled strategy source, used for line lookups."""
 
 
-def load_published_module(source_code: str) -> ModuleType:
-    """Compile and execute published strategy source in this worker process.
+STRATEGY_MODULE_PATH = "app.strategy_protocol.worker"
+"""Dotted import path of this module, used for the worker-role check.
 
-    This is the only source-loading path in the codebase: the adapter takes
-    an already-loaded module, so no API or Runner caller can accidentally
-    execute private code.  Callers must redirect stdout first so module-level
-    ``print`` output cannot mix into the JSON result document.
+When run via ``python -m``, this file executes as ``__main__`` and its
+``__spec__.name`` records this dotted path.
+"""
+
+
+def _require_worker_process() -> None:
+    """Refuse to run unless this process is the isolated contract-check worker.
+
+    Two independent signals must hold: the process must have been started as
+    ``python -m app.strategy_protocol.worker`` (its ``__main__`` spec matches
+    :data:`STRATEGY_MODULE_PATH`), and the parent checker must have set the
+    worker marker environment variable.  Importing this module from an API,
+    Runner, or test process does not satisfy either condition.
     """
 
+    main_spec = getattr(sys.modules.get("__main__"), "__spec__", None)
+    started_as_worker = (
+        main_spec is not None and main_spec.name == STRATEGY_MODULE_PATH
+    )
+    marked_by_parent = os.environ.get("QF_CONTRACT_CHECK_WORKER") == "1"
+    if not (started_as_worker and marked_by_parent):
+        raise RuntimeError(
+            "策略源码只能在隔离的回测契约检查子进程中编译执行。"
+        )
+
+
+def _load_published_module(source_code: str) -> ModuleType:
+    """Compile and execute published strategy source inside this worker.
+
+    Private on purpose: this is the only ``exec`` path in the codebase and it
+    is unreachable unless :func:`_require_worker_process` passes, so no API
+    or Runner process can load user source through an importable helper.
+    """
+
+    _require_worker_process()
     module = ModuleType(STRATEGY_MODULE_NAME)
     compiled = compile(source_code, STRATEGY_MODULE_NAME, "exec")
     exec(compiled, module.__dict__)  # noqa: S102 - isolated subprocess only
@@ -144,7 +173,7 @@ def perform_contract_check(request: dict) -> dict:
     sys.stdout = _BoundedStderrWriter(sys.stderr, MAX_STRATEGY_OUTPUT_BYTES)
     try:
         adapter = FunctionStrategyAdapter(
-            load_published_module(request["source_code"]),
+            _load_published_module(request["source_code"]),
             parameters=request.get("default_parameters", {}),
         )
         decision = adapter.on_step(context)

--- a/backend/tests/__init__.py
+++ b/backend/tests/__init__.py
@@ -6,3 +6,4 @@ import os
 # a developer's local .env file while individual tests still override settings.
 os.environ.setdefault("QF_API_TOKEN", "test-api-token-" + "a" * 48)
 os.environ.setdefault("QF_DATABASE_PASSWORD", "test-database-password")
+os.environ.setdefault("QF_CURSOR_SIGNING_KEY", "test-cursor-signing-key-" + "b" * 40)

--- a/backend/tests/test_backtesting_instrument_specs.py
+++ b/backend/tests/test_backtesting_instrument_specs.py
@@ -1,0 +1,96 @@
+"""Tests for the instrument spec contract and its provider protocol."""
+
+import unittest
+from datetime import datetime, timezone
+from uuid import uuid4
+
+from app.backtesting.domain import DomainValidationError
+from app.backtesting.instrument_specs import InstrumentSpec
+from app.backtesting.result_models import InstrumentDisplaySnapshot, resolve_display_snapshot
+
+
+AS_OF = datetime(2026, 1, 5, tzinfo=timezone.utc)
+
+
+class FakeInstrumentSpecProvider:
+    """In-memory provider proving the protocol needs no market-data client."""
+
+    def __init__(self, specs) -> None:
+        self._specs = {spec.instrument_id: spec for spec in specs}
+        self.resolved_at: list[datetime] = []
+
+    def resolve(self, instrument_id, *, as_of):
+        self.resolved_at.append(as_of)
+        return self._specs.get(instrument_id)
+
+
+class InstrumentSpecTestCase(unittest.TestCase):
+    def test_rejects_non_uuid_identity(self) -> None:
+        with self.assertRaises(DomainValidationError):
+            InstrumentSpec(
+                instrument_id="not-a-uuid",
+                asset_class="etf",
+                trading_code="510300",
+            )
+
+    def test_rejects_blank_asset_class(self) -> None:
+        with self.assertRaises(DomainValidationError):
+            InstrumentSpec(instrument_id=uuid4(), asset_class="   ")
+
+    def test_allows_missing_display_fields(self) -> None:
+        spec = InstrumentSpec(instrument_id=uuid4(), asset_class="fictional")
+        self.assertIsNone(spec.trading_code)
+        self.assertIsNone(spec.name)
+        self.assertIsNone(spec.display_name)
+
+
+class DisplaySnapshotResolutionTestCase(unittest.TestCase):
+    def test_snapshot_freezes_spec_values_at_resolution_time(self) -> None:
+        instrument_id = uuid4()
+        spec = InstrumentSpec(
+            instrument_id=instrument_id,
+            asset_class="etf",
+            trading_code="510300",
+            name="沪深300ETF",
+            display_name="沪深300ETF",
+        )
+        provider = FakeInstrumentSpecProvider([spec])
+
+        snapshot = resolve_display_snapshot(provider, instrument_id, as_of=AS_OF)
+
+        self.assertEqual(snapshot.event_trading_code, "510300")
+        self.assertEqual(snapshot.event_name, "沪深300ETF")
+        self.assertEqual(snapshot.instrument_id, instrument_id)
+
+        # A later catalogue change must never rewrite the frozen snapshot.
+        renamed = InstrumentSpec(
+            instrument_id=instrument_id,
+            asset_class="etf",
+            trading_code="510999",
+            name="改名后的ETF",
+            display_name="改名后的ETF",
+        )
+        provider._specs[instrument_id] = renamed
+        self.assertEqual(snapshot.event_trading_code, "510300")
+        self.assertEqual(snapshot.event_name, "沪深300ETF")
+
+    def test_missing_spec_yields_identity_only_snapshot(self) -> None:
+        instrument_id = uuid4()
+        provider = FakeInstrumentSpecProvider([])
+
+        snapshot = resolve_display_snapshot(provider, instrument_id, as_of=AS_OF)
+
+        self.assertIsInstance(snapshot, InstrumentDisplaySnapshot)
+        self.assertEqual(snapshot.instrument_id, instrument_id)
+        self.assertIsNone(snapshot.event_trading_code)
+        self.assertIsNone(snapshot.event_name)
+        self.assertIsNone(snapshot.event_display_name)
+
+    def test_snapshot_cannot_be_reused_for_another_instrument(self) -> None:
+        snapshot = InstrumentDisplaySnapshot(instrument_id=uuid4())
+        with self.assertRaises(DomainValidationError):
+            snapshot.require_matching_instrument(uuid4(), "display")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/backend/tests/test_backtesting_pagination.py
+++ b/backend/tests/test_backtesting_pagination.py
@@ -269,6 +269,13 @@ class CursorRejectionTestCase(unittest.TestCase):
                 query_upper_bound={"c": Decimal("1.5")},
             )
 
+    def test_non_ascii_tokens_map_to_malformed_cursor(self) -> None:
+        # Non-ASCII content must surface as CursorError (HTTP 400), never as
+        # an underlying UnicodeEncodeError leaking through as HTTP 422.
+        for bad in ("é.00", "abc.é", "日本語.test", "café"):
+            with self.assertRaises(MalformedCursorError):
+                parse(bad)
+
     def test_blank_signing_keys_are_refused(self) -> None:
         for bad in ("", "   ", None):
             with self.assertRaises(ValueError):

--- a/backend/tests/test_backtesting_pagination.py
+++ b/backend/tests/test_backtesting_pagination.py
@@ -1,0 +1,221 @@
+"""Tests for opaque cursor tokens, digests, and the page envelope."""
+
+import json
+import unittest
+from base64 import urlsafe_b64decode, urlsafe_b64encode
+from datetime import datetime, timezone
+from decimal import Decimal
+from uuid import uuid4
+
+from app.backtesting.pagination import (
+    CURSOR_VERSION,
+    DEFAULT_PAGE_SIZE,
+    MAX_PAGE_SIZE,
+    CursorError,
+    CursorPage,
+    CursorQueryMismatchError,
+    MalformedCursorError,
+    UnsupportedCursorVersionError,
+    build_cursor,
+    compute_query_digest,
+    normalize_limit,
+    parse_cursor,
+)
+
+
+TS = datetime(2026, 5, 1, 8, 0, tzinfo=timezone.utc)
+KEY_KINDS = ("ts", "uuid")
+UPPER_COLUMNS = {"submitted_at": "ts", "order_id": "uuid"}
+
+
+def token_for(last_key, bound, digest="d" * 64) -> str:
+    return build_cursor(
+        query_digest=digest,
+        key_kinds=KEY_KINDS,
+        last_sort_key=last_key,
+        upper_bound_columns=UPPER_COLUMNS,
+        query_upper_bound=bound,
+    )
+
+
+class LimitPolicyTestCase(unittest.TestCase):
+    def test_default_and_max_page_size_policy(self) -> None:
+        self.assertEqual(DEFAULT_PAGE_SIZE, 100)
+        self.assertEqual(MAX_PAGE_SIZE, 500)
+
+    def test_rejects_out_of_range_or_non_integer_limits(self) -> None:
+        for bad in (0, -1, 501, True, "100", 1.5):
+            with self.assertRaises(ValueError):
+                normalize_limit(bad)
+        self.assertEqual(normalize_limit(1), 1)
+        self.assertEqual(normalize_limit(500), 500)
+
+
+class QueryDigestTestCase(unittest.TestCase):
+    def base_payload(self) -> dict:
+        return {
+            "kind": "orders",
+            "run_id": "0f9c6d5e-1111-4222-8333-444455556666",
+            "filters": {},
+            "direction": "asc",
+            "sort_keys": ["submitted_at", "order_id"],
+            "page_size_policy": {"default": 100, "max": 500},
+            "limit": 100,
+        }
+
+    def test_digest_is_deterministic_and_order_insensitive(self) -> None:
+        first = compute_query_digest(self.base_payload())
+        second = compute_query_digest(dict(reversed(list(self.base_payload().items()))))
+        self.assertEqual(first, second)
+        self.assertEqual(first, compute_query_digest(self.base_payload()))
+
+    def test_any_condition_change_changes_the_digest(self) -> None:
+        base = compute_query_digest(self.base_payload())
+        variants = []
+        changed = self.base_payload(); changed["run_id"] = str(uuid4()); variants.append(changed)
+        changed = self.base_payload(); changed["filters"] = {"side": "buy"}; variants.append(changed)
+        changed = self.base_payload(); changed["limit"] = 200; variants.append(changed)
+        changed = self.base_payload(); changed["direction"] = "desc"; variants.append(changed)
+        for variant in variants:
+            self.assertNotEqual(base, compute_query_digest(variant))
+
+
+class CursorRoundTripTestCase(unittest.TestCase):
+    def test_round_trip_preserves_typed_values(self) -> None:
+        order_id = uuid4()
+        token = token_for((TS, order_id), {"submitted_at": TS, "order_id": order_id})
+        parsed = parse_cursor(
+            token,
+            expected_query_digest="d" * 64,
+            key_kinds=KEY_KINDS,
+            upper_bound_columns=UPPER_COLUMNS,
+        )
+        self.assertEqual(parsed.version, CURSOR_VERSION)
+        self.assertEqual(parsed.last_sort_key[0], TS)
+        self.assertEqual(parsed.last_sort_key[1], order_id)
+        self.assertEqual(parsed.query_upper_bound["submitted_at"], TS)
+
+    def test_equivalent_instants_in_different_timezones_match(self) -> None:
+        from datetime import timedelta
+
+        tz_plus_eight = timezone(timedelta(hours=8))
+        local = TS.astimezone(tz_plus_eight)
+        order_id = uuid4()
+        token_a = token_for((TS, order_id), {"submitted_at": TS, "order_id": order_id})
+        token_b = token_for(
+            (local, order_id), {"submitted_at": local, "order_id": order_id}
+        )
+        self.assertEqual(token_a, token_b)
+
+    def test_identical_queries_produce_identical_tokens(self) -> None:
+        digest = compute_query_digest({"kind": "fills", "limit": 10})
+        fill_id = uuid4()
+        columns = {"timestamp": "ts", "fill_id": "uuid"}
+        a = build_cursor(
+            query_digest=digest,
+            key_kinds=("ts", "uuid"),
+            last_sort_key=(TS, fill_id),
+            upper_bound_columns=columns,
+            query_upper_bound={"timestamp": TS, "fill_id": fill_id},
+        )
+        b = build_cursor(
+            query_digest=digest,
+            key_kinds=("ts", "uuid"),
+            last_sort_key=(TS, fill_id),
+            upper_bound_columns=columns,
+            query_upper_bound={"timestamp": TS, "fill_id": fill_id},
+        )
+        self.assertEqual(a, b)
+
+
+class CursorRejectionTestCase(unittest.TestCase):
+    def test_malformed_tokens_are_rejected(self) -> None:
+        for bad in ("", "not-base64!!", urlsafe_b64encode(b"[not-json]").decode()):
+            with self.assertRaises(MalformedCursorError):
+                parse_cursor(bad)
+
+    def test_unsupported_version_is_rejected(self) -> None:
+        payload = {
+            "version": CURSOR_VERSION + 1,
+            "query_digest": "d" * 64,
+            "last_sort_key": [],
+            "query_upper_bound": {},
+        }
+        token = urlsafe_b64encode(json.dumps(payload).encode()).decode().rstrip("=")
+        with self.assertRaises(UnsupportedCursorVersionError):
+            parse_cursor(token)
+
+    def test_tampered_payload_is_detected_by_structure_checks(self) -> None:
+        token = token_for((TS, uuid4()), {"submitted_at": TS, "order_id": uuid4()})
+        padded = token + "=" * (-len(token) % 4)
+        payload = json.loads(urlsafe_b64decode(padded))
+        payload["last_sort_key"] = [{"k": "int", "v": 3}, {"k": "str", "v": "x"}]
+        tampered = (
+            urlsafe_b64encode(json.dumps(payload).encode()).decode().rstrip("=")
+        )
+        with self.assertRaises(CursorError):
+            parse_cursor(
+                tampered,
+                expected_query_digest="d" * 64,
+                key_kinds=KEY_KINDS,
+                upper_bound_columns=UPPER_COLUMNS,
+            )
+
+    def test_wrong_length_sort_key_is_rejected(self) -> None:
+        token = build_cursor(
+            query_digest="d" * 64,
+            key_kinds=("ts",),
+            last_sort_key=(TS,),
+            upper_bound_columns=UPPER_COLUMNS,
+            query_upper_bound={"submitted_at": TS, "order_id": uuid4()},
+        )
+        with self.assertRaises(MalformedCursorError):
+            parse_cursor(
+                token,
+                expected_query_digest="d" * 64,
+                key_kinds=KEY_KINDS,
+                upper_bound_columns=UPPER_COLUMNS,
+            )
+
+    def test_query_digest_mismatch_is_rejected(self) -> None:
+        token = token_for((TS, uuid4()), {"submitted_at": TS, "order_id": uuid4()})
+        with self.assertRaises(CursorQueryMismatchError):
+            parse_cursor(
+                token,
+                expected_query_digest="e" * 64,
+                key_kinds=KEY_KINDS,
+                upper_bound_columns=UPPER_COLUMNS,
+            )
+
+    def test_upper_bound_column_mismatch_is_rejected(self) -> None:
+        token = token_for((TS, uuid4()), {"submitted_at": TS, "order_id": uuid4()})
+        with self.assertRaises(MalformedCursorError):
+            parse_cursor(
+                token,
+                expected_query_digest="d" * 64,
+                key_kinds=KEY_KINDS,
+                upper_bound_columns={"other_column": "ts"},
+            )
+
+    def test_naive_timestamps_are_refused_at_encoding_time(self) -> None:
+        naive = datetime(2026, 5, 1, 8, 0)
+        with self.assertRaises(ValueError):
+            build_cursor(
+                query_digest="d" * 64,
+                key_kinds=("ts",),
+                last_sort_key=(naive,),
+                upper_bound_columns={"c": "dec"},
+                query_upper_bound={"c": Decimal("1.5")},
+            )
+
+
+class EnvelopeTestCase(unittest.TestCase):
+    def test_empty_page_shape(self) -> None:
+        page = CursorPage(items=(), next_cursor=None, has_more=False)
+        self.assertEqual(page.items, ())
+        self.assertIsNone(page.next_cursor)
+        self.assertFalse(page.has_more)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/backend/tests/test_backtesting_pagination.py
+++ b/backend/tests/test_backtesting_pagination.py
@@ -20,22 +20,36 @@ from app.backtesting.pagination import (
     compute_query_digest,
     normalize_limit,
     parse_cursor,
+    sign_token,
 )
 
 
 TS = datetime(2026, 5, 1, 8, 0, tzinfo=timezone.utc)
 KEY_KINDS = ("ts", "uuid")
 UPPER_COLUMNS = {"submitted_at": "ts", "order_id": "uuid"}
+SIGNING_KEY = "unit-test-signing-key"
 
 
-def token_for(last_key, bound, digest="d" * 64) -> str:
+def token_for(last_key, bound, digest="d" * 64, signing_key=SIGNING_KEY) -> str:
     return build_cursor(
+        signing_key=signing_key,
         query_digest=digest,
         key_kinds=KEY_KINDS,
         last_sort_key=last_key,
         upper_bound_columns=UPPER_COLUMNS,
         query_upper_bound=bound,
     )
+
+
+def parse(token, **overrides):
+    kwargs = {
+        "signing_key": SIGNING_KEY,
+        "expected_query_digest": "d" * 64,
+        "key_kinds": KEY_KINDS,
+        "upper_bound_columns": UPPER_COLUMNS,
+    }
+    kwargs.update(overrides)
+    return parse_cursor(token, **kwargs)
 
 
 class LimitPolicyTestCase(unittest.TestCase):
@@ -84,12 +98,7 @@ class CursorRoundTripTestCase(unittest.TestCase):
     def test_round_trip_preserves_typed_values(self) -> None:
         order_id = uuid4()
         token = token_for((TS, order_id), {"submitted_at": TS, "order_id": order_id})
-        parsed = parse_cursor(
-            token,
-            expected_query_digest="d" * 64,
-            key_kinds=KEY_KINDS,
-            upper_bound_columns=UPPER_COLUMNS,
-        )
+        parsed = parse(token)
         self.assertEqual(parsed.version, CURSOR_VERSION)
         self.assertEqual(parsed.last_sort_key[0], TS)
         self.assertEqual(parsed.last_sort_key[1], order_id)
@@ -112,6 +121,7 @@ class CursorRoundTripTestCase(unittest.TestCase):
         fill_id = uuid4()
         columns = {"timestamp": "ts", "fill_id": "uuid"}
         a = build_cursor(
+            signing_key=SIGNING_KEY,
             query_digest=digest,
             key_kinds=("ts", "uuid"),
             last_sort_key=(TS, fill_id),
@@ -119,6 +129,7 @@ class CursorRoundTripTestCase(unittest.TestCase):
             query_upper_bound={"timestamp": TS, "fill_id": fill_id},
         )
         b = build_cursor(
+            signing_key=SIGNING_KEY,
             query_digest=digest,
             key_kinds=("ts", "uuid"),
             last_sort_key=(TS, fill_id),
@@ -128,41 +139,105 @@ class CursorRoundTripTestCase(unittest.TestCase):
         self.assertEqual(a, b)
 
 
+def _split(token: str) -> tuple[str, dict, str]:
+    encoded_payload, signature = token.split(".")
+    padded = encoded_payload + "=" * (-len(encoded_payload) % 4)
+    payload = json.loads(urlsafe_b64decode(padded))
+    return encoded_payload, payload, signature
+
+
+def _reencode_without_signature(payload: dict) -> str:
+    canonical = json.dumps(
+        payload, sort_keys=True, separators=(",", ":"), ensure_ascii=False
+    )
+    return urlsafe_b64encode(canonical.encode()).decode().rstrip("=")
+
+
 class CursorRejectionTestCase(unittest.TestCase):
     def test_malformed_tokens_are_rejected(self) -> None:
-        for bad in ("", "not-base64!!", urlsafe_b64encode(b"[not-json]").decode()):
+        for bad in (
+            "",
+            "not-base64!!",
+            urlsafe_b64encode(b"[not-json]").decode(),
+            # Unsigned legacy tokens must not be accepted either.
+            urlsafe_b64encode(b"{}").decode().rstrip("="),
+        ):
             with self.assertRaises(MalformedCursorError):
-                parse_cursor(bad)
+                parse(bad)
+
+    def test_missing_or_garbled_signature_is_rejected(self) -> None:
+        token = token_for((TS, uuid4()), {"submitted_at": TS, "order_id": uuid4()})
+        encoded_payload, _, _ = _split(token)
+        with self.assertRaises(MalformedCursorError):
+            parse(encoded_payload)
+
+    def test_wrong_signing_key_is_rejected(self) -> None:
+        token = token_for((TS, uuid4()), {"submitted_at": TS, "order_id": uuid4()})
+        with self.assertRaises(MalformedCursorError):
+            parse(token, signing_key="a-different-key")
+
+    def test_legitimate_value_tampering_is_rejected(self) -> None:
+        """Swapping in another valid UUID/timestamp must not be accepted."""
+
+        original_bound_id = uuid4()
+        token = token_for(
+            (TS, original_bound_id), {"submitted_at": TS, "order_id": original_bound_id}
+        )
+        _, payload, signature = _split(token)
+
+        # Rewrite the bound to a different but perfectly valid UUID and
+        # timestamp, keeping the original signature untouched.
+        forged_payload = json.loads(json.dumps(payload))
+        forged_payload["query_upper_bound"]["order_id"] = {
+            "k": "uuid",
+            "v": str(uuid4()),
+        }
+        forged_payload["last_sort_key"][0] = {
+            "k": "ts",
+            "v": "2026-05-02T08:00:00+00:00",
+        }
+        forged = f"{_reencode_without_signature(forged_payload)}.{signature}"
+        with self.assertRaises(MalformedCursorError):
+            parse(forged)
+
+    def test_re_signing_with_a_foreign_key_does_not_validate(self) -> None:
+        token = token_for((TS, uuid4()), {"submitted_at": TS, "order_id": uuid4()})
+        _, payload, _ = _split(token)
+        foreign = build_cursor(
+            signing_key="attacker-key",
+            query_digest=payload["query_digest"],
+            key_kinds=KEY_KINDS,
+            last_sort_key=(TS, uuid4()),
+            upper_bound_columns=UPPER_COLUMNS,
+            query_upper_bound={"submitted_at": TS, "order_id": uuid4()},
+        )
+        with self.assertRaises(MalformedCursorError):
+            parse(foreign)
 
     def test_unsupported_version_is_rejected(self) -> None:
-        payload = {
+        # A properly signed token with an unsupported version must still be
+        # rejected by the version check itself.
+        forged_payload = {
             "version": CURSOR_VERSION + 1,
             "query_digest": "d" * 64,
             "last_sort_key": [],
             "query_upper_bound": {},
         }
-        token = urlsafe_b64encode(json.dumps(payload).encode()).decode().rstrip("=")
+        token = sign_token(forged_payload, SIGNING_KEY)
         with self.assertRaises(UnsupportedCursorVersionError):
-            parse_cursor(token)
+            parse(token)
 
     def test_tampered_payload_is_detected_by_structure_checks(self) -> None:
         token = token_for((TS, uuid4()), {"submitted_at": TS, "order_id": uuid4()})
-        padded = token + "=" * (-len(token) % 4)
-        payload = json.loads(urlsafe_b64decode(padded))
+        encoded_payload, payload, _ = _split(token)
         payload["last_sort_key"] = [{"k": "int", "v": 3}, {"k": "str", "v": "x"}]
-        tampered = (
-            urlsafe_b64encode(json.dumps(payload).encode()).decode().rstrip("=")
-        )
+        tampered = f"{_reencode_without_signature(payload)}.{token.split('.')[1]}"
         with self.assertRaises(CursorError):
-            parse_cursor(
-                tampered,
-                expected_query_digest="d" * 64,
-                key_kinds=KEY_KINDS,
-                upper_bound_columns=UPPER_COLUMNS,
-            )
+            parse(tampered)
 
     def test_wrong_length_sort_key_is_rejected(self) -> None:
         token = build_cursor(
+            signing_key=SIGNING_KEY,
             query_digest="d" * 64,
             key_kinds=("ts",),
             last_sort_key=(TS,),
@@ -170,43 +245,41 @@ class CursorRejectionTestCase(unittest.TestCase):
             query_upper_bound={"submitted_at": TS, "order_id": uuid4()},
         )
         with self.assertRaises(MalformedCursorError):
-            parse_cursor(
-                token,
-                expected_query_digest="d" * 64,
-                key_kinds=KEY_KINDS,
-                upper_bound_columns=UPPER_COLUMNS,
-            )
+            parse(token)
 
     def test_query_digest_mismatch_is_rejected(self) -> None:
         token = token_for((TS, uuid4()), {"submitted_at": TS, "order_id": uuid4()})
         with self.assertRaises(CursorQueryMismatchError):
-            parse_cursor(
-                token,
-                expected_query_digest="e" * 64,
-                key_kinds=KEY_KINDS,
-                upper_bound_columns=UPPER_COLUMNS,
-            )
+            parse(token, expected_query_digest="e" * 64)
 
     def test_upper_bound_column_mismatch_is_rejected(self) -> None:
         token = token_for((TS, uuid4()), {"submitted_at": TS, "order_id": uuid4()})
         with self.assertRaises(MalformedCursorError):
-            parse_cursor(
-                token,
-                expected_query_digest="d" * 64,
-                key_kinds=KEY_KINDS,
-                upper_bound_columns={"other_column": "ts"},
-            )
+            parse(token, upper_bound_columns={"other_column": "ts"})
 
     def test_naive_timestamps_are_refused_at_encoding_time(self) -> None:
         naive = datetime(2026, 5, 1, 8, 0)
         with self.assertRaises(ValueError):
             build_cursor(
+                signing_key=SIGNING_KEY,
                 query_digest="d" * 64,
                 key_kinds=("ts",),
                 last_sort_key=(naive,),
                 upper_bound_columns={"c": "dec"},
                 query_upper_bound={"c": Decimal("1.5")},
             )
+
+    def test_blank_signing_keys_are_refused(self) -> None:
+        for bad in ("", "   ", None):
+            with self.assertRaises(ValueError):
+                build_cursor(
+                    signing_key=bad,
+                    query_digest="d" * 64,
+                    key_kinds=(),
+                    last_sort_key=(),
+                    upper_bound_columns={},
+                    query_upper_bound={},
+                )
 
 
 class EnvelopeTestCase(unittest.TestCase):

--- a/backend/tests/test_backtesting_result_api.py
+++ b/backend/tests/test_backtesting_result_api.py
@@ -1,0 +1,192 @@
+"""Tests for the read-only backtest result HTTP layer.
+
+The project test suite calls route functions directly (no TestClient), so
+these tests exercise the same functions FastAPI dispatches to and then
+serialize the response models with ``model_dump(mode="json")`` to pin the
+wire contract (Decimal as string, opaque cursor envelope).
+"""
+
+import unittest
+from datetime import datetime, timedelta, timezone
+from decimal import Decimal
+from uuid import uuid4
+
+from sqlalchemy import create_engine
+from sqlalchemy.orm import Session
+
+from app.backtesting.accounting import OrderSide
+from app.backtesting.domain import PositionSide
+from app.backtesting.pagination import CursorQueryMismatchError
+from app.backtesting.result_models import (
+    BacktestMetricRecord,
+    BacktestOrderRecord,
+    BacktestPositionRecord,
+    InstrumentDisplaySnapshot,
+    ResultOrderStatus,
+)
+from app.backtesting.result_records import RESULT_TABLE_NAMES, Base
+from app.backtesting.result_repository import BacktestResultRepository
+from app.backtesting.result_router import list_metrics, list_orders, list_positions
+from app.backtesting.result_schemas import ResultCursorPage, BacktestOrderItem
+
+
+UTC = timezone.utc
+
+
+def ts(hour: int) -> datetime:
+    return datetime(2026, 6, 1, hour, tzinfo=UTC)
+
+
+class ResultApiTestCase(unittest.TestCase):
+    def setUp(self) -> None:
+        self.engine = create_engine("sqlite:///:memory:")
+        result_tables = [Base.metadata.tables[name] for name in RESULT_TABLE_NAMES]
+        Base.metadata.create_all(self.engine, tables=result_tables)
+        self.session = Session(self.engine)
+        self.repo = BacktestResultRepository(self.session)
+        self.run_id = uuid4()
+
+    def tearDown(self) -> None:
+        self.session.close()
+        self.engine.dispose()
+
+    def seed_orders(self, count: int) -> list[BacktestOrderRecord]:
+        orders = []
+        for index in range(count):
+            instrument_id = uuid4()
+            orders.append(
+                BacktestOrderRecord(
+                    run_id=self.run_id,
+                    order_id=uuid4(),
+                    instrument_id=instrument_id,
+                    display=InstrumentDisplaySnapshot(
+                        instrument_id=instrument_id,
+                        event_trading_code=None,
+                        event_name="虚构资产",
+                    ),
+                    side=OrderSide.BUY,
+                    order_type="market",
+                    quantity="100",
+                    status=ResultOrderStatus.FILLED,
+                    submitted_at=ts(9) + timedelta(minutes=index),
+                    # Binary-float-exact so the SQLite test dialect round-trips
+                    # it losslessly; PostgreSQL NUMERIC stays exact regardless.
+                    price=Decimal("3.5"),
+                )
+            )
+        self.repo.append("orders", *orders)
+        return orders
+
+    def serialize_orders_page(self, **kwargs) -> dict:
+        page = list_orders(run_id=self.run_id, limit=10, cursor=None, session=self.session, **kwargs)
+        model = ResultCursorPage[BacktestOrderItem].model_validate(page)
+        return model.model_dump(mode="json")
+
+    def test_orders_envelope_and_decimal_string_serialization(self) -> None:
+        orders = self.seed_orders(3)
+        payload = self.serialize_orders_page()
+        self.assertEqual(len(payload["items"]), 3)
+        self.assertFalse(payload["has_more"])
+        self.assertIsNone(payload["next_cursor"])
+        item = payload["items"][0]
+        self.assertEqual(item["order_id"], str(orders[0].order_id))
+        # Decimal fields must be strings on the wire, never JSON numbers.
+        self.assertEqual(item["price"], "3.5")
+        self.assertEqual(item["quantity"], "100")
+        self.assertIsInstance(item["price"], str)
+
+    def test_orders_multi_page_cursor_flow(self) -> None:
+        orders = self.seed_orders(12)
+        first = list_orders(run_id=self.run_id, limit=5, cursor=None, session=self.session)
+        self.assertTrue(first["has_more"])
+        second = list_orders(
+            run_id=self.run_id, limit=5, cursor=first["next_cursor"], session=self.session
+        )
+        third = list_orders(
+            run_id=self.run_id, limit=5, cursor=second["next_cursor"], session=self.session
+        )
+        collected = [row.order_id for row in (*first["items"], *second["items"], *third["items"])]
+        self.assertEqual(collected, [order.order_id for order in orders])
+        self.assertFalse(third["has_more"])
+        self.assertIsNone(third["next_cursor"])
+
+    def test_invalid_limit_maps_to_validation_error(self) -> None:
+        from fastapi import HTTPException
+
+        for bad in (0, 501):
+            with self.assertRaises(HTTPException) as caught:
+                list_orders(run_id=self.run_id, limit=bad, cursor=None, session=self.session)
+            self.assertEqual(caught.exception.status_code, 422)
+
+    def test_mismatched_cursor_maps_to_400(self) -> None:
+        from fastapi import HTTPException
+
+        self.seed_orders(12)
+        page = list_orders(run_id=self.run_id, limit=10, cursor=None, session=self.session)
+        with self.assertRaises(HTTPException) as caught:
+            list_orders(
+                run_id=self.run_id, limit=5, cursor=page["next_cursor"], session=self.session
+            )
+        self.assertEqual(caught.exception.status_code, 400)
+
+    def test_naive_time_bound_maps_to_422(self) -> None:
+        from fastapi import HTTPException
+
+        self.seed_orders(1)
+        with self.assertRaises(HTTPException) as caught:
+            list_orders(
+                run_id=self.run_id,
+                limit=10,
+                cursor=None,
+                session=self.session,
+                start_time=datetime(2026, 6, 1, 9, 0),
+            )
+        self.assertEqual(caught.exception.status_code, 422)
+
+    def test_positions_return_raw_snapshots_with_identity_only_filter(self) -> None:
+        instrument = uuid4()
+        rows = [
+            BacktestPositionRecord(
+                run_id=self.run_id,
+                as_of=ts(hour),
+                instrument_id=instrument,
+                display=InstrumentDisplaySnapshot(instrument_id=instrument),
+                side=PositionSide.LONG,
+                quantity=str(quantity),
+                available_quantity=str(quantity),
+                average_price="2",
+                realized_pnl="0",
+                unrealized_pnl="1",
+            )
+            for hour, quantity in ((15, "10"), (16, "8"))
+        ]
+        self.repo.append("positions", *rows)
+        page = list_positions(
+            run_id=self.run_id,
+            limit=10,
+            cursor=None,
+            session=self.session,
+            instrument_id=instrument,
+        )
+        self.assertEqual(len(page["items"]), 2)
+        quantities = {row.quantity for row in page["items"]}
+        self.assertEqual(quantities, {Decimal("10"), Decimal("8")})
+
+    def test_unavailable_metrics_expose_reason_not_zero(self) -> None:
+        self.repo.append(
+            "metrics",
+            BacktestMetricRecord(
+                run_id=self.run_id,
+                metric_key="max_drawdown",
+                formula_version="v1",
+                value=None,
+                unavailable_reason="无有效估值点",
+            ),
+        )
+        page = list_metrics(run_id=self.run_id, limit=10, cursor=None, session=self.session)
+        self.assertIsNone(page["items"][0].value)
+        self.assertEqual(page["items"][0].unavailable_reason, "无有效估值点")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/backend/tests/test_backtesting_result_api.py
+++ b/backend/tests/test_backtesting_result_api.py
@@ -31,6 +31,7 @@ from app.backtesting.result_schemas import ResultCursorPage, BacktestOrderItem
 
 
 UTC = timezone.utc
+SIGNING_KEY = "unit-test-signing-key"
 
 
 def ts(hour: int) -> datetime:
@@ -43,7 +44,9 @@ class ResultApiTestCase(unittest.TestCase):
         result_tables = [Base.metadata.tables[name] for name in RESULT_TABLE_NAMES]
         Base.metadata.create_all(self.engine, tables=result_tables)
         self.session = Session(self.engine)
-        self.repo = BacktestResultRepository(self.session)
+        self.repo = BacktestResultRepository(
+            self.session, cursor_signing_key=SIGNING_KEY
+        )
         self.run_id = uuid4()
 
     def tearDown(self) -> None:

--- a/backend/tests/test_backtesting_result_api.py
+++ b/backend/tests/test_backtesting_result_api.py
@@ -81,7 +81,8 @@ class ResultApiTestCase(unittest.TestCase):
         return orders
 
     def serialize_orders_page(self, **kwargs) -> dict:
-        page = list_orders(run_id=self.run_id, limit=10, cursor=None, session=self.session, **kwargs)
+        page = list_orders(run_id=self.run_id, limit=10, cursor=None, session=self.session,
+            signing_key=SIGNING_KEY, **kwargs)
         model = ResultCursorPage[BacktestOrderItem].model_validate(page)
         return model.model_dump(mode="json")
 
@@ -100,13 +101,22 @@ class ResultApiTestCase(unittest.TestCase):
 
     def test_orders_multi_page_cursor_flow(self) -> None:
         orders = self.seed_orders(12)
-        first = list_orders(run_id=self.run_id, limit=5, cursor=None, session=self.session)
+        first = list_orders(run_id=self.run_id, limit=5, cursor=None, session=self.session,
+            signing_key=SIGNING_KEY)
         self.assertTrue(first["has_more"])
         second = list_orders(
-            run_id=self.run_id, limit=5, cursor=first["next_cursor"], session=self.session
+            run_id=self.run_id,
+            limit=5,
+            cursor=first["next_cursor"],
+            session=self.session,
+            signing_key=SIGNING_KEY,
         )
         third = list_orders(
-            run_id=self.run_id, limit=5, cursor=second["next_cursor"], session=self.session
+            run_id=self.run_id,
+            limit=5,
+            cursor=second["next_cursor"],
+            session=self.session,
+            signing_key=SIGNING_KEY,
         )
         collected = [row.order_id for row in (*first["items"], *second["items"], *third["items"])]
         self.assertEqual(collected, [order.order_id for order in orders])
@@ -118,17 +128,23 @@ class ResultApiTestCase(unittest.TestCase):
 
         for bad in (0, 501):
             with self.assertRaises(HTTPException) as caught:
-                list_orders(run_id=self.run_id, limit=bad, cursor=None, session=self.session)
+                list_orders(run_id=self.run_id, limit=bad, cursor=None, session=self.session,
+            signing_key=SIGNING_KEY)
             self.assertEqual(caught.exception.status_code, 422)
 
     def test_mismatched_cursor_maps_to_400(self) -> None:
         from fastapi import HTTPException
 
         self.seed_orders(12)
-        page = list_orders(run_id=self.run_id, limit=10, cursor=None, session=self.session)
+        page = list_orders(run_id=self.run_id, limit=10, cursor=None, session=self.session,
+            signing_key=SIGNING_KEY)
         with self.assertRaises(HTTPException) as caught:
             list_orders(
-                run_id=self.run_id, limit=5, cursor=page["next_cursor"], session=self.session
+                run_id=self.run_id,
+                limit=5,
+                cursor=page["next_cursor"],
+                session=self.session,
+                signing_key=SIGNING_KEY,
             )
         self.assertEqual(caught.exception.status_code, 400)
 
@@ -142,6 +158,7 @@ class ResultApiTestCase(unittest.TestCase):
                 limit=10,
                 cursor=None,
                 session=self.session,
+            signing_key=SIGNING_KEY,
                 start_time=datetime(2026, 6, 1, 9, 0),
             )
         self.assertEqual(caught.exception.status_code, 422)
@@ -169,6 +186,7 @@ class ResultApiTestCase(unittest.TestCase):
             limit=10,
             cursor=None,
             session=self.session,
+            signing_key=SIGNING_KEY,
             instrument_id=instrument,
         )
         self.assertEqual(len(page["items"]), 2)
@@ -186,7 +204,8 @@ class ResultApiTestCase(unittest.TestCase):
                 unavailable_reason="无有效估值点",
             ),
         )
-        page = list_metrics(run_id=self.run_id, limit=10, cursor=None, session=self.session)
+        page = list_metrics(run_id=self.run_id, limit=10, cursor=None, session=self.session,
+            signing_key=SIGNING_KEY)
         self.assertIsNone(page["items"][0].value)
         self.assertEqual(page["items"][0].unavailable_reason, "无有效估值点")
 

--- a/backend/tests/test_backtesting_result_models.py
+++ b/backend/tests/test_backtesting_result_models.py
@@ -1,0 +1,312 @@
+"""Tests for the immutable backtest result DTO contracts."""
+
+import unittest
+from datetime import datetime, timezone
+from decimal import Decimal
+from uuid import UUID, uuid4
+
+from app.backtesting.accounting import OrderSide
+from app.backtesting.domain import DomainValidationError, PositionSide, ValuationStatus
+from app.backtesting.result_models import (
+    BacktestDataChunkRecord,
+    BacktestEquityCurveRecord,
+    BacktestFillRecord,
+    BacktestMetricRecord,
+    BacktestOrderRecord,
+    BacktestPositionRecord,
+    ChunkValidationStatus,
+    DataPhase,
+    DataQualityStatus,
+    DecisionValidationStatus,
+    InstrumentDisplaySnapshot,
+    ResultOrderStatus,
+    StepPhase,
+)
+
+
+RUN_ID = uuid4()
+INSTRUMENT_ID = uuid4()
+TS = datetime(2026, 3, 1, tzinfo=timezone.utc)
+NAIVE_TS = datetime(2026, 3, 1)
+
+
+def display(**overrides) -> InstrumentDisplaySnapshot:
+    fields = {
+        "instrument_id": INSTRUMENT_ID,
+        "event_trading_code": "510300",
+        "event_name": "沪深300ETF",
+        "event_display_name": "沪深300ETF",
+    }
+    fields.update(overrides)
+    return InstrumentDisplaySnapshot(**fields)
+
+
+def order_dto(**overrides) -> BacktestOrderRecord:
+    fields = {
+        "run_id": RUN_ID,
+        "order_id": uuid4(),
+        "instrument_id": INSTRUMENT_ID,
+        "display": display(),
+        "side": OrderSide.BUY,
+        "order_type": "market",
+        "quantity": "100",
+        "status": ResultOrderStatus.FILLED,
+        "submitted_at": TS,
+        "price": "3.85",
+    }
+    fields.update(overrides)
+    return BacktestOrderRecord(**fields)
+
+
+class IdentityContractTestCase(unittest.TestCase):
+    def test_missing_or_non_uuid_instrument_identity_is_rejected(self) -> None:
+        with self.assertRaises(DomainValidationError):
+            order_dto(instrument_id=None)
+        with self.assertRaises(DomainValidationError):
+            order_dto(instrument_id="510300")
+        with self.assertRaises(DomainValidationError):
+            order_dto(run_id="run-not-a-uuid")
+
+    def test_display_snapshot_must_match_row_instrument(self) -> None:
+        with self.assertRaises(DomainValidationError):
+            order_dto(display=InstrumentDisplaySnapshot(instrument_id=uuid4()))
+
+    def test_empty_display_fields_are_still_valid(self) -> None:
+        record = order_dto(display=display(event_trading_code=None, event_name=None))
+        self.assertIsNone(record.display.event_trading_code)
+        self.assertIsNone(record.display.event_name)
+        self.assertEqual(record.instrument_id, INSTRUMENT_ID)
+
+    def test_frozen_snapshot_survives_later_renames(self) -> None:
+        snapshot = display()
+        renamed = InstrumentDisplaySnapshot(
+            instrument_id=snapshot.instrument_id,
+            event_trading_code="999999",
+            event_name="新名称",
+            event_display_name="新名称",
+        )
+        record = order_dto(display=snapshot)
+        # Writing a differently named snapshot elsewhere cannot mutate history.
+        self.assertEqual(record.display.event_name, "沪深300ETF")
+        self.assertNotEqual(record.display, renamed)
+
+
+class TypeContractTestCase(unittest.TestCase):
+    def test_binary_floats_are_rejected(self) -> None:
+        with self.assertRaises((DomainValidationError, TypeError)):
+            order_dto(price=0.1)
+        with self.assertRaises((DomainValidationError, TypeError)):
+            BacktestFillRecord(
+                run_id=RUN_ID,
+                fill_id=uuid4(),
+                order_id=uuid4(),
+                instrument_id=INSTRUMENT_ID,
+                display=display(),
+                side=OrderSide.SELL,
+                timestamp=TS,
+                price="1.0",
+                quantity="10",
+                fees=0.01,
+            )
+
+    def test_naive_datetimes_are_rejected(self) -> None:
+        with self.assertRaises(DomainValidationError):
+            order_dto(submitted_at=NAIVE_TS)
+
+    def test_nested_json_targets_reject_floats_and_freeze(self) -> None:
+        from app.backtesting.result_models import BacktestDecisionRecord
+
+        decision = BacktestDecisionRecord(
+            run_id=RUN_ID,
+            decision_id=uuid4(),
+            step_sequence=1,
+            decision_time=TS,
+            mode="target_weights",
+            validation_status=DecisionValidationStatus.ACCEPTED,
+            targets={"weights": {"etf-a": "0.6"}},
+            duration_ms="12",
+        )
+        self.assertEqual(decision.targets["weights"]["etf-a"], "0.6")
+        with self.assertRaises(DomainValidationError):
+            BacktestDecisionRecord(
+                run_id=RUN_ID,
+                decision_id=uuid4(),
+                step_sequence=1,
+                decision_time=TS,
+                mode="target_weights",
+                validation_status=DecisionValidationStatus.ACCEPTED,
+                targets={"weight": 0.6},
+            )
+
+    def test_sequence_numbers_must_be_integers(self) -> None:
+        from app.backtesting.result_models import BacktestStepRecord
+
+        with self.assertRaises(DomainValidationError):
+            BacktestStepRecord(
+                run_id=RUN_ID,
+                step_sequence="1",
+                time_start=TS,
+                time_end=TS,
+                data_cutoff_at=TS,
+                phase=StepPhase.DATA,
+                data_quality=DataQualityStatus.OK,
+            )
+        with self.assertRaises(DomainValidationError):
+            BacktestStepRecord(
+                run_id=RUN_ID,
+                step_sequence=True,
+                time_start=TS,
+                time_end=TS,
+                data_cutoff_at=TS,
+                phase=StepPhase.DATA,
+                data_quality=DataQualityStatus.OK,
+            )
+
+
+class PositionContractTestCase(unittest.TestCase):
+    def position_dto(self, **overrides) -> BacktestPositionRecord:
+        fields = {
+            "run_id": RUN_ID,
+            "as_of": TS,
+            "instrument_id": INSTRUMENT_ID,
+            "display": display(),
+            "side": PositionSide.LONG,
+            "quantity": "100",
+            "available_quantity": "100",
+            "average_price": "3.80",
+            "mark_price": "3.90",
+            "realized_pnl": "0",
+            "unrealized_pnl": "10",
+        }
+        fields.update(overrides)
+        return BacktestPositionRecord(**fields)
+
+    def test_zero_quantity_position_is_rejected(self) -> None:
+        with self.assertRaises(DomainValidationError):
+            self.position_dto(quantity="0")
+
+    def test_negative_quantity_is_rejected(self) -> None:
+        with self.assertRaises(DomainValidationError):
+            self.position_dto(quantity="-5")
+
+    def test_available_quantity_cannot_exceed_quantity(self) -> None:
+        with self.assertRaises(DomainValidationError):
+            self.position_dto(quantity="10", available_quantity="11")
+
+
+class EquityAndMetricContractTestCase(unittest.TestCase):
+    def test_blocked_points_cannot_carry_equity_values(self) -> None:
+        with self.assertRaises(DomainValidationError):
+            BacktestEquityCurveRecord(
+                run_id=RUN_ID,
+                sequence=1,
+                as_of=TS,
+                valuation_status=ValuationStatus.BLOCKED,
+                cash="100",
+                equity="100",
+                cumulative_fees="0",
+            )
+
+    def test_valid_points_require_equity_fields(self) -> None:
+        with self.assertRaises(DomainValidationError):
+            BacktestEquityCurveRecord(
+                run_id=RUN_ID,
+                sequence=1,
+                as_of=TS,
+                valuation_status=ValuationStatus.COMPLETE,
+                cash="100",
+                cumulative_fees="0",
+            )
+
+    def test_metrics_need_value_xor_reason(self) -> None:
+        unavailable = BacktestMetricRecord(
+            run_id=RUN_ID,
+            metric_key="sharpe_ratio",
+            formula_version="v1",
+            value=None,
+            unavailable_reason="样本数不足",
+        )
+        self.assertIsNone(unavailable.value)
+        with self.assertRaises(DomainValidationError):
+            BacktestMetricRecord(
+                run_id=RUN_ID,
+                metric_key="sharpe_ratio",
+                formula_version="v1",
+                value=None,
+            )
+        with self.assertRaises(DomainValidationError):
+            BacktestMetricRecord(
+                run_id=RUN_ID,
+                metric_key="sharpe_ratio",
+                formula_version="v1",
+                value="1.5",
+                unavailable_reason="样本数不足",
+            )
+
+
+class GeneralityContractTestCase(unittest.TestCase):
+    def test_fictional_asset_uses_the_same_dtos(self) -> None:
+        fictional = InstrumentDisplaySnapshot(
+            instrument_id=uuid4(),
+            event_trading_code=None,
+            event_name="虚构资产",
+        )
+        record = order_dto(
+            instrument_id=fictional.instrument_id,
+            display=fictional,
+        )
+        self.assertIsInstance(record, BacktestOrderRecord)
+        self.assertEqual(record.display.event_name, "虚构资产")
+
+    def test_result_models_expose_no_etf_specific_fields(self) -> None:
+        import dataclasses
+        import inspect
+
+        import app.backtesting.result_models as module
+        import app.backtesting.result_records as records_module
+
+        etf_terms = ("ts_code", "fund_type", "purchase_status", "redemption_status")
+        dto_field_names: set[str] = set()
+        for name, member in inspect.getmembers(module, dataclasses.is_dataclass):
+            if isinstance(member, type):
+                dto_field_names.update(field.name for field in dataclasses.fields(member))
+        orm_column_names: set[str] = set()
+        for name, member in inspect.getmembers(records_module, inspect.isclass):
+            # Only tables owned by this module; Base.metadata is shared with
+            # unrelated models once the whole app has been imported.
+            if issubclass(member, records_module.Base) and hasattr(member, "__tablename__"):
+                orm_column_names.update(member.__table__.columns.keys())
+        for term in etf_terms:
+            self.assertNotIn(term, dto_field_names, f"result DTOs expose ETF field {term}")
+            self.assertNotIn(term, orm_column_names, f"result tables expose ETF column {term}")
+
+
+class ChunkContractTestCase(unittest.TestCase):
+    def chunk_dto(self, **overrides) -> BacktestDataChunkRecord:
+        fields = {
+            "run_id": RUN_ID,
+            "phase": DataPhase.SESSION,
+            "chunk_sequence": 0,
+            "time_start": TS,
+            "time_end": TS,
+            "chunk_strategy_version": "bounded_blocks@1",
+            "token_digest": "sha256:abc",
+            "validation_status": ChunkValidationStatus.PASSED,
+        }
+        fields.update(overrides)
+        return BacktestDataChunkRecord(**fields)
+
+    def test_failed_chunks_require_reason_and_passed_forbid_it(self) -> None:
+        failed = self.chunk_dto(
+            validation_status=ChunkValidationStatus.FAILED,
+            failure_reason="校验和不一致",
+        )
+        self.assertEqual(failed.failure_reason, "校验和不一致")
+        with self.assertRaises(DomainValidationError):
+            self.chunk_dto(validation_status=ChunkValidationStatus.FAILED)
+        with self.assertRaises(DomainValidationError):
+            self.chunk_dto(failure_reason="多余的原因")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/backend/tests/test_backtesting_result_models.py
+++ b/backend/tests/test_backtesting_result_models.py
@@ -301,6 +301,22 @@ class GeneralityContractTestCase(unittest.TestCase):
                 f"{table_name} is invisible to Alembic autogenerate",
             )
 
+    def test_equity_cash_column_is_not_nullable(self) -> None:
+        from sqlalchemy.dialects import postgresql
+        from sqlalchemy.schema import CreateTable
+
+        from app.backtesting.result_records import BacktestEquityCurveRecord
+
+        ddl = str(
+            CreateTable(BacktestEquityCurveRecord.__table__).compile(
+                dialect=postgresql.dialect()
+            )
+        )
+        self.assertRegex(
+            ddl,
+            r"cash NUMERIC\(38, 18\) NOT NULL",
+        )
+
     def test_fictional_asset_uses_the_same_dtos(self) -> None:
         fictional = InstrumentDisplaySnapshot(
             instrument_id=uuid4(),

--- a/backend/tests/test_backtesting_result_models.py
+++ b/backend/tests/test_backtesting_result_models.py
@@ -22,6 +22,7 @@ from app.backtesting.result_models import (
     ResultOrderStatus,
     StepPhase,
 )
+from app.backtesting.result_records import RESULT_TABLE_NAMES
 
 
 RUN_ID = uuid4()
@@ -195,28 +196,58 @@ class PositionContractTestCase(unittest.TestCase):
 
 
 class EquityAndMetricContractTestCase(unittest.TestCase):
+    def complete_equity(self, **overrides) -> BacktestEquityCurveRecord:
+        fields = dict(
+            run_id=RUN_ID,
+            sequence=1,
+            as_of=TS,
+            valuation_status=ValuationStatus.COMPLETE,
+            cash="100",
+            market_value="50",
+            equity="150",
+            period_return="0.05",
+            total_pnl="50",
+            cumulative_return="0.5",
+            drawdown="-0.1",
+            cumulative_fees="3",
+        )
+        fields.update(overrides)
+        return BacktestEquityCurveRecord(**fields)
+
     def test_blocked_points_cannot_carry_equity_values(self) -> None:
         with self.assertRaises(DomainValidationError):
-            BacktestEquityCurveRecord(
-                run_id=RUN_ID,
-                sequence=1,
-                as_of=TS,
+            self.complete_equity(valuation_status=ValuationStatus.BLOCKED)
+
+    def test_blocked_points_still_require_cash_and_reason(self) -> None:
+        with self.assertRaises(DomainValidationError):
+            self.complete_equity(
+                valuation_status=ValuationStatus.BLOCKED, cash=None
+            )
+        with self.assertRaises(DomainValidationError):
+            self.complete_equity(
                 valuation_status=ValuationStatus.BLOCKED,
-                cash="100",
-                equity="100",
-                cumulative_fees="0",
+                market_value=None,
+                equity=None,
+                period_return=None,
+                total_pnl=None,
+                cumulative_return=None,
+                drawdown=None,
+                valuation_reason=None,
             )
 
-    def test_valid_points_require_equity_fields(self) -> None:
-        with self.assertRaises(DomainValidationError):
-            BacktestEquityCurveRecord(
-                run_id=RUN_ID,
-                sequence=1,
-                as_of=TS,
-                valuation_status=ValuationStatus.COMPLETE,
-                cash="100",
-                cumulative_fees="0",
-            )
+    def test_valid_points_require_all_valuation_fields(self) -> None:
+        for missing in (
+            "cash",
+            "market_value",
+            "equity",
+            "period_return",
+            "total_pnl",
+            "cumulative_return",
+            "drawdown",
+        ):
+            fields = {missing: None}
+            with self.assertRaises(DomainValidationError, msg=missing):
+                self.complete_equity(**fields)
 
     def test_metrics_need_value_xor_reason(self) -> None:
         unavailable = BacktestMetricRecord(
@@ -245,6 +276,19 @@ class EquityAndMetricContractTestCase(unittest.TestCase):
 
 
 class GeneralityContractTestCase(unittest.TestCase):
+    def test_result_tables_are_registered_in_alembic_metadata(self) -> None:
+        # Importing app.models is what the Alembic env does; autogenerate can
+        # only discover the result tables through that import chain.
+        import app.models  # noqa: F401
+        from app.db.base import Base as MetadataBase
+
+        for table_name in RESULT_TABLE_NAMES:
+            self.assertIn(
+                table_name,
+                MetadataBase.metadata.tables,
+                f"{table_name} is invisible to Alembic autogenerate",
+            )
+
     def test_fictional_asset_uses_the_same_dtos(self) -> None:
         fictional = InstrumentDisplaySnapshot(
             instrument_id=uuid4(),

--- a/backend/tests/test_backtesting_result_models.py
+++ b/backend/tests/test_backtesting_result_models.py
@@ -234,6 +234,18 @@ class EquityAndMetricContractTestCase(unittest.TestCase):
                 drawdown=None,
                 valuation_reason=None,
             )
+        # Blank text normalizes to None and must not pose as a reason.
+        with self.assertRaises(DomainValidationError):
+            self.complete_equity(
+                valuation_status=ValuationStatus.BLOCKED,
+                market_value=None,
+                equity=None,
+                period_return=None,
+                total_pnl=None,
+                cumulative_return=None,
+                drawdown=None,
+                valuation_reason="   ",
+            )
 
     def test_valid_points_require_all_valuation_fields(self) -> None:
         for missing in (

--- a/backend/tests/test_backtesting_result_repository.py
+++ b/backend/tests/test_backtesting_result_repository.py
@@ -39,6 +39,7 @@ from app.backtesting.result_repository import (
 
 
 UTC = timezone.utc
+SIGNING_KEY = "unit-test-signing-key"
 
 
 def ts(hour: int, minute: int = 0) -> datetime:
@@ -99,7 +100,9 @@ class ResultRepositoryTestCase(unittest.TestCase):
         ]
         Base.metadata.create_all(self.engine, tables=result_tables)
         self.session = Session(self.engine)
-        self.repo = BacktestResultRepository(self.session)
+        self.repo = BacktestResultRepository(
+            self.session, cursor_signing_key=SIGNING_KEY
+        )
         self.run_id = uuid4()
 
     def tearDown(self) -> None:
@@ -158,6 +161,24 @@ class WriteContractTestCase(ResultRepositoryTestCase):
         order = make_order(self.run_id)
         with self.assertRaises(ResultRecordConflictError):
             self.repo.append("orders", order, order)
+
+    def test_same_identity_across_different_runs_is_allowed(self) -> None:
+        shared_order_id = uuid4()
+        other_run = uuid4()
+        self.repo.append(
+            "orders",
+            make_order(self.run_id, order_id=shared_order_id),
+            make_order(other_run, order_id=shared_order_id),
+        )
+        first = self.repo.read_page("orders", run_id=self.run_id)
+        second = self.repo.read_page("orders", run_id=other_run)
+        self.assertEqual([row.order_id for row in first.items], [shared_order_id])
+        self.assertEqual([row.order_id for row in second.items], [shared_order_id])
+
+    def test_missing_signing_key_is_rejected(self) -> None:
+        for bad in ("", "   "):
+            with self.assertRaises(ValueError):
+                BacktestResultRepository(self.session, cursor_signing_key=bad)
 
     def test_positions_unique_per_valuation_point_and_side(self) -> None:
         as_of = ts(15)
@@ -514,6 +535,10 @@ class FilterContractTestCase(ResultRepositoryTestCase):
                 cash="100",
                 market_value="50",
                 equity="150",
+                # Binary-float-exact values so the SQLite test dialect
+                # round-trips them without precision artifacts.
+                period_return="0.5",
+                total_pnl="50",
                 cumulative_return="0.5",
                 drawdown="-0.1",
                 cumulative_fees="3",
@@ -530,6 +555,33 @@ class FilterContractTestCase(ResultRepositoryTestCase):
             for row in page_rows
         ]
         self.assertEqual(normalized, [(ts(9), 0), (ts(10), 1), (ts(10), 2)])
+        # The full valuation detail, including period return and total PnL,
+        # survives the persistence round trip.
+        self.assertEqual(
+            (page_rows[0].period_return, page_rows[0].total_pnl),
+            (Decimal("0.5"), Decimal("50")),
+        )
+
+    def test_blocked_points_require_cash_and_reason(self) -> None:
+        base = dict(
+            run_id=self.run_id,
+            sequence=0,
+            as_of=ts(9),
+            valuation_status=ValuationStatus.BLOCKED,
+            cumulative_fees="1",
+        )
+        with self.assertRaises(Exception):
+            BacktestEquityCurveRecord(**base, cash=None, valuation_reason=None)
+        with self.assertRaises(Exception):
+            BacktestEquityCurveRecord(
+                **base, cash="100", valuation_reason=None
+            )
+        blocked = BacktestEquityCurveRecord(
+            **base, cash="100", valuation_reason="行情数据缺失"
+        )
+        self.assertIsNone(blocked.equity)
+        self.assertIsNone(blocked.period_return)
+        self.assertIsNone(blocked.total_pnl)
 
 
 if __name__ == "__main__":

--- a/backend/tests/test_backtesting_result_repository.py
+++ b/backend/tests/test_backtesting_result_repository.py
@@ -16,7 +16,10 @@ from sqlalchemy.orm import Session
 
 from app.backtesting.accounting import OrderSide
 from app.backtesting.domain import PositionSide, ValuationStatus
-from app.backtesting.pagination import CursorQueryMismatchError
+from app.backtesting.pagination import (
+    CursorQueryMismatchError,
+    parse_cursor,
+)
 from app.backtesting.result_models import (
     BacktestDataChunkRecord,
     BacktestDataPreflightRecord,
@@ -381,6 +384,66 @@ class PaginationContractTestCase(ResultRepositoryTestCase):
             self.repo.read_page(
                 "orders", run_id=uuid4(), limit=10, cursor=page.next_cursor
             )
+
+    def test_multi_column_bound_is_the_true_lexicographic_maximum(self) -> None:
+        """Per-column maxima must not be spliced into a synthetic bound.
+
+        Rows: R1=(t1, high-id), R2=(t2, low-id).  The lexicographically
+        largest key is (t2, low-id) because time dominates; independently
+        maximized columns would instead fabricate (t2, high-id), which would
+        wrongly admit a later row inserted between the two ids.
+        """
+
+        t1 = ts(9)
+        t2 = ts(10)
+        high_id = UUID(int=0xDEADBEEF)
+        low_id = UUID(int=0x10000000)
+        mid_id = UUID(int=(0xDEADBEEF + 0x10000000) // 2)
+        assert low_id < mid_id < high_id
+
+        r1 = make_order(self.run_id, submitted_at=t1, order_id=high_id)
+        r2 = make_order(self.run_id, submitted_at=t2, order_id=low_id)
+        self.repo.append("orders", r1, r2)
+
+        first_page = self.repo.read_page("orders", run_id=self.run_id, limit=1)
+        self.assertEqual([row.order_id for row in first_page.items], [high_id])
+        self.assertTrue(first_page.has_more)
+
+        # The cursor's bound must be exactly (t2, low-id) — the top row.
+        parsed = parse_cursor(
+            first_page.next_cursor,
+            signing_key=SIGNING_KEY,
+            expected_query_digest=None,
+            key_kinds=("ts", "uuid"),
+            upper_bound_columns={"submitted_at": "ts", "order_id": "uuid"},
+        )
+        bound_time = parsed.query_upper_bound["submitted_at"]
+        if bound_time.tzinfo is None:
+            bound_time = bound_time.replace(tzinfo=UTC)
+        self.assertEqual(
+            (bound_time, parsed.query_upper_bound["order_id"]),
+            (t2.astimezone(timezone.utc), low_id),
+        )
+
+        # A row inserted after pagination began with (t2, mid_id): it sorts
+        # above the correct bound (t2, low-id) and must stay invisible to
+        # this cursor walk.  A fabricated per-column bound (t2, high-id)
+        # would have admitted it.
+        late = make_order(self.run_id, submitted_at=t2, order_id=mid_id)
+        self.repo.append("orders", late)
+
+        collected = list(first_page.items)
+        cursor = first_page.next_cursor
+        while cursor is not None:
+            # The limit participates in the query digest, so the walk must
+            # keep the original page size.
+            page = self.repo.read_page(
+                "orders", run_id=self.run_id, limit=1, cursor=cursor
+            )
+            collected.extend(page.items)
+            cursor = page.next_cursor
+        seen_ids = {row.order_id for row in collected}
+        self.assertEqual(seen_ids, {high_id, low_id})
 
     def test_appended_rows_stay_outside_an_existing_cursor(self) -> None:
         original = self.seed_orders(30)

--- a/backend/tests/test_backtesting_result_repository.py
+++ b/backend/tests/test_backtesting_result_repository.py
@@ -1,0 +1,536 @@
+"""Repository tests for result writes and cursor-paginated reads.
+
+The tests run against an in-memory SQLite database so keyset pagination,
+uniqueness constraints, and snapshot upper bounds are exercised through a
+real SQL engine.  PostgreSQL remains the production dialect; the JSON
+columns carry a SQLite variant purely for this test suite.
+"""
+
+import unittest
+from datetime import datetime, timedelta, timezone
+from decimal import Decimal
+from uuid import UUID, uuid4
+
+from sqlalchemy import create_engine
+from sqlalchemy.orm import Session
+
+from app.backtesting.accounting import OrderSide
+from app.backtesting.domain import PositionSide, ValuationStatus
+from app.backtesting.pagination import CursorQueryMismatchError
+from app.backtesting.result_models import (
+    BacktestDataChunkRecord,
+    BacktestDataPreflightRecord,
+    BacktestEquityCurveRecord,
+    BacktestFillRecord,
+    BacktestMetricRecord,
+    BacktestOrderRecord,
+    BacktestPositionRecord,
+    ChunkValidationStatus,
+    DataPhase,
+    InstrumentDisplaySnapshot,
+    ResultOrderStatus,
+)
+from app.backtesting.result_records import Base
+from app.backtesting.result_repository import (
+    BacktestResultRepository,
+    ResultFilterError,
+    ResultRecordConflictError,
+)
+
+
+UTC = timezone.utc
+
+
+def ts(hour: int, minute: int = 0) -> datetime:
+    return datetime(2026, 6, 1, hour, minute, tzinfo=UTC)
+
+
+def make_order(
+    run_id,
+    *,
+    submitted_at=None,
+    instrument_id=None,
+    side=OrderSide.BUY,
+    status=ResultOrderStatus.FILLED,
+    order_id=None,
+) -> BacktestOrderRecord:
+    instrument_id = instrument_id or uuid4()
+    return BacktestOrderRecord(
+        run_id=run_id,
+        order_id=order_id or uuid4(),
+        instrument_id=instrument_id,
+        display=InstrumentDisplaySnapshot(
+            instrument_id=instrument_id,
+            event_trading_code="510300",
+            event_name="沪深300ETF",
+            event_display_name="沪深300ETF",
+        ),
+        side=side,
+        order_type="market",
+        quantity="100",
+        status=status,
+        submitted_at=submitted_at or ts(9),
+        price="3.85",
+    )
+
+
+RESULT_TABLE_NAMES = [
+    "backtest_steps",
+    "backtest_decisions",
+    "backtest_orders",
+    "backtest_order_updates",
+    "backtest_fills",
+    "backtest_positions",
+    "backtest_equity_curve",
+    "backtest_metrics",
+    "backtest_data_preflight",
+    "backtest_data_chunks",
+]
+
+
+class ResultRepositoryTestCase(unittest.TestCase):
+    def setUp(self) -> None:
+        self.engine = create_engine("sqlite:///:memory:")
+        # Exact names: the shared Base.metadata also holds unrelated
+        # backtest_* tables (e.g. account profiles with JSONB columns that
+        # the SQLite test dialect cannot compile).
+        result_tables = [
+            Base.metadata.tables[name] for name in RESULT_TABLE_NAMES
+        ]
+        Base.metadata.create_all(self.engine, tables=result_tables)
+        self.session = Session(self.engine)
+        self.repo = BacktestResultRepository(self.session)
+        self.run_id = uuid4()
+
+    def tearDown(self) -> None:
+        self.session.close()
+        self.engine.dispose()
+
+    # -- helpers -----------------------------------------------------------
+
+    def seed_orders(self, count: int, *, start_hour: int = 9) -> list[UUID]:
+        orders = [
+            make_order(self.run_id, submitted_at=ts(start_hour) + timedelta(minutes=index))
+            for index in range(count)
+        ]
+        self.repo.append("orders", *orders)
+        return [order.order_id for order in orders]
+
+    def walk_pages(self, kind: str, *, limit: int, **filters):
+        """Collect a full cursor walk and return (ids, page_count)."""
+
+        collected = []
+        cursor = None
+        pages = 0
+        while True:
+            page = self.repo.read_page(
+                kind, run_id=self.run_id, limit=limit, cursor=cursor, **filters
+            )
+            pages += 1
+            collected.extend(page.items)
+            if not page.has_more:
+                self.assertIsNone(page.next_cursor)
+                break
+            cursor = page.next_cursor
+            self.assertIsNotNone(cursor)
+        return collected, pages
+
+
+class WriteContractTestCase(ResultRepositoryTestCase):
+    def test_round_trips_orders_and_preserves_display_fields(self) -> None:
+        order_id = self.seed_orders(1)[0]
+        page = self.repo.read_page("orders", run_id=self.run_id)
+        self.assertEqual(len(page.items), 1)
+        row = page.items[0]
+        self.assertEqual(row.order_id, order_id)
+        self.assertEqual(row.event_trading_code, "510300")
+        self.assertEqual(row.event_name, "沪深300ETF")
+        self.assertEqual(row.status, "filled")
+
+    def test_duplicate_business_key_across_batches_is_rejected(self) -> None:
+        order = make_order(self.run_id)
+        self.repo.append("orders", order)
+        duplicate = make_order(self.run_id, order_id=order.order_id)
+        with self.assertRaises(ResultRecordConflictError):
+            self.repo.append("orders", duplicate)
+
+    def test_duplicate_identity_within_one_batch_is_rejected(self) -> None:
+        order = make_order(self.run_id)
+        with self.assertRaises(ResultRecordConflictError):
+            self.repo.append("orders", order, order)
+
+    def test_positions_unique_per_valuation_point_and_side(self) -> None:
+        as_of = ts(15)
+        instrument = uuid4()
+        snapshot = InstrumentDisplaySnapshot(instrument_id=instrument)
+        position = BacktestPositionRecord(
+            run_id=self.run_id,
+            as_of=as_of,
+            instrument_id=instrument,
+            display=snapshot,
+            side=PositionSide.LONG,
+            quantity="10",
+            available_quantity="10",
+            average_price="2",
+            realized_pnl="0",
+            unrealized_pnl="1",
+        )
+        duplicate = BacktestPositionRecord(
+            run_id=self.run_id,
+            as_of=as_of,
+            instrument_id=instrument,
+            display=snapshot,
+            side=PositionSide.LONG,
+            quantity="10",
+            available_quantity="10",
+            average_price="2",
+            realized_pnl="0",
+            unrealized_pnl="1",
+        )
+        self.repo.append("positions", position)
+        with self.assertRaises(ResultRecordConflictError):
+            self.repo.append("positions", duplicate)
+
+    def test_wrong_dto_type_for_kind_is_rejected(self) -> None:
+        with self.assertRaises(ValueError):
+            self.repo.append("orders", BacktestMetricRecord(
+                run_id=self.run_id,
+                metric_key="k",
+                formula_version="v1",
+                value="1",
+            ))
+
+    def test_unknown_kind_is_rejected(self) -> None:
+        with self.assertRaises(ValueError):
+            self.repo.append("no_such_kind")
+
+    def test_metrics_keep_unavailable_reason_instead_of_zero(self) -> None:
+        self.repo.append(
+            "metrics",
+            BacktestMetricRecord(
+                run_id=self.run_id,
+                metric_key="sharpe_ratio",
+                formula_version="v1",
+                value=None,
+                unavailable_reason="样本数不足",
+                sample_count=3,
+            ),
+        )
+        row = self.repo.read_page("metrics", run_id=self.run_id).items[0]
+        self.assertIsNone(row.value)
+        self.assertEqual(row.unavailable_reason, "样本数不足")
+
+    def test_preflight_unique_per_phase(self) -> None:
+        admission = BacktestDataPreflightRecord(
+            run_id=self.run_id,
+            phase=DataPhase.ADMISSION,
+            status="passed",
+            report_hash="hash-a",
+        )
+        session_report = BacktestDataPreflightRecord(
+            run_id=self.run_id,
+            phase=DataPhase.SESSION,
+            status="passed",
+            report_hash="hash-b",
+        )
+        self.repo.append("data_preflight", admission, session_report)
+        with self.assertRaises(ResultRecordConflictError):
+            self.repo.append(
+                "data_preflight",
+                BacktestDataPreflightRecord(
+                    run_id=self.run_id,
+                    phase=DataPhase.ADMISSION,
+                    status="failed",
+                    report_hash="hash-c",
+                ),
+            )
+
+    def test_data_chunks_sort_by_phase_then_sequence(self) -> None:
+        self.repo.append(
+            "data_chunks",
+            BacktestDataChunkRecord(
+                run_id=self.run_id,
+                phase=DataPhase.SESSION,
+                chunk_sequence=1,
+                time_start=ts(10),
+                time_end=ts(11),
+                chunk_strategy_version="bounded_blocks@1",
+                token_digest="digest-1",
+                validation_status=ChunkValidationStatus.PASSED,
+            ),
+            BacktestDataChunkRecord(
+                run_id=self.run_id,
+                phase=DataPhase.ADMISSION,
+                chunk_sequence=5,
+                time_start=ts(9),
+                time_end=ts(10),
+                chunk_strategy_version="bounded_blocks@1",
+                token_digest="digest-0",
+                validation_status=ChunkValidationStatus.FAILED,
+                failure_reason="校验失败",
+            ),
+        )
+        rows, _ = self.walk_pages("data_chunks", limit=10)
+        self.assertEqual(
+            [(row.phase, row.chunk_sequence) for row in rows],
+            [("admission", 5), ("session", 1)],
+        )
+
+
+class PaginationContractTestCase(ResultRepositoryTestCase):
+    def test_empty_run_returns_empty_envelope(self) -> None:
+        page = self.repo.read_page("orders", run_id=self.run_id)
+        self.assertEqual(page.items, ())
+        self.assertIsNone(page.next_cursor)
+        self.assertFalse(page.has_more)
+
+    def test_invalid_limit_is_rejected(self) -> None:
+        for bad in (0, 501, -3):
+            with self.assertRaises(ValueError):
+                self.repo.read_page("orders", run_id=self.run_id, limit=bad)
+
+    def test_multi_page_walk_is_complete_ordered_and_duplicate_free(self) -> None:
+        expected = self.seed_orders(25)
+        collected, pages = self.walk_pages("orders", limit=10)
+        self.assertEqual([row.order_id for row in collected], expected)
+        self.assertEqual(pages, 3)
+        times = [row.submitted_at for row in collected]
+        self.assertEqual(times, sorted(times))
+
+    def test_identical_queries_produce_identical_cursors(self) -> None:
+        self.seed_orders(15)
+        first = self.repo.read_page("orders", run_id=self.run_id, limit=10)
+        second = self.repo.read_page("orders", run_id=self.run_id, limit=10)
+        self.assertEqual(first.next_cursor, second.next_cursor)
+
+    def test_equal_timestamps_are_disambiguated_by_order_id(self) -> None:
+        same_time = ts(9, 30)
+        order_a = make_order(self.run_id, submitted_at=same_time)
+        order_b = make_order(self.run_id, submitted_at=same_time)
+        ordered_pair = sorted([order_a, order_b], key=lambda o: o.order_id)
+        self.repo.append("orders", *ordered_pair)
+
+        page_one = self.repo.read_page("orders", run_id=self.run_id, limit=1)
+        self.assertEqual(page_one.items[0].order_id, ordered_pair[0].order_id)
+        self.assertTrue(page_one.has_more)
+        page_two = self.repo.read_page(
+            "orders", run_id=self.run_id, limit=1, cursor=page_one.next_cursor
+        )
+        self.assertEqual(page_two.items[0].order_id, ordered_pair[1].order_id)
+        self.assertFalse(page_two.has_more)
+
+    def test_tampered_cursor_is_rejected(self) -> None:
+        self.seed_orders(15)
+        page = self.repo.read_page("orders", run_id=self.run_id, limit=10)
+        token = page.next_cursor
+        tampered = (
+            token[:-2] + ("AA" if not token.endswith("AA") else "BB")
+        )
+        with self.assertRaises(ValueError):
+            self.repo.read_page(
+                "orders", run_id=self.run_id, limit=10, cursor=tampered
+            )
+        self.assertTrue(token)  # original token remains usable
+        self.repo.read_page("orders", run_id=self.run_id, limit=10, cursor=token)
+
+    def test_limit_change_invalidates_old_cursor(self) -> None:
+        self.seed_orders(15)
+        page = self.repo.read_page("orders", run_id=self.run_id, limit=10)
+        with self.assertRaises(CursorQueryMismatchError):
+            self.repo.read_page(
+                "orders", run_id=self.run_id, limit=5, cursor=page.next_cursor
+            )
+
+    def test_filter_change_invalidates_old_cursor(self) -> None:
+        self.seed_orders(15)
+        page = self.repo.read_page("orders", run_id=self.run_id, limit=10)
+        with self.assertRaises(CursorQueryMismatchError):
+            self.repo.read_page(
+                "orders",
+                run_id=self.run_id,
+                limit=10,
+                cursor=page.next_cursor,
+                side="sell",
+            )
+
+    def test_other_run_invalidates_old_cursor(self) -> None:
+        self.seed_orders(15)
+        page = self.repo.read_page("orders", run_id=self.run_id, limit=10)
+        with self.assertRaises(CursorQueryMismatchError):
+            self.repo.read_page(
+                "orders", run_id=uuid4(), limit=10, cursor=page.next_cursor
+            )
+
+    def test_appended_rows_stay_outside_an_existing_cursor(self) -> None:
+        original = self.seed_orders(30)
+        first_page = self.repo.read_page("orders", run_id=self.run_id, limit=10)
+
+        # Simulate a running run appending results after pagination began.
+        late_orders = [
+            make_order(self.run_id, submitted_at=ts(23) + timedelta(minutes=index))
+            for index in range(10)
+        ]
+        self.repo.append("orders", *late_orders)
+
+        collected = list(first_page.items)
+        cursor = first_page.next_cursor
+        while cursor is not None:
+            page = self.repo.read_page(
+                "orders", run_id=self.run_id, limit=10, cursor=cursor
+            )
+            collected.extend(page.items)
+            cursor = page.next_cursor
+
+        seen_ids = [row.order_id for row in collected]
+        self.assertEqual(len(seen_ids), len(set(seen_ids)))
+        self.assertEqual(set(seen_ids), set(original))
+        late_ids = {order.order_id for order in late_orders}
+        self.assertEqual(set(seen_ids) & late_ids, set())
+
+    def test_decisions_tie_break_by_decision_id(self) -> None:
+        from app.backtesting.result_models import (
+            BacktestDecisionRecord,
+            DecisionValidationStatus,
+        )
+
+        decision_time = ts(10)
+        first = BacktestDecisionRecord(
+            run_id=self.run_id,
+            decision_id=uuid4(),
+            step_sequence=1,
+            decision_time=decision_time,
+            mode="hold",
+            validation_status=DecisionValidationStatus.ACCEPTED,
+        )
+        second = BacktestDecisionRecord(
+            run_id=self.run_id,
+            decision_id=uuid4(),
+            step_sequence=1,
+            decision_time=decision_time,
+            mode="hold",
+            validation_status=DecisionValidationStatus.ACCEPTED,
+        )
+        pair = sorted([first, second], key=lambda d: d.decision_id)
+        self.repo.append("decisions", *pair)
+        rows, _ = self.walk_pages("decisions", limit=1)
+        self.assertEqual([row.decision_id for row in rows], [d.decision_id for d in pair])
+
+
+class FilterContractTestCase(ResultRepositoryTestCase):
+    def test_instrument_filter_uses_identity_only(self) -> None:
+        instrument_a = uuid4()
+        instrument_b = uuid4()
+        orders = [
+            make_order(self.run_id, instrument_id=instrument_a),
+            make_order(self.run_id, instrument_id=instrument_b),
+        ]
+        self.repo.append("orders", *orders)
+        page = self.repo.read_page(
+            "orders", run_id=self.run_id, instrument_id=instrument_b
+        )
+        self.assertEqual(len(page.items), 1)
+        self.assertEqual(page.items[0].instrument_id, instrument_b)
+
+    def test_time_bounds_are_inclusive(self) -> None:
+        self.seed_orders(5)  # 09:00 .. 09:04
+        page = self.repo.read_page(
+            "orders",
+            run_id=self.run_id,
+            start_time=ts(9, 1),
+            end_time=ts(9, 3),
+        )
+        self.assertEqual(len(page.items), 3)
+
+    def test_naive_time_bounds_are_rejected(self) -> None:
+        with self.assertRaises(ResultFilterError):
+            self.repo.read_page(
+                "orders",
+                run_id=self.run_id,
+                start_time=datetime(2026, 6, 1, 9, 0),
+            )
+
+    def test_enum_filters_on_orders(self) -> None:
+        buy = make_order(self.run_id, side=OrderSide.BUY)
+        sell = make_order(self.run_id, side=OrderSide.SELL)
+        rejected = make_order(
+            self.run_id, status=ResultOrderStatus.REJECTED
+        )
+        self.repo.append("orders", buy, sell, rejected)
+        sells = self.repo.read_page(
+            "orders", run_id=self.run_id, side="sell"
+        )
+        self.assertEqual([row.order_id for row in sells.items], [sell.order_id])
+        rejected_page = self.repo.read_page(
+            "orders", run_id=self.run_id, status="rejected"
+        )
+        self.assertEqual(
+            [row.order_id for row in rejected_page.items], [rejected.order_id]
+        )
+
+    def test_unsupported_filter_is_rejected(self) -> None:
+        with self.assertRaises(ResultFilterError):
+            self.repo.read_page("metrics", run_id=self.run_id, side="buy")
+
+    def test_positions_return_raw_non_zero_snapshots(self) -> None:
+        as_of_one = ts(15)
+        as_of_two = ts(16)
+        instrument = uuid4()
+        rows = [
+            BacktestPositionRecord(
+                run_id=self.run_id,
+                as_of=as_of,
+                instrument_id=instrument,
+                display=InstrumentDisplaySnapshot(instrument_id=instrument),
+                side=PositionSide.LONG,
+                quantity=quantity,
+                available_quantity=quantity,
+                average_price="2",
+                realized_pnl="0",
+                unrealized_pnl="1",
+            )
+            for as_of, quantity in ((as_of_one, "10"), (as_of_two, "8"))
+        ]
+        self.repo.append("positions", *rows)
+        page = self.repo.read_page(
+            "positions", run_id=self.run_id, instrument_id=instrument
+        )
+        # Both raw valuation snapshots are returned; nothing collapses to the
+        # latest row, and zero rows never exist.  (SQLite returns naive
+        # datetimes, so comparisons normalize back to UTC.)
+        returned_times = [
+            row.as_of.replace(tzinfo=UTC) if row.as_of.tzinfo is None else row.as_of
+            for row in page.items
+        ]
+        self.assertEqual(returned_times, [as_of_one, as_of_two])
+        self.assertEqual([row.quantity for row in page.items], [Decimal("10"), Decimal("8")])
+
+    def test_equity_curve_sort_key_uses_time_then_sequence(self) -> None:
+        rows = [
+            BacktestEquityCurveRecord(
+                run_id=self.run_id,
+                sequence=sequence,
+                as_of=as_of,
+                valuation_status=ValuationStatus.COMPLETE,
+                cash="100",
+                market_value="50",
+                equity="150",
+                cumulative_return="0.5",
+                drawdown="-0.1",
+                cumulative_fees="3",
+            )
+            for sequence, as_of in ((0, ts(9)), (1, ts(10)), (2, ts(10)))
+        ]
+        self.repo.append("equity_curve", *rows)
+        page_rows, _ = self.walk_pages("equity_curve", limit=2)
+        normalized = [
+            (
+                row.as_of.replace(tzinfo=UTC) if row.as_of.tzinfo is None else row.as_of,
+                row.sequence,
+            )
+            for row in page_rows
+        ]
+        self.assertEqual(normalized, [(ts(9), 0), (ts(10), 1), (ts(10), 2)])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/backend/tests/test_config.py
+++ b/backend/tests/test_config.py
@@ -8,6 +8,7 @@ from app.core.config import Settings
 
 
 API_TOKEN = "a" * 64
+CURSOR_SIGNING_KEY = "b" * 64
 
 
 class SettingsTestCase(unittest.TestCase):
@@ -15,6 +16,7 @@ class SettingsTestCase(unittest.TestCase):
         with patch.dict(os.environ, {}, clear=True):
             settings = Settings(
                 api_token=API_TOKEN,
+                cursor_signing_key=CURSOR_SIGNING_KEY,
                 database_password="test-secret",
                 _env_file=None,
             )
@@ -25,6 +27,9 @@ class SettingsTestCase(unittest.TestCase):
         self.assertEqual(str(settings.server_host), "127.0.0.1")
         self.assertEqual(settings.server_port, 8000)
         self.assertEqual(settings.api_token.get_secret_value(), API_TOKEN)
+        self.assertEqual(
+            settings.cursor_signing_key.get_secret_value(), CURSOR_SIGNING_KEY
+        )
         self.assertEqual(settings.log_dir.name, "logs")
         self.assertEqual(settings.log_level, "INFO")
         self.assertEqual(settings.log_retention_days, 30)
@@ -51,6 +56,7 @@ class SettingsTestCase(unittest.TestCase):
             "QF_SERVER_HOST": "0.0.0.0",
             "QF_SERVER_PORT": "9000",
             "QF_API_TOKEN": API_TOKEN,
+            "QF_CURSOR_SIGNING_KEY": CURSOR_SIGNING_KEY,
             "QF_LOG_DIR": "var/logs",
             "QF_LOG_LEVEL": "WARNING",
             "QF_LOG_RETENTION_DAYS": "14",
@@ -105,6 +111,7 @@ class SettingsTestCase(unittest.TestCase):
             {
                 "QF_ENVIRONMENT": "invalid",
                 "QF_API_TOKEN": API_TOKEN,
+                "QF_CURSOR_SIGNING_KEY": CURSOR_SIGNING_KEY,
                 "QF_DATABASE_PASSWORD": "test-secret",
             },
             clear=True,
@@ -130,6 +137,7 @@ class SettingsTestCase(unittest.TestCase):
                     with self.assertRaises(ValidationError):
                         Settings(
                             api_token=API_TOKEN,
+                            cursor_signing_key=CURSOR_SIGNING_KEY,
                             database_password="test-secret",
                             _env_file=None,
                         )
@@ -137,7 +145,11 @@ class SettingsTestCase(unittest.TestCase):
     def test_database_password_is_required(self) -> None:
         with patch.dict(os.environ, {}, clear=True):
             with self.assertRaises(ValidationError):
-                Settings(api_token=API_TOKEN, _env_file=None)
+                Settings(
+                    api_token=API_TOKEN,
+                    cursor_signing_key=CURSOR_SIGNING_KEY,
+                    _env_file=None,
+                )
 
     def test_api_token_is_required_and_rejects_short_values(self) -> None:
         invalid_tokens = (None, "too-short")
@@ -148,6 +160,26 @@ class SettingsTestCase(unittest.TestCase):
                 with patch.dict(os.environ, {}, clear=True):
                     with self.assertRaises(ValidationError):
                         Settings(
+                            cursor_signing_key=CURSOR_SIGNING_KEY,
+                            database_password="test-secret",
+                            _env_file=None,
+                            **arguments,
+                        )
+
+    def test_cursor_signing_key_is_required_and_rejects_short_values(self) -> None:
+        invalid_keys = (None, "too-short")
+
+        for cursor_signing_key in invalid_keys:
+            with self.subTest(cursor_signing_key=cursor_signing_key):
+                arguments = (
+                    {"cursor_signing_key": cursor_signing_key}
+                    if cursor_signing_key is not None
+                    else {}
+                )
+                with patch.dict(os.environ, {}, clear=True):
+                    with self.assertRaises(ValidationError):
+                        Settings(
+                            api_token=API_TOKEN,
                             database_password="test-secret",
                             _env_file=None,
                             **arguments,
@@ -156,6 +188,7 @@ class SettingsTestCase(unittest.TestCase):
     def test_database_url_encodes_credentials(self) -> None:
         settings = Settings(
             api_token=API_TOKEN,
+            cursor_signing_key=CURSOR_SIGNING_KEY,
             database_user="user@example.com",
             database_password="p@ss/word",
             _env_file=None,

--- a/backend/tests/test_strategy_api.py
+++ b/backend/tests/test_strategy_api.py
@@ -28,7 +28,7 @@ from app.strategies.validation import StrategyValidationIssue, validate_strategy
 
 
 API_TOKEN = "a" * 64
-SOURCE = "def run(context, parameters):\n    return {'intents': []}\n"
+SOURCE = "def run(context, parameters):\n    return {'mode': 'hold'}\n"
 
 
 class StrategyValidationTestCase(unittest.TestCase):

--- a/backend/tests/test_strategy_contract_check.py
+++ b/backend/tests/test_strategy_contract_check.py
@@ -1,0 +1,206 @@
+"""Tests for the isolated subprocess strategy contract check.
+
+These tests spawn real worker subprocesses; they verify the happy path,
+protocol failures, timeout, cancellation, synthetic identity injection, and
+determinism of the check evidence.
+"""
+
+import unittest
+from datetime import date, datetime, timedelta, timezone
+from uuid import uuid4
+
+from app.strategy_protocol.checker import (
+    ContractCheckRequest,
+    build_worker_payload,
+    run_strategy_contract_check,
+)
+from app.strategy_protocol.contract import FAILURE_PHASE_STRATEGY_CONTRACT_CHECK
+
+AWARE_TIME = datetime(2026, 8, 21, 15, 0, 0, tzinfo=timezone(timedelta(hours=8)))
+STATIC_ID = uuid4()
+
+
+def _request(source: str, **overrides) -> ContractCheckRequest:
+    defaults = dict(
+        source_code=source,
+        parameter_schema={},
+        default_parameters={},
+        static_instrument_ids=(str(STATIC_ID),),
+        session_date=date(2026, 8, 21),
+        decision_time=AWARE_TIME,
+        data_cutoff=AWARE_TIME,
+    )
+    defaults.update(overrides)
+    return ContractCheckRequest(**defaults)
+
+
+HOLD_STRATEGY = "def run(context, parameters):\n    return {'mode': 'hold'}\n"
+
+
+class ContractCheckPayloadTestCase(unittest.TestCase):
+    """Cover request serialization rules."""
+
+    def test_payload_uses_deterministic_fallback_dates(self) -> None:
+        payload = build_worker_payload(
+            ContractCheckRequest(source_code=HOLD_STRATEGY, parameter_schema={}, default_parameters={})
+        )
+        import json
+
+        decoded = json.loads(payload)
+        # Fixed fallback session, never derived from the wall clock.
+        self.assertEqual(decoded["session_date"], "2030-01-15")
+        self.assertIn("+08:00", decoded["decision_time"])
+
+    def test_payload_serializes_static_ids_and_positions(self) -> None:
+        payload = build_worker_payload(
+            _request(
+                HOLD_STRATEGY,
+                initial_positions=(
+                    {
+                        "instrument_id": STATIC_ID,
+                        "side": "long",
+                        "quantity": "100",
+                        "available_quantity": "100",
+                        "average_price": "10",
+                    },
+                ),
+            )
+        )
+        import json
+
+        decoded = json.loads(payload)
+        self.assertEqual(decoded["static_instrument_ids"], [str(STATIC_ID)])
+        self.assertEqual(decoded["initial_positions"][0]["quantity"], "100")
+
+
+class ContractCheckSubprocessTestCase(unittest.TestCase):
+    """Run the real isolated worker for each scenario."""
+
+    def test_valid_strategy_passes_with_evidence(self) -> None:
+        result = run_strategy_contract_check(_request(HOLD_STRATEGY))
+        self.assertTrue(result.ok, result.message)
+        self.assertIsNone(result.failure_phase)
+        self.assertEqual(result.evidence["contract_version"], 1)
+        self.assertIn(str(STATIC_ID), str(result.evidence["identity_rows"]))
+
+    def test_target_weights_strategy_passes_with_static_id(self) -> None:
+        source = (
+            "def run(context, parameters):\n"
+            f"    return {{'mode': 'target_weights',\n"
+            f"            'targets': {{'{STATIC_ID}': '1'}}}}\n"
+        )
+        result = run_strategy_contract_check(_request(source))
+        self.assertTrue(result.ok, result.message)
+        self.assertEqual(result.evidence["mode"], "target_weights")
+        self.assertEqual(result.evidence["target_count"], 1)
+
+    def test_invalid_return_fails_with_contract_check_phase(self) -> None:
+        for source in (
+            "def run(context, parameters):\n    return 0.5\n",
+            "def run(context, parameters):\n    return {'intents': []}\n",
+            "def run(context, parameters):\n    return {'mode': 'mystery'}\n",
+            (
+                "def run(context, parameters):\n"
+                "    return {'mode': 'target_weights',\n"
+                "            'targets': {'" + str(uuid4()) + "': '1'}}\n"
+            ),
+            "def run(context, parameters):\n    raise ValueError('boom')\n",
+        ):
+            result = run_strategy_contract_check(_request(source))
+            self.assertFalse(result.ok, source)
+            self.assertEqual(
+                result.failure_phase, FAILURE_PHASE_STRATEGY_CONTRACT_CHECK
+            )
+            self.assertTrue(result.error_type)
+            self.assertTrue(result.message)
+
+    def test_syntax_error_reports_line(self) -> None:
+        result = run_strategy_contract_check(
+            _request("def run(context, parameters)\n    pass\n")
+        )
+        self.assertFalse(result.ok)
+        self.assertEqual(result.error_type, "SyntaxError")
+        self.assertEqual(result.line, 1)
+
+    def test_unknown_identity_keeps_official_error_semantics(self) -> None:
+        source = (
+            "def run(context, parameters):\n"
+            "    bar = context.data.bars(\n"
+            f"        '{uuid4()}', lookback_sessions=5)\n"
+            "    return {'mode': 'hold'}\n"
+        )
+        result = run_strategy_contract_check(_request(source))
+        self.assertFalse(result.ok)
+        self.assertEqual(result.error_type, "UnknownInstrumentError")
+
+    def test_data_cutoff_and_lookback_semantics_match_the_real_run(self) -> None:
+        future_source = (
+            "def run(context, parameters):\n"
+            "    import datetime\n"
+            "    context.data.bars(\n"
+            f"        '{STATIC_ID}',\n"
+            "        end_date=datetime.date(2026, 8, 22))\n"
+            "    return {'mode': 'hold'}\n"
+        )
+        result = run_strategy_contract_check(_request(future_source))
+        self.assertFalse(result.ok)
+        self.assertEqual(result.error_type, "DataCutoffViolationError")
+
+        oversized_source = (
+            "def run(context, parameters):\n"
+            "    context.data.bars(\n"
+            f"        '{STATIC_ID}', lookback_sessions=513)\n"
+            "    return {'mode': 'hold'}\n"
+        )
+        result = run_strategy_contract_check(_request(oversized_source))
+        self.assertFalse(result.ok)
+        self.assertEqual(result.error_type, "LookbackLimitExceededError")
+
+    def test_timeout_kills_the_worker(self) -> None:
+        source = (
+            "def run(context, parameters):\n"
+            "    import time\n"
+            "    time.sleep(60)\n"
+            "    return {'mode': 'hold'}\n"
+        )
+        result = run_strategy_contract_check(
+            _request(source), timeout_seconds=1.5
+        )
+        self.assertFalse(result.ok)
+        self.assertEqual(result.error_type, "ContractCheckTimeout")
+        self.assertEqual(
+            result.failure_phase, FAILURE_PHASE_STRATEGY_CONTRACT_CHECK
+        )
+
+    def test_cancel_signal_terminates_the_worker(self) -> None:
+        source = (
+            "def run(context, parameters):\n"
+            "    import time\n"
+            "    time.sleep(60)\n"
+            "    return {'mode': 'hold'}\n"
+        )
+        result = run_strategy_contract_check(
+            _request(source), should_cancel=lambda: True
+        )
+        self.assertFalse(result.ok)
+        self.assertEqual(result.error_type, "ContractCheckCancelled")
+
+    def test_check_is_deterministic_across_repeats(self) -> None:
+        first = run_strategy_contract_check(_request(HOLD_STRATEGY))
+        second = run_strategy_contract_check(_request(HOLD_STRATEGY))
+        self.assertEqual(first.evidence, second.evidence)
+
+    def test_check_does_not_touch_the_database_or_network(self) -> None:
+        # A strategy importing a DB driver or network client is not part of
+        # the synthetic check surface; the worker only receives JSON stdin.
+        source = (
+            "def run(context, parameters):\n"
+            "    import json\n"
+            "    return {'mode': 'hold', 'reason': json.dumps({'ok': True})}\n"
+        )
+        result = run_strategy_contract_check(_request(source))
+        self.assertTrue(result.ok, result.message)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/backend/tests/test_strategy_contract_check.py
+++ b/backend/tests/test_strategy_contract_check.py
@@ -156,6 +156,59 @@ class ContractCheckSubprocessTestCase(unittest.TestCase):
         self.assertFalse(result.ok)
         self.assertEqual(result.error_type, "LookbackLimitExceededError")
 
+    def test_non_zero_initial_position_passes_end_to_end(self) -> None:
+        # Regression: position instrument ids cross the process boundary as
+        # strings and must be decoded by the worker, not fail the check.
+        source = (
+            "def run(context, parameters):\n"
+            "    positions = context.portfolio.positions\n"
+            "    assert len(positions) == 1\n"
+            f"    assert str(positions[0].instrument_id) == '{STATIC_ID}'\n"
+            "    return {'mode': 'hold'}\n"
+        )
+        result = run_strategy_contract_check(
+            _request(
+                source,
+                initial_positions=(
+                    {
+                        "instrument_id": STATIC_ID,
+                        "side": "long",
+                        "quantity": "100",
+                        "available_quantity": "100",
+                        "average_price": "10",
+                    },
+                ),
+            )
+        )
+        self.assertTrue(result.ok, result.message)
+
+    def test_strategy_stdout_cannot_pollute_the_result_document(self) -> None:
+        # Regression: strategy prints are redirected to stderr so stdout only
+        # ever carries the one machine-readable JSON result.
+        source = (
+            "def run(context, parameters):\n"
+            "    print('debug')\n"
+            "    print('more noise', 123)\n"
+            "    return {'mode': 'hold'}\n"
+        )
+        result = run_strategy_contract_check(_request(source))
+        self.assertTrue(result.ok, result.message)
+        self.assertEqual(result.evidence["mode"], "hold")
+
+    def test_runtime_failure_reports_line_and_technical_details(self) -> None:
+        source = (
+            "def run(context, parameters):\n"
+            "    marker = 1\n"
+            "    raise ValueError('boom at runtime')\n"
+        )
+        result = run_strategy_contract_check(_request(source))
+        self.assertFalse(result.ok)
+        self.assertEqual(result.error_type, "ValueError")
+        # The failing line inside the strategy module is reported.
+        self.assertEqual(result.line, 3)
+        self.assertIn("ValueError", result.technical or "")
+        self.assertIn("boom at runtime", result.message)
+
     def test_timeout_kills_the_worker(self) -> None:
         source = (
             "def run(context, parameters):\n"

--- a/backend/tests/test_strategy_contract_check.py
+++ b/backend/tests/test_strategy_contract_check.py
@@ -256,6 +256,14 @@ class ContractCheckSubprocessTestCase(unittest.TestCase):
         result = run_strategy_contract_check(_request(source))
         self.assertTrue(result.ok, result.message)
 
+    def test_source_compilation_is_refused_outside_the_worker(self) -> None:
+        # Regression: importing the worker from an ordinary process (this
+        # test process) must not expose a callable user-source loader.
+        from app.strategy_protocol.worker import _load_published_module
+
+        with self.assertRaises(RuntimeError):
+            _load_published_module("value = 7\n")
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/backend/tests/test_strategy_contract_check.py
+++ b/backend/tests/test_strategy_contract_check.py
@@ -5,6 +5,7 @@ protocol failures, timeout, cancellation, synthetic identity injection, and
 determinism of the check evidence.
 """
 
+import os
 import time
 import unittest
 from datetime import date, datetime, timedelta, timezone
@@ -36,6 +37,12 @@ def _request(source: str, **overrides) -> ContractCheckRequest:
 
 
 HOLD_STRATEGY = "def run(context, parameters):\n    return {'mode': 'hold'}\n"
+
+
+def _open_fd_count() -> int:
+    """Count open fds on POSIX; used by the leak regression test."""
+
+    return len(os.listdir("/dev/fd")) if os.path.isdir("/dev/fd") else -1
 
 
 class ContractCheckPayloadTestCase(unittest.TestCase):
@@ -251,6 +258,54 @@ class ContractCheckSubprocessTestCase(unittest.TestCase):
         result = run_strategy_contract_check(_request(source))
         self.assertFalse(result.ok)
         self.assertEqual(result.error_type, "ContractCheckOutputLimit")
+
+    def test_stdout_flood_cannot_block_or_fail_the_check(self) -> None:
+        # Worker stdout goes to DEVNULL: a strategy dumping megabytes to fd 1
+        # can neither block on a full pipe nor affect the verdict.
+        source = (
+            "def run(context, parameters):\n"
+            "    import os\n"
+            "    os.write(1, b'x' * 1000000)\n"
+            "    return {'mode': 'hold'}\n"
+        )
+        result = run_strategy_contract_check(_request(source))
+        self.assertTrue(result.ok, result.message)
+
+    def test_repeated_terminal_checks_do_not_leak_file_descriptors(self) -> None:
+        # Regression: timeout, cancel, and overflow exits used to leak the
+        # result-channel fd; repeated runs must not grow the open-fd count.
+        baseline = _open_fd_count()
+        if baseline < 0:  # pragma: no cover - non-POSIX platform
+            self.skipTest("no /dev/fd on this platform")
+        sleeper = (
+            "def run(context, parameters):\n"
+            "    import time\n"
+            "    time.sleep(60)\n"
+            "    return {'mode': 'hold'}\n"
+        )
+        for _ in range(3):
+            result = run_strategy_contract_check(
+                _request(sleeper), timeout_seconds=0.2
+            )
+            self.assertEqual(result.error_type, "ContractCheckTimeout")
+        for _ in range(3):
+            result = run_strategy_contract_check(
+                _request(sleeper), should_cancel=lambda: True
+            )
+            self.assertEqual(result.error_type, "ContractCheckCancelled")
+        flooder = (
+            "def run(context, parameters):\n"
+            "    import sys\n"
+            "    noise = 'x' * 65536\n"
+            "    for _ in range(8):\n"
+            "        sys.stderr.write(noise)\n"
+            "    sys.stderr.flush()\n"
+            "    return {'mode': 'hold'}\n"
+        )
+        for _ in range(3):
+            result = run_strategy_contract_check(_request(flooder))
+            self.assertEqual(result.error_type, "ContractCheckOutputLimit")
+        self.assertLessEqual(_open_fd_count(), baseline + 1)
 
     def test_timeout_kills_the_whole_process_tree(self) -> None:
         # Regression: a strategy that spawns its own child used to keep the

--- a/backend/tests/test_strategy_contract_check.py
+++ b/backend/tests/test_strategy_contract_check.py
@@ -5,6 +5,7 @@ protocol failures, timeout, cancellation, synthetic identity injection, and
 determinism of the check evidence.
 """
 
+import time
 import unittest
 from datetime import date, datetime, timedelta, timezone
 from uuid import uuid4
@@ -211,21 +212,72 @@ class ContractCheckSubprocessTestCase(unittest.TestCase):
         self.assertIn("ValueError", result.technical or "")
         self.assertIn("boom at runtime", result.message)
 
-    def test_timeout_kills_the_worker(self) -> None:
+    def test_forged_stdout_result_cannot_produce_success(self) -> None:
+        # Regression: writing a fake JSON verdict to fd 1 and exiting must
+        # not pass the check; the parent only trusts its dedicated result
+        # descriptor and validates the full protocol.
         source = (
             "def run(context, parameters):\n"
+            "    import os\n"
+            "    os.write(1, b'{\"ok\": true}')\n"
+            "    return {'mode': 'hold'}\n"
+        )
+        result = run_strategy_contract_check(_request(source))
+        self.assertTrue(result.ok, result.message)
+        self.assertEqual(result.evidence["mode"], "hold")
+
+        source = (
+            "def run(context, parameters):\n"
+            "    import os\n"
+            "    os.write(1, b'{\"ok\": true}')\n"
+            "    os._exit(0)\n"
+        )
+        result = run_strategy_contract_check(_request(source))
+        self.assertFalse(result.ok)
+        self.assertEqual(
+            result.failure_phase, FAILURE_PHASE_STRATEGY_CONTRACT_CHECK
+        )
+
+    def test_stderr_flood_is_capped_and_fails_the_check(self) -> None:
+        source = (
+            "def run(context, parameters):\n"
+            "    import sys\n"
+            "    noise = 'x' * 65536\n"
+            "    for _ in range(64):\n"
+            "        sys.stderr.write(noise)\n"
+            "    sys.stderr.flush()\n"
+            "    return {'mode': 'hold'}\n"
+        )
+        result = run_strategy_contract_check(_request(source))
+        self.assertFalse(result.ok)
+        self.assertEqual(result.error_type, "ContractCheckOutputLimit")
+
+    def test_timeout_kills_the_whole_process_tree(self) -> None:
+        # Regression: a strategy that spawns its own child used to keep the
+        # pipes open after the worker was killed, blocking the parent until
+        # the grandchild exited.
+        source = (
+            "def run(context, parameters):\n"
+            "    import subprocess, sys\n"
+            "    subprocess.Popen(\n"
+            "        [sys.executable, '-c', 'import time; time.sleep(30)'],\n"
+            "    )\n"
             "    import time\n"
             "    time.sleep(60)\n"
             "    return {'mode': 'hold'}\n"
         )
+        started = time.monotonic()
         result = run_strategy_contract_check(
-            _request(source), timeout_seconds=1.5
+            _request(source), timeout_seconds=0.3
         )
+        elapsed = time.monotonic() - started
         self.assertFalse(result.ok)
         self.assertEqual(result.error_type, "ContractCheckTimeout")
         self.assertEqual(
             result.failure_phase, FAILURE_PHASE_STRATEGY_CONTRACT_CHECK
         )
+        # The tree-kill must not wait for the 30-second grandchild.
+        self.assertLess(elapsed, 5.0, f"tree kill took {elapsed:.2f}s")
 
     def test_cancel_signal_terminates_the_worker(self) -> None:
         source = (

--- a/backend/tests/test_strategy_contract_check.py
+++ b/backend/tests/test_strategy_contract_check.py
@@ -184,8 +184,10 @@ class ContractCheckSubprocessTestCase(unittest.TestCase):
 
     def test_strategy_stdout_cannot_pollute_the_result_document(self) -> None:
         # Regression: strategy prints are redirected to stderr so stdout only
-        # ever carries the one machine-readable JSON result.
+        # ever carries the one machine-readable JSON result.  Module-level
+        # code runs before run() and must be covered by the redirect too.
         source = (
+            'print("top-level noise")\n'
             "def run(context, parameters):\n"
             "    print('debug')\n"
             "    print('more noise', 123)\n"

--- a/backend/tests/test_strategy_contract_check.py
+++ b/backend/tests/test_strategy_contract_check.py
@@ -307,6 +307,54 @@ class ContractCheckSubprocessTestCase(unittest.TestCase):
             self.assertEqual(result.error_type, "ContractCheckOutputLimit")
         self.assertLessEqual(_open_fd_count(), baseline + 1)
 
+    def test_grandchild_dies_when_worker_exits_normally(self) -> None:
+        # Regression: a strategy that spawns a child and returns a valid
+        # decision immediately must not leave the grandchild running after
+        # the check reports success.  poll() reaps the worker before cleanup,
+        # so the kill must target the fixed process group, not query the
+        # already-reaped group leader.
+        import os as _os
+        import tempfile
+
+        handle = tempfile.NamedTemporaryFile(
+            mode="w", suffix=".pid", delete=False
+        )
+        handle.close()
+        pid_file = handle.name
+        self.addCleanup(lambda: _os.unlink(pid_file))
+        source = (
+            "def run(context, parameters):\n"
+            "    import subprocess, sys\n"
+            "    child = subprocess.Popen(\n"
+            "        [sys.executable, '-c', 'import time; time.sleep(30)'],\n"
+            "        stdout=subprocess.DEVNULL,\n"
+            "        stderr=subprocess.DEVNULL,\n"
+            "    )\n"
+            "    with open(parameters['pid_file'], 'w') as sink:\n"
+            "        sink.write(str(child.pid))\n"
+            "    return {'mode': 'hold'}\n"
+        )
+        result = run_strategy_contract_check(
+            _request(source, default_parameters={"pid_file": pid_file})
+        )
+        self.assertTrue(result.ok, result.message)
+        with open(pid_file) as source_file:
+            child_pid = int(source_file.read())
+
+        import signal as signal_module
+        deadline = time.monotonic() + 5.0
+        while time.monotonic() < deadline:
+            try:
+                _os.kill(child_pid, 0)
+            except ProcessLookupError:
+                break  # tree kill reached the orphaned grandchild
+            except PermissionError:
+                break  # reaped and reused; no longer ours
+            time.sleep(0.05)
+        else:
+            self.fail("grandchild survived the contract check")
+        del signal_module
+
     def test_timeout_kills_the_whole_process_tree(self) -> None:
         # Regression: a strategy that spawns its own child used to keep the
         # pipes open after the worker was killed, blocking the parent until

--- a/backend/tests/test_strategy_protocol_adapter.py
+++ b/backend/tests/test_strategy_protocol_adapter.py
@@ -3,6 +3,7 @@
 import unittest
 from datetime import date, datetime, timedelta, timezone
 from decimal import Decimal
+from types import ModuleType
 from uuid import uuid4
 
 from app.strategy_protocol.adapter import (
@@ -19,17 +20,20 @@ from app.strategy_protocol.synthetic import (
     ContractCheckParameters,
     build_synthetic_context,
 )
-from app.strategy_protocol.worker import load_published_module
 
 AWARE_TIME = datetime(2026, 8, 21, 15, 0, 0, tzinfo=timezone(timedelta(hours=8)))
 
 
 def load(source: str, parameters: dict | None = None) -> FunctionStrategyAdapter:
-    """Load a strategy through the same path the isolated worker uses."""
+    """Build an adapter over a compiled module, as only the worker may do.
 
-    return FunctionStrategyAdapter(
-        load_published_module(source), parameters=parameters or {}
-    )
+    The tests own this tiny compile step because source loading itself is
+    private to the worker process; the adapter only ever sees a module.
+    """
+
+    module = ModuleType("published_strategy")
+    exec(compile(source, "published_strategy", "exec"), module.__dict__)  # noqa: S102 - test fixture only
+    return FunctionStrategyAdapter(module, parameters=parameters or {})
 
 
 def _context(static_id=None):

--- a/backend/tests/test_strategy_protocol_adapter.py
+++ b/backend/tests/test_strategy_protocol_adapter.py
@@ -6,7 +6,6 @@ from decimal import Decimal
 from uuid import uuid4
 
 from app.strategy_protocol.adapter import (
-    ISOLATED_SUBPROCESS_SCOPE,
     FunctionStrategyAdapter,
     known_instrument_ids,
 )
@@ -20,17 +19,16 @@ from app.strategy_protocol.synthetic import (
     ContractCheckParameters,
     build_synthetic_context,
 )
+from app.strategy_protocol.worker import load_published_module
 
 AWARE_TIME = datetime(2026, 8, 21, 15, 0, 0, tzinfo=timezone(timedelta(hours=8)))
 
 
 def load(source: str, parameters: dict | None = None) -> FunctionStrategyAdapter:
-    """Load a strategy the way only the isolated worker is allowed to."""
+    """Load a strategy through the same path the isolated worker uses."""
 
-    return FunctionStrategyAdapter.from_source(
-        source,
-        parameters=parameters or {},
-        execution_scope=ISOLATED_SUBPROCESS_SCOPE,
+    return FunctionStrategyAdapter(
+        load_published_module(source), parameters=parameters or {}
     )
 
 
@@ -47,16 +45,15 @@ def _context(static_id=None):
 
 
 class ExecutionScopeTestCase(unittest.TestCase):
-    """Cover the guard that keeps user-source execution subprocess-only."""
+    """The adapter must not expose any source-loading entry point."""
 
-    def test_from_source_requires_the_isolated_subprocess_scope(self) -> None:
-        for wrong_scope in (None, "", "api_process", ISOLATED_SUBPROCESS_SCOPE + "x"):
-            with self.assertRaises(StrategyProtocolError):
-                FunctionStrategyAdapter.from_source(
-                    "def run(context, parameters):\n    return {'mode': 'hold'}\n",
-                    parameters={},
-                    execution_scope=wrong_scope,
-                )
+    def test_adapter_has_no_source_loading_capability(self) -> None:
+        # Source compilation lives only in the worker module, so an API or
+        # Runner caller cannot execute private code through the adapter.
+        self.assertFalse(hasattr(FunctionStrategyAdapter, "from_source"))
+        self.assertNotIn(
+            "exec", FunctionStrategyAdapter.__init__.__code__.co_names
+        )
 
 
 class FunctionStrategyAdapterTestCase(unittest.TestCase):

--- a/backend/tests/test_strategy_protocol_adapter.py
+++ b/backend/tests/test_strategy_protocol_adapter.py
@@ -5,7 +5,11 @@ from datetime import date, datetime, timedelta, timezone
 from decimal import Decimal
 from uuid import uuid4
 
-from app.strategy_protocol.adapter import FunctionStrategyAdapter, known_instrument_ids
+from app.strategy_protocol.adapter import (
+    ISOLATED_SUBPROCESS_SCOPE,
+    FunctionStrategyAdapter,
+    known_instrument_ids,
+)
 from app.strategy_protocol.contract import (
     STRATEGY_CONTRACT_VERSION,
     InvalidDecisionPayloadError,
@@ -20,6 +24,16 @@ from app.strategy_protocol.synthetic import (
 AWARE_TIME = datetime(2026, 8, 21, 15, 0, 0, tzinfo=timezone(timedelta(hours=8)))
 
 
+def load(source: str, parameters: dict | None = None) -> FunctionStrategyAdapter:
+    """Load a strategy the way only the isolated worker is allowed to."""
+
+    return FunctionStrategyAdapter.from_source(
+        source,
+        parameters=parameters or {},
+        execution_scope=ISOLATED_SUBPROCESS_SCOPE,
+    )
+
+
 def _context(static_id=None):
     parameters = ContractCheckParameters(
         session_date=date(2026, 8, 21),
@@ -30,6 +44,19 @@ def _context(static_id=None):
     )
     context, _ = build_synthetic_context(parameters)
     return context
+
+
+class ExecutionScopeTestCase(unittest.TestCase):
+    """Cover the guard that keeps user-source execution subprocess-only."""
+
+    def test_from_source_requires_the_isolated_subprocess_scope(self) -> None:
+        for wrong_scope in (None, "", "api_process", ISOLATED_SUBPROCESS_SCOPE + "x"):
+            with self.assertRaises(StrategyProtocolError):
+                FunctionStrategyAdapter.from_source(
+                    "def run(context, parameters):\n    return {'mode': 'hold'}\n",
+                    parameters={},
+                    execution_scope=wrong_scope,
+                )
 
 
 class FunctionStrategyAdapterTestCase(unittest.TestCase):
@@ -45,7 +72,7 @@ class FunctionStrategyAdapterTestCase(unittest.TestCase):
             "        'reason': '测试原因',\n"
             "    }\n"
         )
-        adapter = FunctionStrategyAdapter.from_source(source, parameters={})
+        adapter = load(source)
         context = _context()
         decision = adapter.on_step(context)
         self.assertIsInstance(decision, StrategyDecision)
@@ -57,10 +84,7 @@ class FunctionStrategyAdapterTestCase(unittest.TestCase):
         self.assertEqual(decision.contract_version, STRATEGY_CONTRACT_VERSION)
 
     def test_hold_decision_is_a_valid_noop(self) -> None:
-        adapter = FunctionStrategyAdapter.from_source(
-            "def run(context, parameters):\n    return {'mode': 'hold'}\n",
-            parameters={},
-        )
+        adapter = load("def run(context, parameters):\n    return {'mode': 'hold'}\n")
         decision = adapter.on_step(_context())
         self.assertEqual(decision.mode, "hold")
         self.assertEqual(dict(decision.targets), {})
@@ -76,7 +100,7 @@ class FunctionStrategyAdapterTestCase(unittest.TestCase):
             ),
             "def run(context, parameters):\n    return {'intents': []}\n",
         ):
-            adapter = FunctionStrategyAdapter.from_source(source, parameters={})
+            adapter = load(source)
             with self.assertRaises(StrategyProtocolError):
                 adapter.on_step(_context())
 
@@ -87,21 +111,58 @@ class FunctionStrategyAdapterTestCase(unittest.TestCase):
             "    return {'mode': 'hold',\n"
             f"            'targets': {{'{known}': '1'}}}}\n"
         )
-        adapter = FunctionStrategyAdapter.from_source(source, parameters={})
+        adapter = load(source)
         with self.assertRaises(InvalidDecisionPayloadError):
             adapter.on_step(_context())
 
-    def test_parameters_are_passed_to_the_entry_point(self) -> None:
+    def test_parameters_are_deeply_read_only_across_steps(self) -> None:
         source = (
             "def run(context, parameters):\n"
-            "    assert parameters['window'] == 20\n"
+            "    parameters['window'] = 99\n"
             "    return {'mode': 'hold'}\n"
         )
-        adapter = FunctionStrategyAdapter.from_source(
-            source, parameters={"window": 20}
+        adapter = load(source, parameters={"window": 20})
+        with self.assertRaises((TypeError, AttributeError)):
+            adapter.on_step(_context())
+
+        nested_source = (
+            "def run(context, parameters):\n"
+            "    parameters['bounds']['low'] = -1\n"
+            "    return {'mode': 'hold'}\n"
         )
-        decision = adapter.on_step(_context())
-        self.assertEqual(decision.mode, "hold")
+        nested_adapter = load(
+            nested_source, parameters={"bounds": {"low": 0}}
+        )
+        with self.assertRaises((TypeError, AttributeError)):
+            nested_adapter.on_step(_context())
+
+        list_source = (
+            "def run(context, parameters):\n"
+            "    parameters['items'].append('x')\n"
+            "    return {'mode': 'hold'}\n"
+        )
+        list_adapter = load(list_source, parameters={"items": [1]})
+        with self.assertRaises((TypeError, AttributeError)):
+            list_adapter.on_step(_context())
+
+    def test_parameter_mutation_attempts_cannot_leak_into_later_steps(self) -> None:
+        # Even a strategy that catches the write error cannot corrupt the
+        # parameter object seen by later steps.
+        source = (
+            "state = {'seen': []}\n"
+            "def run(context, parameters):\n"
+            "    try:\n"
+            "        parameters['window'] = 99\n"
+            "    except (TypeError, AttributeError):\n"
+            "        pass\n"
+            "    state['seen'].append(parameters['window'])\n"
+            "    return {'mode': 'hold', 'reason': str(parameters['window'])}\n"
+        )
+        adapter = load(source, parameters={"window": 20})
+        first = adapter.on_step(_context())
+        second = adapter.on_step(_context())
+        self.assertEqual(first.reason, "20")
+        self.assertEqual(second.reason, "20")
 
     def test_module_state_persists_within_one_run(self) -> None:
         source = (
@@ -110,7 +171,7 @@ class FunctionStrategyAdapterTestCase(unittest.TestCase):
             "    counter['calls'] += 1\n"
             "    return {'mode': 'hold', 'reason': str(counter['calls'])}\n"
         )
-        adapter = FunctionStrategyAdapter.from_source(source, parameters={})
+        adapter = load(source)
         context = _context()
         first = adapter.on_step(context)
         second = adapter.on_step(context)
@@ -131,13 +192,10 @@ class FunctionStrategyAdapterTestCase(unittest.TestCase):
                 StrategyProtocolError,
                 msg=f"entry point {source!r} must be rejected",
             ):
-                FunctionStrategyAdapter.from_source(source, parameters={})
+                load(source)
 
     def test_lifecycle_defaults_are_noop(self) -> None:
-        adapter = FunctionStrategyAdapter.from_source(
-            "def run(context, parameters):\n    return {'mode': 'hold'}\n",
-            parameters={},
-        )
+        adapter = load("def run(context, parameters):\n    return {'mode': 'hold'}\n")
         self.assertIsNone(adapter.on_start(None))
         self.assertIsNone(adapter.on_order_update(None))
         self.assertIsNone(adapter.on_fill(None))

--- a/backend/tests/test_strategy_protocol_adapter.py
+++ b/backend/tests/test_strategy_protocol_adapter.py
@@ -1,0 +1,148 @@
+"""Tests for the FunctionStrategyAdapter and its decision conversion."""
+
+import unittest
+from datetime import date, datetime, timedelta, timezone
+from decimal import Decimal
+from uuid import uuid4
+
+from app.strategy_protocol.adapter import FunctionStrategyAdapter, known_instrument_ids
+from app.strategy_protocol.contract import (
+    STRATEGY_CONTRACT_VERSION,
+    InvalidDecisionPayloadError,
+    StrategyProtocolError,
+)
+from app.strategy_protocol.decisions import StrategyDecision
+from app.strategy_protocol.synthetic import (
+    ContractCheckParameters,
+    build_synthetic_context,
+)
+
+AWARE_TIME = datetime(2026, 8, 21, 15, 0, 0, tzinfo=timezone(timedelta(hours=8)))
+
+
+def _context(static_id=None):
+    parameters = ContractCheckParameters(
+        session_date=date(2026, 8, 21),
+        decision_time=AWARE_TIME,
+        data_cutoff=AWARE_TIME,
+        static_instrument_ids=(static_id,) if static_id else (),
+        initial_positions=(),
+    )
+    context, _ = build_synthetic_context(parameters)
+    return context
+
+
+class FunctionStrategyAdapterTestCase(unittest.TestCase):
+    """Cover module loading, lifecycle defaults, and payload validation."""
+
+    def test_target_weights_decision_is_built_from_return_value(self) -> None:
+        known = next(iter(known_instrument_ids(_context())))
+        source = (
+            "def run(context, parameters):\n"
+            "    return {\n"
+            f"        'mode': 'target_weights',\n"
+            f"        'targets': {{'{known}': '0.60'}},\n"
+            "        'reason': '测试原因',\n"
+            "    }\n"
+        )
+        adapter = FunctionStrategyAdapter.from_source(source, parameters={})
+        context = _context()
+        decision = adapter.on_step(context)
+        self.assertIsInstance(decision, StrategyDecision)
+        self.assertEqual(decision.mode, "target_weights")
+        self.assertEqual(decision.targets[str(known)], Decimal("0.60"))
+        self.assertEqual(decision.reason, "测试原因")
+        self.assertEqual(decision.step_sequence, 1)
+        self.assertEqual(decision.decision_time, AWARE_TIME)
+        self.assertEqual(decision.contract_version, STRATEGY_CONTRACT_VERSION)
+
+    def test_hold_decision_is_a_valid_noop(self) -> None:
+        adapter = FunctionStrategyAdapter.from_source(
+            "def run(context, parameters):\n    return {'mode': 'hold'}\n",
+            parameters={},
+        )
+        decision = adapter.on_step(_context())
+        self.assertEqual(decision.mode, "hold")
+        self.assertEqual(dict(decision.targets), {})
+
+    def test_float_unknown_mode_and_unknown_instrument_fail(self) -> None:
+        for source in (
+            "def run(context, parameters):\n    return 0.5\n",
+            "def run(context, parameters):\n    return {'mode': 'mystery'}\n",
+            (
+                "def run(context, parameters):\n"
+                "    return {'mode': 'target_weights',\n"
+                "            'targets': {'" + str(uuid4()) + "': '1'}}\n"
+            ),
+            "def run(context, parameters):\n    return {'intents': []}\n",
+        ):
+            adapter = FunctionStrategyAdapter.from_source(source, parameters={})
+            with self.assertRaises(StrategyProtocolError):
+                adapter.on_step(_context())
+
+    def test_hold_with_targets_is_rejected(self) -> None:
+        known = next(iter(known_instrument_ids(_context())))
+        source = (
+            "def run(context, parameters):\n"
+            "    return {'mode': 'hold',\n"
+            f"            'targets': {{'{known}': '1'}}}}\n"
+        )
+        adapter = FunctionStrategyAdapter.from_source(source, parameters={})
+        with self.assertRaises(InvalidDecisionPayloadError):
+            adapter.on_step(_context())
+
+    def test_parameters_are_passed_to_the_entry_point(self) -> None:
+        source = (
+            "def run(context, parameters):\n"
+            "    assert parameters['window'] == 20\n"
+            "    return {'mode': 'hold'}\n"
+        )
+        adapter = FunctionStrategyAdapter.from_source(
+            source, parameters={"window": 20}
+        )
+        decision = adapter.on_step(_context())
+        self.assertEqual(decision.mode, "hold")
+
+    def test_module_state_persists_within_one_run(self) -> None:
+        source = (
+            "counter = {'calls': 0}\n"
+            "def run(context, parameters):\n"
+            "    counter['calls'] += 1\n"
+            "    return {'mode': 'hold', 'reason': str(counter['calls'])}\n"
+        )
+        adapter = FunctionStrategyAdapter.from_source(source, parameters={})
+        context = _context()
+        first = adapter.on_step(context)
+        second = adapter.on_step(context)
+        # One run reuses a single loaded module; in-memory strategy state
+        # survives across steps of the same run.
+        self.assertEqual(first.reason, "1")
+        self.assertEqual(second.reason, "2")
+
+    def test_entry_point_shape_errors_are_locatable(self) -> None:
+        for source in (
+            "",
+            "run = 42\n",
+            "def run(context):\n    return {}\n",
+            "def run(context, parameters, extra):\n    return {}\n",
+            "async def run(context, parameters):\n    return {}\n",
+        ):
+            with self.assertRaises(
+                StrategyProtocolError,
+                msg=f"entry point {source!r} must be rejected",
+            ):
+                FunctionStrategyAdapter.from_source(source, parameters={})
+
+    def test_lifecycle_defaults_are_noop(self) -> None:
+        adapter = FunctionStrategyAdapter.from_source(
+            "def run(context, parameters):\n    return {'mode': 'hold'}\n",
+            parameters={},
+        )
+        self.assertIsNone(adapter.on_start(None))
+        self.assertIsNone(adapter.on_order_update(None))
+        self.assertIsNone(adapter.on_fill(None))
+        self.assertIsNone(adapter.on_finish(None))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/backend/tests/test_strategy_protocol_data.py
+++ b/backend/tests/test_strategy_protocol_data.py
@@ -12,6 +12,7 @@ from app.strategy_protocol.contract import (
     DataCutoffViolationError,
     IdentityMappingMissingError,
     IncompleteHistoryError,
+    InvalidProviderResultError,
     LookbackLimitExceededError,
 )
 from app.strategy_protocol.data_view import (
@@ -102,6 +103,121 @@ class DataBoundaryTestCase(unittest.TestCase):
         bar = _bar(AWARE_CUTOFF.date())
         with self.assertRaises(TypeError):
             bar.values["close"] = Decimal("1")
+        # Binary floats, booleans, and non-finite values are rejected.
+        for bad in (1.0, True, "NaN", "Infinity", None):
+            with self.assertRaises(ValueError, msg=repr(bad)):
+                BarDTO(
+                    instrument_id=INSTRUMENT_ID,
+                    trade_date=AWARE_CUTOFF.date(),
+                    values={"close": bad},
+                )
+
+
+class ReadOnlyFacadeTestCase(unittest.TestCase):
+    """Strategies must not be able to rewrite query conditions."""
+
+    def _facade(self) -> StrategyDataDTO:
+        return StrategyDataDTO(_CountingView(), data_cutoff=AWARE_CUTOFF)
+
+    def test_data_facade_attributes_are_read_only(self) -> None:
+        facade = self._facade()
+        for name, value in (
+            ("_data_cutoff", AWARE_CUTOFF.replace(year=2999)),
+            ("_max_lookback_sessions", 100_000),
+            ("_view", _CountingView()),
+            ("_adjustment_gate", AdjustmentPolicyGate.active_gate()),
+        ):
+            with self.assertRaises(AttributeError, msg=name):
+                setattr(facade, name, value)
+            with self.assertRaises(AttributeError):
+                delattr(facade, name)
+
+    def test_universe_facade_attributes_are_read_only(self) -> None:
+        class _Universe:
+            def query(self, *, exchanges=None, asset_classes=None):
+                return ()
+
+        facade = UniverseQueryDTO(_Universe())
+        with self.assertRaises(AttributeError):
+            facade._query = lambda **kwargs: ()
+        with self.assertRaises(AttributeError):
+            delattr(facade, "_query")
+
+    def test_conflicting_lookback_and_start_date_is_rejected(self) -> None:
+        view = _CountingView([_bar(day) for day in (
+            AWARE_CUTOFF.date() - timedelta(days=offset) for offset in range(10)
+        )])
+        facade = StrategyDataDTO(view, data_cutoff=AWARE_CUTOFF)
+        start = AWARE_CUTOFF.date() - timedelta(days=2)
+        # lookback 5 implies a start before the explicit one; the conflict is
+        # a caller error instead of silently widening the read.
+        with self.assertRaises(ValueError):
+            facade.bars(
+                INSTRUMENT_ID, start_date=start, lookback_sessions=5
+            )
+        self.assertEqual(view.reads, 0)
+
+    def test_provider_rows_are_revalidated_on_the_way_out(self) -> None:
+        cutoff_day = AWARE_CUTOFF.date()
+
+        class _FutureProvider(_CountingView):
+            def bars(self, instrument_id, *, start_date, end_date, lookback_sessions):
+                self.reads += 1
+                return (_bar(cutoff_day + timedelta(days=4), "11"),)
+
+        with self.assertRaises(InvalidProviderResultError):
+            StrategyDataDTO(_FutureProvider(), data_cutoff=AWARE_CUTOFF).bars(
+                INSTRUMENT_ID
+            )
+
+        class _ForeignIdProvider(_CountingView):
+            def bars(self, instrument_id, *, start_date, end_date, lookback_sessions):
+                self.reads += 1
+                return (
+                    BarDTO(
+                        instrument_id=uuid4(),
+                        trade_date=cutoff_day,
+                        values={"close": Decimal("1")},
+                    ),
+                )
+
+        with self.assertRaises(InvalidProviderResultError):
+            StrategyDataDTO(_ForeignIdProvider(), data_cutoff=AWARE_CUTOFF).bars(
+                INSTRUMENT_ID
+            )
+
+        class _UnsortedProvider(_CountingView):
+            def bars(self, instrument_id, *, start_date, end_date, lookback_sessions):
+                self.reads += 1
+                return (
+                    _bar(cutoff_day),
+                    _bar(cutoff_day - timedelta(days=1)),
+                )
+
+        with self.assertRaises(InvalidProviderResultError):
+            StrategyDataDTO(_UnsortedProvider(), data_cutoff=AWARE_CUTOFF).bars(
+                INSTRUMENT_ID
+            )
+
+        class _FutureSeriesProvider(_CountingView):
+            def adjusted_series(
+                self, instrument_id, *, start_date, end_date, lookback_sessions, basis
+            ):
+                self.reads += 1
+                return (
+                    AdjustedSeriesPointDTO(
+                        instrument_id=instrument_id,
+                        trade_date=cutoff_day + timedelta(days=1),
+                        adj_factor=Decimal("1"),
+                    ),
+                )
+
+        with self.assertRaises(InvalidProviderResultError):
+            StrategyDataDTO(
+                _FutureSeriesProvider(),
+                data_cutoff=AWARE_CUTOFF,
+                adjustment_gate=AdjustmentPolicyGate.active_gate(),
+            ).adjusted_series(INSTRUMENT_ID, basis="qfq")
 
 
 class AdjustmentPolicyTestCase(unittest.TestCase):
@@ -188,6 +304,46 @@ class PitStitchingTestCase(unittest.TestCase):
                 segments,
                 sessions=[date(2026, 8, 18), date(2026, 8, 20), date(2026, 8, 21)],
                 read_segment=reader,
+            )
+
+    def test_overlapping_segments_block_instead_of_duplicating_bars(self) -> None:
+        # Both segments claim 2026-08-19; exactly-one coverage must fail.
+        segments = (
+            PitSegment("OLD.CODE", date(2026, 8, 17), date(2026, 8, 19)),
+            PitSegment("MID.CODE", date(2026, 8, 18), date(2026, 8, 20)),
+        )
+        reads: list[str] = []
+
+        def reader(code, start, end):
+            reads.append(code)
+            return [
+                BarDTO(
+                    instrument_id=INSTRUMENT_ID,
+                    trade_date=day,
+                    values={"close": Decimal("1")},
+                )
+                for day in (start, end)
+            ]
+
+        with self.assertRaises(IdentityMappingMissingError):
+            stitch_segmented_history(
+                segments,
+                sessions=[date(2026, 8, 18), date(2026, 8, 19)],
+                read_segment=reader,
+            )
+
+    def test_duplicate_or_unsorted_session_input_is_rejected(self) -> None:
+        with self.assertRaises(ValueError):
+            stitch_segmented_history(
+                self._segments(),
+                sessions=[date(2026, 8, 19), date(2026, 8, 19)],
+                read_segment=lambda code, start, end: [],
+            )
+        with self.assertRaises(ValueError):
+            stitch_segmented_history(
+                self._segments(),
+                sessions=[date(2026, 8, 21), date(2026, 8, 18)],
+                read_segment=lambda code, start, end: [],
             )
 
     def test_missing_history_bars_block_instead_of_forward_fill(self) -> None:

--- a/backend/tests/test_strategy_protocol_data.py
+++ b/backend/tests/test_strategy_protocol_data.py
@@ -400,6 +400,17 @@ class PitStitchingTestCase(unittest.TestCase):
             )
         self.assertEqual(reads, [])
 
+    def test_segment_readers_must_return_real_bar_dtos(self) -> None:
+        class _FakeBar:
+            trade_date = date(2026, 8, 18)
+
+        with self.assertRaises(InvalidProviderResultError):
+            stitch_segmented_history(
+                self._segments(),
+                sessions=[date(2026, 8, 18)],
+                read_segment=lambda code, start, end: [_FakeBar()],
+            )
+
     def test_duplicate_bars_within_one_segment_are_rejected(self) -> None:
         def reader(code, start, end):
             return [
@@ -541,7 +552,7 @@ class UniverseQueryTestCase(unittest.TestCase):
             with self.assertRaises(ValueError, msg=blank_field):
                 InstrumentCandidateDTO(instrument_id=uuid4(), **{**base, blank_field: "  "})
 
-    def test_candidate_metadata_is_deep_frozen(self) -> None:
+    def test_candidate_metadata_is_deep_frozen_and_json_only(self) -> None:
         candidate = InstrumentCandidateDTO(
             instrument_id=uuid4(),
             trading_code="SYN.A",
@@ -555,6 +566,24 @@ class UniverseQueryTestCase(unittest.TestCase):
             candidate.metadata["tags"].append("c")  # type: ignore[attr-defined]
         with self.assertRaises((TypeError, AttributeError)):
             candidate.metadata["meta"]["k"].append(3)  # type: ignore[index]
+
+        base = dict(
+            trading_code="SYN.A",
+            name="合成标的 A",
+            display_name="Synthetic A",
+            asset_class="etf",
+            exchange="SSE",
+        )
+        # Non-JSON values such as sets are rejected outright.
+        with self.assertRaises(ValueError):
+            InstrumentCandidateDTO(
+                instrument_id=uuid4(), **base, metadata={"tags": {"a"}}
+            )
+        # Non-string keys are rejected instead of silently stringified.
+        with self.assertRaises(ValueError):
+            InstrumentCandidateDTO(
+                instrument_id=uuid4(), **base, metadata={1: "one"}
+            )
 
     def test_universe_provider_results_are_validated_and_sorted(self) -> None:
         first_id = uuid4()

--- a/backend/tests/test_strategy_protocol_data.py
+++ b/backend/tests/test_strategy_protocol_data.py
@@ -595,6 +595,26 @@ class UniverseQueryTestCase(unittest.TestCase):
             instrument_id=uuid4(), **base, metadata={"weight": 0.5}
         )
         self.assertEqual(ok.metadata["weight"], 0.5)
+        # Regression: scalar subclasses can carry mutable attributes, so only
+        # exact JSON scalar types pass through.
+        class _MutableInt(int):
+            pass
+
+        smuggled = _MutableInt(1)
+        object.__setattr__(smuggled, "payload", [])
+        with self.assertRaises(ValueError):
+            InstrumentCandidateDTO(
+                instrument_id=uuid4(), **base, metadata={"x": smuggled}
+            )
+
+        class _MutableStr(str):
+            pass
+
+        with self.assertRaises(ValueError):
+            InstrumentCandidateDTO(
+                instrument_id=uuid4(),
+                **{**base, "name": _MutableStr("别名")},
+            )
 
     def test_universe_provider_results_are_validated_and_sorted(self) -> None:
         first_id = uuid4()

--- a/backend/tests/test_strategy_protocol_data.py
+++ b/backend/tests/test_strategy_protocol_data.py
@@ -584,6 +584,17 @@ class UniverseQueryTestCase(unittest.TestCase):
             InstrumentCandidateDTO(
                 instrument_id=uuid4(), **base, metadata={1: "one"}
             )
+        # Non-finite floats are not valid JSON numbers.
+        for bad_float in (float("nan"), float("inf"), float("-inf")):
+            with self.assertRaises(ValueError, msg=repr(bad_float)):
+                InstrumentCandidateDTO(
+                    instrument_id=uuid4(), **base, metadata={"weight": bad_float}
+                )
+        # Finite floats stay accepted.
+        ok = InstrumentCandidateDTO(
+            instrument_id=uuid4(), **base, metadata={"weight": 0.5}
+        )
+        self.assertEqual(ok.metadata["weight"], 0.5)
 
     def test_universe_provider_results_are_validated_and_sorted(self) -> None:
         first_id = uuid4()

--- a/backend/tests/test_strategy_protocol_data.py
+++ b/backend/tests/test_strategy_protocol_data.py
@@ -181,6 +181,55 @@ class ReadOnlyFacadeTestCase(unittest.TestCase):
             )
         self.assertEqual(view.reads, 0)
 
+    def test_provider_rows_must_be_immutable_dtos(self) -> None:
+        cutoff_day = AWARE_CUTOFF.date()
+
+        class _FakeBar:
+            instrument_id = INSTRUMENT_ID
+            trade_date = cutoff_day
+            values = {"close": []}
+
+        class _FakeProvider(_CountingView):
+            def bars(self, instrument_id, *, start_date, end_date, lookback_sessions):
+                self.reads += 1
+                return (_FakeBar(),)
+
+        with self.assertRaises(InvalidProviderResultError):
+            StrategyDataDTO(_FakeProvider(), data_cutoff=AWARE_CUTOFF).bars(
+                INSTRUMENT_ID
+            )
+
+        class _FakePoint:
+            instrument_id = INSTRUMENT_ID
+            trade_date = cutoff_day
+            adj_factor = 1.5
+
+        class _FakeSeriesProvider(_CountingView):
+            def adjusted_series(
+                self, instrument_id, *, start_date, end_date, lookback_sessions, basis
+            ):
+                self.reads += 1
+                return (_FakePoint(),)
+
+        with self.assertRaises(InvalidProviderResultError):
+            StrategyDataDTO(
+                _FakeSeriesProvider(),
+                data_cutoff=AWARE_CUTOFF,
+                adjustment_gate=AdjustmentPolicyGate.active_gate(),
+            ).adjusted_series(INSTRUMENT_ID, basis="qfq")
+
+    def test_lookback_and_explicit_dates_cannot_be_combined(self) -> None:
+        view = _CountingView([_bar(AWARE_CUTOFF.date())])
+        facade = StrategyDataDTO(view, data_cutoff=AWARE_CUTOFF)
+        day = AWARE_CUTOFF.date() - timedelta(days=3)
+        with self.assertRaises(ValueError):
+            facade.bars(INSTRUMENT_ID, start_date=day, lookback_sessions=5)
+        with self.assertRaises(ValueError):
+            facade.bars(INSTRUMENT_ID, end_date=day, lookback_sessions=5)
+        # Pure lookback and pure explicit ranges both stay valid.
+        facade.bars(INSTRUMENT_ID, lookback_sessions=5)
+        facade.bars(INSTRUMENT_ID, start_date=day, end_date=AWARE_CUTOFF.date())
+
     def test_provider_rows_are_revalidated_on_the_way_out(self) -> None:
         cutoff_day = AWARE_CUTOFF.date()
 
@@ -491,6 +540,21 @@ class UniverseQueryTestCase(unittest.TestCase):
         for blank_field in ("trading_code", "name", "display_name", "asset_class", "exchange"):
             with self.assertRaises(ValueError, msg=blank_field):
                 InstrumentCandidateDTO(instrument_id=uuid4(), **{**base, blank_field: "  "})
+
+    def test_candidate_metadata_is_deep_frozen(self) -> None:
+        candidate = InstrumentCandidateDTO(
+            instrument_id=uuid4(),
+            trading_code="SYN.A",
+            name="合成标的 A",
+            display_name="Synthetic A",
+            asset_class="etf",
+            exchange="SSE",
+            metadata={"tags": ["a", "b"], "meta": {"k": [1, 2]}},
+        )
+        with self.assertRaises((TypeError, AttributeError)):
+            candidate.metadata["tags"].append("c")  # type: ignore[attr-defined]
+        with self.assertRaises((TypeError, AttributeError)):
+            candidate.metadata["meta"]["k"].append(3)  # type: ignore[index]
 
     def test_universe_provider_results_are_validated_and_sorted(self) -> None:
         first_id = uuid4()

--- a/backend/tests/test_strategy_protocol_data.py
+++ b/backend/tests/test_strategy_protocol_data.py
@@ -119,18 +119,42 @@ class ReadOnlyFacadeTestCase(unittest.TestCase):
     def _facade(self) -> StrategyDataDTO:
         return StrategyDataDTO(_CountingView(), data_cutoff=AWARE_CUTOFF)
 
-    def test_data_facade_attributes_are_read_only(self) -> None:
+    def test_provider_objects_are_not_part_of_the_public_surface(self) -> None:
         facade = self._facade()
-        for name, value in (
-            ("_data_cutoff", AWARE_CUTOFF.replace(year=2999)),
-            ("_max_lookback_sessions", 100_000),
-            ("_view", _CountingView()),
-            ("_adjustment_gate", AdjustmentPolicyGate.active_gate()),
-        ):
-            with self.assertRaises(AttributeError, msg=name):
-                setattr(facade, name, value)
+        # Plain attribute names are gone entirely; only the name-mangled
+        # engine-internal slots remain, and writes stay blocked.
+        for name in ("_view", "_data_cutoff", "_max_lookback_sessions",
+                     "_adjustment_gate"):
+            self.assertFalse(hasattr(facade, name), name)
             with self.assertRaises(AttributeError):
-                delattr(facade, name)
+                getattr(facade, name)
+        with self.assertRaises(AttributeError):
+            setattr(facade, "_StrategyDataDTO__view", _CountingView())
+
+    def test_adjustment_gate_is_read_only(self) -> None:
+        gate = AdjustmentPolicyGate.inactive_gate()
+        with self.assertRaises(AttributeError):
+            gate._active = True
+        with self.assertRaises(AttributeError):
+            delattr(gate, "_AdjustmentPolicyGate__active")
+        self.assertFalse(gate.is_active())
+
+    def test_lookback_cap_cannot_be_raised_by_configuration(self) -> None:
+        view = _CountingView()
+        with self.assertRaises(ValueError):
+            StrategyDataDTO(view, data_cutoff=AWARE_CUTOFF,
+                            max_lookback_sessions=10_000)
+        with self.assertRaises(ValueError):
+            StrategyDataDTO(view, data_cutoff=AWARE_CUTOFF,
+                            max_lookback_sessions=MAX_LOOKBACK_SESSIONS + 1)
+        with self.assertRaises(ValueError):
+            StrategyDataDTO(view, data_cutoff=AWARE_CUTOFF,
+                            max_lookback_sessions=0)
+        # Lowering the cap is the only configuration allowed.
+        lowered = StrategyDataDTO(view, data_cutoff=AWARE_CUTOFF,
+                                  max_lookback_sessions=8)
+        with self.assertRaises(LookbackLimitExceededError):
+            lowered.bars(INSTRUMENT_ID, lookback_sessions=9)
 
     def test_universe_facade_attributes_are_read_only(self) -> None:
         class _Universe:
@@ -141,7 +165,7 @@ class ReadOnlyFacadeTestCase(unittest.TestCase):
         with self.assertRaises(AttributeError):
             facade._query = lambda **kwargs: ()
         with self.assertRaises(AttributeError):
-            delattr(facade, "_query")
+            delattr(facade, "_UniverseQueryDTO__query")
 
     def test_conflicting_lookback_and_start_date_is_rejected(self) -> None:
         view = _CountingView([_bar(day) for day in (
@@ -307,7 +331,8 @@ class PitStitchingTestCase(unittest.TestCase):
             )
 
     def test_overlapping_segments_block_instead_of_duplicating_bars(self) -> None:
-        # Both segments claim 2026-08-19; exactly-one coverage must fail.
+        # Both segments claim 2026-08-19; exactly-one coverage must fail
+        # before any provider read happens.
         segments = (
             PitSegment("OLD.CODE", date(2026, 8, 17), date(2026, 8, 19)),
             PitSegment("MID.CODE", date(2026, 8, 18), date(2026, 8, 20)),
@@ -316,19 +341,52 @@ class PitStitchingTestCase(unittest.TestCase):
 
         def reader(code, start, end):
             reads.append(code)
-            return [
-                BarDTO(
-                    instrument_id=INSTRUMENT_ID,
-                    trade_date=day,
-                    values={"close": Decimal("1")},
-                )
-                for day in (start, end)
-            ]
+            return []
 
         with self.assertRaises(IdentityMappingMissingError):
             stitch_segmented_history(
                 segments,
                 sessions=[date(2026, 8, 18), date(2026, 8, 19)],
+                read_segment=reader,
+            )
+        self.assertEqual(reads, [])
+
+    def test_duplicate_bars_within_one_segment_are_rejected(self) -> None:
+        def reader(code, start, end):
+            return [
+                BarDTO(
+                    instrument_id=INSTRUMENT_ID,
+                    trade_date=date(2026, 8, 18),
+                    values={"close": Decimal("1")},
+                ),
+                BarDTO(
+                    instrument_id=INSTRUMENT_ID,
+                    trade_date=date(2026, 8, 18),
+                    values={"close": Decimal("2")},
+                ),
+            ]
+
+        with self.assertRaises(IncompleteHistoryError):
+            stitch_segmented_history(
+                self._segments(),
+                sessions=[date(2026, 8, 18)],
+                read_segment=reader,
+            )
+
+    def test_out_of_range_segment_bars_are_rejected(self) -> None:
+        def reader(code, start, end):
+            return [
+                BarDTO(
+                    instrument_id=INSTRUMENT_ID,
+                    trade_date=date(2026, 8, 21),
+                    values={"close": Decimal("1")},
+                ),
+            ]
+
+        with self.assertRaises(IncompleteHistoryError):
+            stitch_segmented_history(
+                self._segments(),
+                sessions=[date(2026, 8, 18)],
                 read_segment=reader,
             )
 
@@ -397,6 +455,52 @@ class UniverseQueryTestCase(unittest.TestCase):
             row.metadata["x"] = "y"
         # Filtering by another exchange returns nothing.
         self.assertEqual(facade.query(exchanges=["SZSE"]), ())
+
+    def test_universe_provider_results_are_validated_and_sorted(self) -> None:
+        first_id = uuid4()
+        second_id = uuid4()
+        rows = [
+            (second_id, "SYN.B"),
+            (first_id, "SYN.A"),
+        ]
+
+        def make_provider(candidate_rows):
+            class _Universe:
+                def query(self, *, exchanges=None, asset_classes=None):
+                    return tuple(
+                        InstrumentCandidateDTO(
+                            instrument_id=instrument_id,
+                            trading_code=code,
+                            name=code,
+                            display_name=code,
+                            asset_class="etf",
+                            exchange="SSE",
+                        )
+                        for instrument_id, code in candidate_rows
+                    )
+
+            return _Universe()
+
+        # Results come back in stable instrument_id order regardless of the
+        # provider's ordering.
+        result = UniverseQueryDTO(make_provider(rows)).query()
+        expected_order = [
+            code for _, code in sorted(rows, key=lambda row: str(row[0]))
+        ]
+        self.assertEqual(
+            [row.trading_code for row in result], expected_order
+        )
+
+        # Duplicate identities are rejected instead of handed to strategies.
+        with self.assertRaises(InvalidProviderResultError):
+            UniverseQueryDTO(make_provider([(first_id, "A"), (first_id, "B")])).query()
+
+        class _BrokenUniverse:
+            def query(self, *, exchanges=None, asset_classes=None):
+                return ("not-a-candidate",)
+
+        with self.assertRaises(InvalidProviderResultError):
+            UniverseQueryDTO(_BrokenUniverse()).query()
 
 
 if __name__ == "__main__":

--- a/backend/tests/test_strategy_protocol_data.py
+++ b/backend/tests/test_strategy_protocol_data.py
@@ -1,0 +1,247 @@
+"""Tests for the strategy data-query contract and its boundaries."""
+
+import unittest
+from dataclasses import FrozenInstanceError
+from datetime import date, datetime, timedelta, timezone
+from decimal import Decimal
+from uuid import uuid4
+
+from app.strategy_protocol.contract import (
+    MAX_LOOKBACK_SESSIONS,
+    AdjustmentNotActiveError,
+    DataCutoffViolationError,
+    IdentityMappingMissingError,
+    IncompleteHistoryError,
+    LookbackLimitExceededError,
+)
+from app.strategy_protocol.data_view import (
+    AdjustmentBasis,
+    AdjustmentPolicyGate,
+    AdjustedSeriesPointDTO,
+    BarDTO,
+    InstrumentCandidateDTO,
+    PitSegment,
+    StrategyDataDTO,
+    UniverseQueryDTO,
+    stitch_segmented_history,
+)
+
+AWARE_CUTOFF = datetime(2026, 8, 21, 15, 0, 0, tzinfo=timezone(timedelta(hours=8)))
+INSTRUMENT_ID = uuid4()
+
+
+class _CountingView:
+    """Read side that records whether any read actually happened."""
+
+    def __init__(self, rows=()):
+        self.rows = list(rows)
+        self.reads = 0
+
+    def bars(self, instrument_id, *, start_date, end_date, lookback_sessions):
+        self.reads += 1
+        selected = [
+            row
+            for row in self.rows
+            if (start_date is None or row.trade_date >= start_date)
+            and (end_date is None or row.trade_date <= end_date)
+        ]
+        if lookback_sessions is not None:
+            selected = selected[-lookback_sessions:]
+        return tuple(selected)
+
+    def adjusted_series(
+        self, instrument_id, *, start_date, end_date, lookback_sessions, basis
+    ):
+        self.reads += 1
+        if basis is AdjustmentBasis.RAW:
+            # Raw series carry no adjustment factors by contract.
+            return ()
+        return (
+            AdjustedSeriesPointDTO(instrument_id=instrument_id, trade_date=day, adj_factor=Decimal("1.1"))
+            for day in (date(2026, 8, 20), date(2026, 8, 21))
+        )
+
+
+def _bar(day: date, close: str = "10") -> BarDTO:
+    return BarDTO(
+        instrument_id=INSTRUMENT_ID,
+        trade_date=day,
+        values={"close": Decimal(close)},
+    )
+
+
+class DataBoundaryTestCase(unittest.TestCase):
+    """Cover cutoff and lookback enforcement before any read happens."""
+
+    def test_query_past_data_cutoff_is_rejected_without_reading(self) -> None:
+        view = _CountingView()
+        facade = StrategyDataDTO(view, data_cutoff=AWARE_CUTOFF)
+        with self.assertRaises(DataCutoffViolationError):
+            facade.bars(INSTRUMENT_ID, end_date=AWARE_CUTOFF.date() + timedelta(days=1))
+        with self.assertRaises(DataCutoffViolationError):
+            facade.bars(INSTRUMENT_ID, start_date=AWARE_CUTOFF.date() + timedelta(days=1))
+        self.assertEqual(view.reads, 0)
+
+    def test_lookback_over_512_fails_before_reading(self) -> None:
+        view = _CountingView()
+        facade = StrategyDataDTO(view, data_cutoff=AWARE_CUTOFF)
+        with self.assertRaises(LookbackLimitExceededError):
+            facade.bars(INSTRUMENT_ID, lookback_sessions=MAX_LOOKBACK_SESSIONS + 1)
+        self.assertEqual(view.reads, 0)
+        with self.assertRaises(LookbackLimitExceededError):
+            facade.adjusted_series(INSTRUMENT_ID, lookback_sessions=513)
+
+    def test_valid_window_within_limits_reads_normally(self) -> None:
+        view = _CountingView([_bar(AWARE_CUTOFF.date())])
+        facade = StrategyDataDTO(view, data_cutoff=AWARE_CUTOFF)
+        bars = facade.bars(INSTRUMENT_ID, lookback_sessions=MAX_LOOKBACK_SESSIONS)
+        self.assertEqual(len(bars), 1)
+        self.assertEqual(bars[0].values["close"], Decimal("10"))
+
+    def test_bar_dto_values_are_read_only_and_float_free(self) -> None:
+        bar = _bar(AWARE_CUTOFF.date())
+        with self.assertRaises(TypeError):
+            bar.values["close"] = Decimal("1")
+
+
+class AdjustmentPolicyTestCase(unittest.TestCase):
+    """Cover raw/qfq/hfq gating rules."""
+
+    def setUp(self) -> None:
+        self.view = _CountingView()
+
+    def test_raw_needs_no_active_policy(self) -> None:
+        facade = StrategyDataDTO(
+            self.view,
+            data_cutoff=AWARE_CUTOFF,
+            adjustment_gate=AdjustmentPolicyGate.inactive_gate(),
+        )
+        points = facade.adjusted_series(INSTRUMENT_ID, basis="raw")
+        self.assertEqual(list(points), [])
+
+    def test_qfq_hfq_blocked_until_policy_active(self) -> None:
+        facade = StrategyDataDTO(
+            self.view,
+            data_cutoff=AWARE_CUTOFF,
+            adjustment_gate=AdjustmentPolicyGate.inactive_gate(),
+        )
+        for basis in ("qfq", "hfq"):
+            with self.assertRaises(AdjustmentNotActiveError):
+                facade.adjusted_series(INSTRUMENT_ID, basis=basis)
+
+    def test_adjusted_series_served_only_with_active_verified_policy(self) -> None:
+        gate = AdjustmentPolicyGate.from_policy_key("tushare_adj_factor_native@1")
+        facade = StrategyDataDTO(
+            self.view, data_cutoff=AWARE_CUTOFF, adjustment_gate=gate
+        )
+        points = facade.adjusted_series(
+            INSTRUMENT_ID,
+            end_date=AWARE_CUTOFF.date(),
+            basis=AdjustmentBasis.QFQ,
+        )
+        self.assertTrue(all(point.adj_factor == Decimal("1.1") for point in points))
+        # An unknown policy key never activates the gate.
+        inactive = AdjustmentPolicyGate.from_policy_key("some_other@9")
+        self.assertFalse(inactive.is_active())
+
+
+class PitStitchingTestCase(unittest.TestCase):
+    """Cover cross-code PIT segmentation and blocking semantics."""
+
+    def _segments(self) -> tuple[PitSegment, ...]:
+        return (
+            PitSegment("OLD.CODE", date(2026, 8, 17), date(2026, 8, 19)),
+            PitSegment("NEW.CODE", date(2026, 8, 20), date(2026, 8, 21)),
+        )
+
+    def test_segments_stitch_back_to_one_sorted_series(self) -> None:
+        sessions = [date(2026, 8, d) for d in (18, 19, 20, 21)]
+
+        def reader(code, start, end):
+            days = [day for day in sessions if start <= day <= end]
+            return [
+                BarDTO(instrument_id=INSTRUMENT_ID, trade_date=day, values={"close": Decimal("1")})
+                for day in days
+            ]
+
+        stitched = stitch_segmented_history(
+            self._segments(), sessions=sessions, read_segment=reader
+        )
+        self.assertEqual([bar.trade_date for bar in stitched], sessions)
+        # All bars carry the same stable identity, not the historical codes.
+        self.assertTrue(all(bar.instrument_id == INSTRUMENT_ID for bar in stitched))
+
+    def test_mapping_gap_blocks_instead_of_returning_shorter_window(self) -> None:
+        # Session 2026-08-20 is covered by neither segment.
+        segments = (
+            PitSegment("OLD.CODE", date(2026, 8, 17), date(2026, 8, 19)),
+            PitSegment("NEW.CODE", date(2026, 8, 21), date(2026, 8, 21)),
+        )
+
+        def reader(code, start, end):
+            return [
+                BarDTO(instrument_id=INSTRUMENT_ID, trade_date=start, values={"close": Decimal("1")})
+            ]
+
+        with self.assertRaises(IdentityMappingMissingError):
+            stitch_segmented_history(
+                segments,
+                sessions=[date(2026, 8, 18), date(2026, 8, 20), date(2026, 8, 21)],
+                read_segment=reader,
+            )
+
+    def test_missing_history_bars_block_instead_of_forward_fill(self) -> None:
+        sessions = [date(2026, 8, 18), date(2026, 8, 19)]
+
+        def reader(code, start, end):
+            # The old code only has the first session; the second is missing.
+            return [
+                BarDTO(
+                    instrument_id=INSTRUMENT_ID,
+                    trade_date=date(2026, 8, 18),
+                    values={"close": Decimal("1")},
+                )
+            ]
+
+        with self.assertRaises(IncompleteHistoryError):
+            stitch_segmented_history(
+                self._segments(), sessions=sessions, read_segment=reader
+            )
+
+
+class UniverseQueryTestCase(unittest.TestCase):
+    """Cover candidate identity and immutability."""
+
+    def test_query_returns_read_only_candidates_with_display_identity(self) -> None:
+        candidate = InstrumentCandidateDTO(
+            instrument_id=uuid4(),
+            trading_code="SYN.A",
+            name="合成标的 A",
+            display_name="Synthetic A",
+            asset_class="etf",
+            exchange="SSE",
+        )
+
+        class _Universe:
+            def query(self, *, exchanges=None, asset_classes=None):
+                if exchanges is not None and "SSE" not in set(exchanges):
+                    return ()
+                return (candidate,)
+
+        facade = UniverseQueryDTO(_Universe())
+        result = facade.query()
+        self.assertIsInstance(result, tuple)
+        row = result[0]
+        self.assertEqual(row.trading_code, "SYN.A")
+        self.assertEqual(row.asset_class, "etf")
+        self.assertEqual(row.exchange, "SSE")
+        with self.assertRaises(FrozenInstanceError):
+            row.name = "改写"
+        with self.assertRaises(TypeError):
+            row.metadata["x"] = "y"
+        # Filtering by another exchange returns nothing.
+        self.assertEqual(facade.query(exchanges=["SZSE"]), ())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/backend/tests/test_strategy_protocol_data.py
+++ b/backend/tests/test_strategy_protocol_data.py
@@ -390,6 +390,26 @@ class PitStitchingTestCase(unittest.TestCase):
                 read_segment=reader,
             )
 
+    def test_extra_bars_on_mapped_but_unrequested_days_are_rejected(self) -> None:
+        # Session 2026-08-19 is inside the old segment's mapped range but was
+        # not requested; the reader must not smuggle it into the result.
+        def reader(code, start, end):
+            return [
+                BarDTO(
+                    instrument_id=INSTRUMENT_ID,
+                    trade_date=day,
+                    values={"close": Decimal("1")},
+                )
+                for day in (date(2026, 8, 18), date(2026, 8, 19))
+            ]
+
+        with self.assertRaises(IncompleteHistoryError):
+            stitch_segmented_history(
+                self._segments(),
+                sessions=[date(2026, 8, 18)],
+                read_segment=reader,
+            )
+
     def test_duplicate_or_unsorted_session_input_is_rejected(self) -> None:
         with self.assertRaises(ValueError):
             stitch_segmented_history(
@@ -455,6 +475,22 @@ class UniverseQueryTestCase(unittest.TestCase):
             row.metadata["x"] = "y"
         # Filtering by another exchange returns nothing.
         self.assertEqual(facade.query(exchanges=["SZSE"]), ())
+
+    def test_candidate_identity_fields_are_validated(self) -> None:
+        base = dict(
+            trading_code="SYN.A",
+            name="合成标的 A",
+            display_name="Synthetic A",
+            asset_class="etf",
+            exchange="SSE",
+        )
+        with self.assertRaises(ValueError):
+            InstrumentCandidateDTO(instrument_id="not-a-uuid", **base)
+        with self.assertRaises(ValueError):
+            InstrumentCandidateDTO(instrument_id=None, **base)
+        for blank_field in ("trading_code", "name", "display_name", "asset_class", "exchange"):
+            with self.assertRaises(ValueError, msg=blank_field):
+                InstrumentCandidateDTO(instrument_id=uuid4(), **{**base, blank_field: "  "})
 
     def test_universe_provider_results_are_validated_and_sorted(self) -> None:
         first_id = uuid4()

--- a/backend/tests/test_strategy_protocol_decisions.py
+++ b/backend/tests/test_strategy_protocol_decisions.py
@@ -17,6 +17,8 @@ from app.strategy_protocol.contract import (
 from app.strategy_protocol.context import (
     DecisionContext,
     DeterministicClockDTO,
+    FillSummaryDTO,
+    OrderSummaryDTO,
     PortfolioDTO,
     PositionDTO,
     PreviousStepDTO,
@@ -334,6 +336,25 @@ class ContextDtoTestCase(unittest.TestCase):
         self.assertEqual(context.clock.today(), context.session_date)
         with self.assertRaises(FrozenInstanceError):
             context.step_sequence = 99
+
+    def test_previous_step_sequences_are_frozen_tuples(self) -> None:
+        previous = PreviousStepDTO(step_sequence=1, order_statuses=["pending"])
+        with self.assertRaises((AttributeError, TypeError)):
+            previous.order_statuses.append("filled")
+        self.assertEqual(previous.order_statuses, ("pending",))
+        # Mutable stand-ins for orders/fills are rejected outright.
+        with self.assertRaises(InvalidDecisionPayloadError):
+            PreviousStepDTO(step_sequence=1, orders=[{"x": []}])
+        with self.assertRaises(InvalidDecisionPayloadError):
+            PreviousStepDTO(step_sequence=1, fills=[object()])
+        valid = PreviousStepDTO(
+            step_sequence=1,
+            orders=[OrderSummaryDTO(instrument_id=uuid4(), side="buy",
+                                    quantity=Decimal("1"), status="filled")],
+            fills=[FillSummaryDTO(instrument_id=uuid4(), side="buy",
+                                  quantity=Decimal("1"), price=Decimal("10"))],
+        )
+        self.assertIsInstance(valid.orders, tuple)
 
     def test_context_rejects_mismatched_or_naive_clock_fields(self) -> None:
         clock = DeterministicClockDTO(

--- a/backend/tests/test_strategy_protocol_decisions.py
+++ b/backend/tests/test_strategy_protocol_decisions.py
@@ -279,6 +279,55 @@ class ContextDtoTestCase(unittest.TestCase):
                 positions=(_make_position(same_id), _make_position(same_id)),
             )
 
+    def test_portfolio_rejects_float_and_invalid_amounts(self) -> None:
+        base = dict(
+            cash_balances={"CNY": Decimal("1")},
+            available_cash=Decimal("1"),
+            frozen_cash=Decimal("0"),
+            margin_used=Decimal("0"),
+            margin_available=Decimal("1"),
+            equity=Decimal("1"),
+        )
+        # The engine's Decimal normalization rejects binary floats with a
+        # TypeError and invalid decimal values with a DomainValidationError.
+        numeric_error = (TypeError, ValueError)
+        for field in ("available_cash", "frozen_cash", "margin_used",
+                      "margin_available", "equity"):
+            with self.assertRaises(numeric_error, msg=field):
+                PortfolioDTO(**{**base, field: 1.5})
+        with self.assertRaises(numeric_error):
+            PortfolioDTO(**{**base, "cash_balances": {"CNY": 2.5}})
+        # Negative non-cash amounts are rejected as well.
+        with self.assertRaises(ValueError):
+            PortfolioDTO(**{**base, "frozen_cash": Decimal("-1")})
+
+    def test_position_rejects_float_and_inconsistent_quantities(self) -> None:
+        def position(**overrides):
+            values = dict(
+                instrument_id=uuid4(),
+                trading_code="SYN.A",
+                name="合成标的 A",
+                display_name="Synthetic A",
+                side="long",
+                quantity=Decimal("100"),
+                available_quantity=Decimal("100"),
+                average_price=Decimal("10"),
+                mark_price=Decimal("11"),
+                realized_pnl=Decimal("0"),
+                unrealized_pnl=Decimal("100"),
+            )
+            values.update(overrides)
+            return PositionDTO(**values)
+
+        numeric_error = (TypeError, ValueError)
+        for field in ("quantity", "average_price", "mark_price", "realized_pnl"):
+            with self.assertRaises(numeric_error, msg=field):
+                position(**{field: 1.5})
+        with self.assertRaises(ValueError):  # available above owned quantity
+            position(available_quantity=Decimal("200"))
+        with self.assertRaises(ValueError):  # zero-quantity positions rejected
+            position(quantity=Decimal("0"), average_price=None)
+
     def test_context_binds_clock_to_step_and_is_immutable(self) -> None:
         context = _make_context()
         self.assertEqual(context.clock.now(), context.decision_time)

--- a/backend/tests/test_strategy_protocol_decisions.py
+++ b/backend/tests/test_strategy_protocol_decisions.py
@@ -356,6 +356,56 @@ class ContextDtoTestCase(unittest.TestCase):
         )
         self.assertIsInstance(valid.orders, tuple)
 
+    def test_position_rejects_invalid_identity_and_display_fields(self) -> None:
+        base = dict(
+            trading_code="SYN.A",
+            name="合成标的 A",
+            display_name="Synthetic A",
+            side="long",
+            quantity=Decimal("100"),
+            available_quantity=Decimal("100"),
+            average_price=Decimal("10"),
+            mark_price=Decimal("11"),
+            realized_pnl=Decimal("0"),
+            unrealized_pnl=Decimal("100"),
+        )
+        with self.assertRaises(InvalidDecisionPayloadError):
+            PositionDTO(instrument_id="not-a-uuid", **base)
+        with self.assertRaises(InvalidDecisionPayloadError):
+            PositionDTO(instrument_id=uuid4(), **{**base, "trading_code": ""})
+
+    def test_order_and_fill_summaries_validate_identity_and_strings(self) -> None:
+        with self.assertRaises(InvalidDecisionPayloadError):
+            OrderSummaryDTO(
+                instrument_id="not-a-uuid", side="buy",
+                quantity=Decimal("1"), status="filled",
+            )
+        with self.assertRaises(InvalidDecisionPayloadError):
+            OrderSummaryDTO(
+                instrument_id=uuid4(), side="  ",
+                quantity=Decimal("1"), status="filled",
+            )
+        with self.assertRaises(InvalidDecisionPayloadError):
+            FillSummaryDTO(
+                instrument_id=None, side="buy",
+                quantity=Decimal("1"), price=Decimal("10"),
+            )
+
+    def test_portfolio_rejects_non_position_elements(self) -> None:
+        class _FakePosition:
+            instrument_id = uuid4()
+
+        with self.assertRaises(InvalidDecisionPayloadError):
+            PortfolioDTO(
+                cash_balances={},
+                available_cash=Decimal("0"),
+                frozen_cash=Decimal("0"),
+                margin_used=Decimal("0"),
+                margin_available=Decimal("0"),
+                equity=Decimal("0"),
+                positions=(_FakePosition(),),
+            )
+
     def test_context_rejects_mismatched_or_naive_clock_fields(self) -> None:
         clock = DeterministicClockDTO(
             decision_time=AWARE_TIME, session_date=date(1999, 1, 1)

--- a/backend/tests/test_strategy_protocol_decisions.py
+++ b/backend/tests/test_strategy_protocol_decisions.py
@@ -1,0 +1,309 @@
+"""Tests for strategy protocol decisions, modes, and the read-only context."""
+
+import unittest
+from dataclasses import FrozenInstanceError
+from datetime import date, datetime, timedelta, timezone
+from decimal import Decimal
+from types import MappingProxyType
+from uuid import uuid4
+
+from app.strategy_protocol.contract import (
+    STRATEGY_CONTRACT_VERSION,
+    InvalidDecisionPayloadError,
+    MissingDecisionModeError,
+    UnknownDecisionModeError,
+    UnknownInstrumentError,
+)
+from app.strategy_protocol.context import (
+    DecisionContext,
+    DeterministicClockDTO,
+    PortfolioDTO,
+    PositionDTO,
+    PreviousStepDTO,
+)
+from app.strategy_protocol.decisions import (
+    HOLD_MODE,
+    TARGET_WEIGHTS_MODE,
+    StrategyDecision,
+    build_default_registry,
+)
+
+AWARE_TIME = datetime(2026, 8, 21, 15, 0, 0, tzinfo=timezone(timedelta(hours=8)))
+SESSION_DAY = date(2026, 8, 21)
+
+
+def _make_position(instrument_id=None):
+    return PositionDTO(
+        instrument_id=instrument_id or uuid4(),
+        trading_code="SYN.A",
+        name="合成标的 A",
+        display_name="Synthetic A",
+        side="long",
+        quantity=Decimal("100"),
+        available_quantity=Decimal("100"),
+        average_price=Decimal("10"),
+        mark_price=Decimal("11"),
+        realized_pnl=Decimal("0"),
+        unrealized_pnl=Decimal("100"),
+    )
+
+
+def _make_context(positions=(), candidates=()):
+    """Build a minimal context with stub query facades."""
+
+    class _StubUniverse:
+        def __init__(self, rows):
+            self._rows = tuple(rows)
+
+        def query(self, *, exchanges=None, asset_classes=None):
+            return self._rows
+
+    class _StubData:
+        pass
+
+    clock = DeterministicClockDTO(decision_time=AWARE_TIME, session_date=SESSION_DAY)
+    portfolio = PortfolioDTO(
+        cash_balances={"CNY": Decimal("100000")},
+        available_cash=Decimal("100000"),
+        frozen_cash=Decimal("0"),
+        margin_used=Decimal("0"),
+        margin_available=Decimal("100000"),
+        equity=Decimal("100000"),
+        positions=tuple(positions),
+    )
+    return DecisionContext(
+        step_sequence=1,
+        session_date=SESSION_DAY,
+        decision_time=AWARE_TIME,
+        data_cutoff=AWARE_TIME,
+        timezone="Asia/Shanghai",
+        clock=clock,
+        portfolio=portfolio,
+        previous_step=PreviousStepDTO(step_sequence=0),
+        data=_StubData(),
+        universe=_StubUniverse(candidates),
+    )
+
+
+class DecisionObjectTestCase(unittest.TestCase):
+    """Cover immutability and numeric conversion rules."""
+
+    def test_decision_is_immutable_value_object(self) -> None:
+        decision = StrategyDecision(
+            step_sequence=1,
+            decision_time=AWARE_TIME,
+            mode=HOLD_MODE,
+        )
+        with self.assertRaises(FrozenInstanceError):
+            decision.mode = TARGET_WEIGHTS_MODE
+
+    def test_decimal_strings_and_decimals_are_converted(self) -> None:
+        decision = StrategyDecision(
+            step_sequence=1,
+            decision_time=AWARE_TIME,
+            mode=TARGET_WEIGHTS_MODE,
+            targets={"a": "0.60", "b": Decimal("0.40"), "c": 1},
+        )
+        self.assertEqual(decision.targets["a"], Decimal("0.60"))
+        self.assertEqual(decision.targets["b"], Decimal("0.40"))
+        self.assertEqual(decision.targets["c"], Decimal("1"))
+        # The exposed mapping cannot be mutated by callers.
+        with self.assertRaises(TypeError):
+            decision.targets["a"] = Decimal("1")
+
+    def test_float_bool_and_invalid_values_are_rejected(self) -> None:
+        for value in (0.6, True, False, "abc", "NaN", "Infinity", None, ["0.5"]):
+            with self.assertRaises(Exception, msg=f"{value!r} must be rejected"):
+                StrategyDecision(
+                    step_sequence=1,
+                    decision_time=AWARE_TIME,
+                    mode=TARGET_WEIGHTS_MODE,
+                    targets={"x": value},
+                )
+
+    def test_contract_version_is_pinned(self) -> None:
+        decision = StrategyDecision(
+            step_sequence=1, decision_time=AWARE_TIME, mode=HOLD_MODE
+        )
+        self.assertEqual(decision.contract_version, STRATEGY_CONTRACT_VERSION)
+        with self.assertRaises(InvalidDecisionPayloadError):
+            StrategyDecision(
+                step_sequence=1,
+                decision_time=AWARE_TIME,
+                mode=HOLD_MODE,
+                contract_version=2,
+            )
+
+    def test_naive_decision_time_is_rejected(self) -> None:
+        with self.assertRaises(InvalidDecisionPayloadError):
+            StrategyDecision(
+                step_sequence=1,
+                decision_time=datetime(2026, 8, 21, 15, 0, 0),
+                mode=HOLD_MODE,
+            )
+
+
+class DecisionModeRegistryTestCase(unittest.TestCase):
+    """Cover the first-version registry semantics."""
+
+    def setUp(self) -> None:
+        self.known = {uuid4()}
+        self.registry = build_default_registry()
+
+    def test_only_two_modes_are_registered_but_registry_is_extensible(self) -> None:
+        self.assertEqual(
+            self.registry.modes(), (HOLD_MODE, TARGET_WEIGHTS_MODE)
+        )
+        # The public object is not hard-coded to this subset.
+        self.registry.register("target_positions", lambda targets, ids: {})
+        self.assertIn("target_positions", self.registry.modes())
+
+    def test_target_weights_accepts_partial_known_targets(self) -> None:
+        mode, targets = self.registry.validate(
+            {
+                "mode": "target_weights",
+                "targets": {str(next(iter(self.known))): "0.60"},
+            },
+            known_instrument_ids=self.known,
+        )
+        self.assertEqual(mode, TARGET_WEIGHTS_MODE)
+        self.assertEqual(targets[str(next(iter(self.known)))], Decimal("0.60"))
+
+    def test_unknown_mode_is_rejected(self) -> None:
+        with self.assertRaises(UnknownDecisionModeError):
+            self.registry.validate(
+                {"mode": "order_intents"}, known_instrument_ids=self.known
+            )
+
+    def test_missing_mode_is_rejected(self) -> None:
+        with self.assertRaises(MissingDecisionModeError):
+            self.registry.validate({}, known_instrument_ids=self.known)
+
+    def test_non_object_payloads_are_rejected(self) -> None:
+        for payload in (0.5, "hold", [], None, 3):
+            with self.assertRaises(InvalidDecisionPayloadError):
+                self.registry.validate(payload, known_instrument_ids=self.known)
+
+    def test_unknown_instrument_id_is_rejected(self) -> None:
+        with self.assertRaises(UnknownInstrumentError):
+            self.registry.validate(
+                {
+                    "mode": "target_weights",
+                    "targets": {str(uuid4()): "1"},
+                },
+                known_instrument_ids=self.known,
+            )
+        with self.assertRaises(UnknownInstrumentError):
+            self.registry.validate(
+                {
+                    "mode": "target_weights",
+                    "targets": {"instrument-a": "1"},
+                },
+                known_instrument_ids=self.known,
+            )
+
+    def test_hold_must_not_carry_targets(self) -> None:
+        mode, targets = self.registry.validate(
+            {"mode": "hold"}, known_instrument_ids=self.known
+        )
+        self.assertEqual((mode, targets), (HOLD_MODE, {}))
+        mode, targets = self.registry.validate(
+            {"mode": "hold", "targets": {}}, known_instrument_ids=self.known
+        )
+        self.assertEqual(targets, {})
+        with self.assertRaises(InvalidDecisionPayloadError):
+            self.registry.validate(
+                {
+                    "mode": "hold",
+                    "targets": {str(next(iter(self.known))): "1"},
+                },
+                known_instrument_ids=self.known,
+            )
+
+    def test_legacy_intents_protocol_has_no_compatibility_branch(self) -> None:
+        with self.assertRaises(MissingDecisionModeError):
+            self.registry.validate({"intents": []}, known_instrument_ids=self.known)
+        with self.assertRaises(UnknownDecisionModeError):
+            self.registry.validate(
+                {"mode": "intents", "intents": []},
+                known_instrument_ids=self.known,
+            )
+
+
+class ContextDtoTestCase(unittest.TestCase):
+    """Cover deterministic clock and read-only nested DTOs."""
+
+    def test_clock_is_stable_within_one_step(self) -> None:
+        clock = DeterministicClockDTO(decision_time=AWARE_TIME, session_date=SESSION_DAY)
+        for _ in range(3):
+            self.assertEqual(clock.now(), AWARE_TIME)
+            self.assertEqual(clock.today(), SESSION_DAY)
+
+    def test_real_startup_time_does_not_change_clock_results(self) -> None:
+        first = DeterministicClockDTO(
+            decision_time=AWARE_TIME, session_date=SESSION_DAY
+        )
+        second = DeterministicClockDTO(
+            decision_time=AWARE_TIME, session_date=SESSION_DAY
+        )
+        self.assertEqual(first.now(), second.now())
+        self.assertEqual(first.today(), second.today())
+
+    def test_portfolio_and_positions_are_immutable(self) -> None:
+        position = _make_position()
+        portfolio = PortfolioDTO(
+            cash_balances={"CNY": Decimal("1")},
+            available_cash=Decimal("1"),
+            frozen_cash=Decimal("0"),
+            margin_used=Decimal("0"),
+            margin_available=Decimal("1"),
+            equity=Decimal("1"),
+            positions=(position,),
+        )
+        with self.assertRaises(TypeError):
+            portfolio.cash_balances["USD"] = Decimal("1")
+        with self.assertRaises(FrozenInstanceError):
+            position.quantity = Decimal("2")
+        self.assertIsInstance(portfolio.positions, tuple)
+
+    def test_portfolio_rejects_duplicate_instrument_ids(self) -> None:
+        same_id = uuid4()
+        with self.assertRaises(InvalidDecisionPayloadError):
+            PortfolioDTO(
+                cash_balances={},
+                available_cash=Decimal("0"),
+                frozen_cash=Decimal("0"),
+                margin_used=Decimal("0"),
+                margin_available=Decimal("0"),
+                equity=Decimal("0"),
+                positions=(_make_position(same_id), _make_position(same_id)),
+            )
+
+    def test_context_binds_clock_to_step_and_is_immutable(self) -> None:
+        context = _make_context()
+        self.assertEqual(context.clock.now(), context.decision_time)
+        self.assertEqual(context.clock.today(), context.session_date)
+        with self.assertRaises(FrozenInstanceError):
+            context.step_sequence = 99
+
+    def test_context_rejects_mismatched_or_naive_clock_fields(self) -> None:
+        clock = DeterministicClockDTO(
+            decision_time=AWARE_TIME, session_date=date(1999, 1, 1)
+        )
+        with self.assertRaises(InvalidDecisionPayloadError):
+            _make_context().__class__(
+                step_sequence=1,
+                session_date=SESSION_DAY,
+                decision_time=AWARE_TIME,
+                data_cutoff=AWARE_TIME,
+                timezone="Asia/Shanghai",
+                clock=clock,
+                portfolio=_make_context().portfolio,
+                previous_step=PreviousStepDTO(step_sequence=0),
+                data=_make_context().data,
+                universe=_make_context().universe,
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/backend/tests/test_strategy_storage.py
+++ b/backend/tests/test_strategy_storage.py
@@ -23,8 +23,11 @@ from app.strategies.service import (
 )
 
 
-SOURCE_V1 = "def run(context, parameters):\n    return {'intents': []}\n"
-SOURCE_V2 = "def run(context, parameters):\n    return {'intents': [{'ts_code': '510300.SH'}]}\n"
+SOURCE_V1 = "def run(context, parameters):\n    return {'mode': 'hold'}\n"
+SOURCE_V2 = (
+    "def run(context, parameters):\n"
+    "    return {'mode': 'target_weights', 'targets': {}}\n"
+)
 
 
 class StrategyStorageModelTestCase(unittest.TestCase):
@@ -239,6 +242,28 @@ class StrategyStorageServiceTestCase(unittest.TestCase):
 
         self.assertEqual(revision.runtime_manifest, DEFAULT_RUNTIME_MANIFEST)
         self.assertIsNot(revision.runtime_manifest, DEFAULT_RUNTIME_MANIFEST)
+
+    def test_publish_rejects_manifests_with_wrong_protocol_version(self) -> None:
+        strategy, draft = self._strategy_with_draft(version=1)
+        self.service.repository.get_strategy.return_value = strategy
+        self.service.repository.get_draft.return_value = draft
+
+        for bad_manifest in (
+            {"strategy_contract_version": 2},
+            {"strategy_contract_version": "1"},
+            {},
+        ):
+            with self.assertRaises(
+                StrategyStorageValidationError, msg=str(bad_manifest)
+            ):
+                self.service.publish_revision(
+                    strategy.id,
+                    expected_draft_version=1,
+                    runtime_manifest=bad_manifest,
+                )
+        # No revision is created when the protocol metadata check fails.
+        self.session.add.assert_not_called()
+        self.assertIsNone(strategy.current_revision_id)
 
     def test_publish_rejects_a_draft_whose_stored_hash_was_tampered_with(self) -> None:
         strategy, draft = self._strategy_with_draft(version=1)

--- a/frontend/src/pages/StrategiesPage.tsx
+++ b/frontend/src/pages/StrategiesPage.tsx
@@ -47,8 +47,14 @@ const SOURCE_TEMPLATE = `"""Private strategy entry point."""
 
 
 def run(context, parameters):
-    """Return declarative trading intents for one decision context."""
-    return {"intents": []}
+    """Return one decision for the current step.
+
+    Two modes are supported in the first version:
+    - target_weights: submit the full target portfolio as
+      {"mode": "target_weights", "targets": {"<instrument_id>": "0.60"}}
+    - hold: submit no new trading intent with {"mode": "hold"}
+    """
+    return {"mode": "hold"}
 `;
 
 const EMPTY_PARAMETER_SCHEMA = {

--- a/scripts/selfhost.sh
+++ b/scripts/selfhost.sh
@@ -168,6 +168,10 @@ main() {
             compose logs --follow postgres backend frontend
             ;;
         migrate)
+            # Upgrades must also refresh an existing .env so newly required
+            # keys (for example QF_CURSOR_SIGNING_KEY) exist before Alembic
+            # loads the application settings.
+            ensure_environment
             run_migrations
             ;;
         psql)

--- a/scripts/selfhost_env.py
+++ b/scripts/selfhost_env.py
@@ -25,9 +25,12 @@ SERVER_HOST_KEY = "QF_SERVER_HOST"
 LEGACY_SERVER_HOST = "127.0.0.1"
 DATABASE_PASSWORD_KEY = "QF_DATABASE_PASSWORD"
 API_TOKEN_KEY = "QF_API_TOKEN"
+CURSOR_SIGNING_KEY = "QF_CURSOR_SIGNING_KEY"
+SECRET_KEYS = (DATABASE_PASSWORD_KEY, API_TOKEN_KEY, CURSOR_SIGNING_KEY)
 LEGACY_URL_KEY = "QF_DATABASE_URL"
 WEAK_DATABASE_PASSWORDS = {"", "change-me", "postgres"}
 WEAK_API_TOKENS = {"", "change-me"}
+WEAK_CURSOR_SIGNING_KEYS = {"", "change-me"}
 ENV_ASSIGNMENT = re.compile(r"^\s*([A-Za-z_][A-Za-z0-9_]*)\s*=")
 
 
@@ -56,6 +59,13 @@ def ensure_selfhost_environment(env_path: Path, template_path: Path) -> frozense
         generated_keys,
         minimum_length=32,
     )
+    cursor_signing_key = _ensure_secret(
+        values,
+        CURSOR_SIGNING_KEY,
+        WEAK_CURSOR_SIGNING_KEYS,
+        generated_keys,
+        minimum_length=32,
+    )
     # Existing self-hosted installations retain their .env across deployments.
     # Seed only keys absent from that file with template defaults so new
     # configuration (for example, a newly added data provider) becomes visible
@@ -71,6 +81,7 @@ def ensure_selfhost_environment(env_path: Path, template_path: Path) -> frozense
         **DATABASE_DEFAULTS,
         DATABASE_PASSWORD_KEY: database_password,
         API_TOKEN_KEY: api_token,
+        CURSOR_SIGNING_KEY: cursor_signing_key,
     }
 
     updated_lines: list[str] = []
@@ -87,7 +98,7 @@ def ensure_selfhost_environment(env_path: Path, template_path: Path) -> frozense
         if key in desired:
             value = (
                 desired[key]
-                if key in {DATABASE_PASSWORD_KEY, API_TOKEN_KEY} or not values.get(key)
+                if key in SECRET_KEYS or not values.get(key)
                 else values[key]
             )
             updated_lines.append(f"{key}={value}\n")
@@ -159,6 +170,7 @@ def main() -> None:
     secrets_to_report = (
         (DATABASE_PASSWORD_KEY, "PostgreSQL password"),
         (API_TOKEN_KEY, "API token"),
+        (CURSOR_SIGNING_KEY, "cursor signing key"),
     )
     for key, label in secrets_to_report:
         action = "Generated a random" if key in generated_keys else "Using the existing"

--- a/tests/test_selfhost_env.py
+++ b/tests/test_selfhost_env.py
@@ -111,6 +111,42 @@ class SelfhostEnvironmentTestCase(unittest.TestCase):
             # An upgrade must never replace operator-provided secrets.
             self.assertIn(f"QF_CURSOR_SIGNING_KEY={'e' * 64}", content)
 
+    def test_upgrade_generates_missing_cursor_signing_key(self) -> None:
+        """An old .env without the cursor key must be upgraded in place.
+
+        Running `make selfhost-migrate` on a pre-existing installation loads
+        the application settings; a missing required secret there would abort
+        Alembic before any migration runs.
+        """
+
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            root = Path(temporary_directory)
+            template = root / ".env.example"
+            env = root / ".env"
+            template.write_text(
+                f"QF_API_TOKEN=\nQF_DATABASE_PASSWORD=\nQF_CURSOR_SIGNING_KEY=\n",
+                encoding="utf-8",
+            )
+            env.write_text(
+                f"QF_API_TOKEN={'d' * 64}\n"
+                "QF_DATABASE_PASSWORD=strong-password\n",
+                encoding="utf-8",
+            )
+
+            generated = ensure_selfhost_environment(env, template)
+
+            content = env.read_text(encoding="utf-8")
+            self.assertEqual(generated, {CURSOR_SIGNING_KEY})
+            self.assertIn("QF_DATABASE_PASSWORD=strong-password", content)
+            self.assertIn(f"QF_API_TOKEN={'d' * 64}", content)
+            self.assertIn("QF_CURSOR_SIGNING_KEY=", content)
+            key_line = next(
+                line
+                for line in content.splitlines()
+                if line.startswith("QF_CURSOR_SIGNING_KEY=")
+            )
+            self.assertGreaterEqual(len(key_line.split("=", 1)[1]), 64)
+
     def test_appends_new_template_keys_to_an_existing_environment(self) -> None:
         with tempfile.TemporaryDirectory() as temporary_directory:
             root = Path(temporary_directory)

--- a/tests/test_selfhost_env.py
+++ b/tests/test_selfhost_env.py
@@ -6,6 +6,7 @@ from unittest.mock import patch
 
 from scripts.selfhost_env import (
     API_TOKEN_KEY,
+    CURSOR_SIGNING_KEY,
     DATABASE_PASSWORD_KEY,
     ensure_selfhost_environment,
 )
@@ -18,23 +19,30 @@ class SelfhostEnvironmentTestCase(unittest.TestCase):
             template = root / ".env.example"
             env = root / ".env"
             template.write_text(
-                "QF_APP_NAME=Test\nQF_API_TOKEN=\nQF_DATABASE_PASSWORD=\n",
+                "QF_APP_NAME=Test\n"
+                "QF_API_TOKEN=\n"
+                "QF_DATABASE_PASSWORD=\n"
+                "QF_CURSOR_SIGNING_KEY=\n",
                 encoding="utf-8",
             )
 
             with patch(
                 "scripts.selfhost_env.secrets.token_hex",
-                side_effect=("a" * 64, "b" * 64),
+                side_effect=("a" * 64, "b" * 64, "c" * 64),
             ):
                 generated = ensure_selfhost_environment(env, template)
             first_content = env.read_text(encoding="utf-8")
             generated_again = ensure_selfhost_environment(env, template)
 
-            self.assertEqual(generated, {DATABASE_PASSWORD_KEY, API_TOKEN_KEY})
+            self.assertEqual(
+                generated,
+                {DATABASE_PASSWORD_KEY, API_TOKEN_KEY, CURSOR_SIGNING_KEY},
+            )
             self.assertEqual(generated_again, set())
             self.assertEqual(first_content, env.read_text(encoding="utf-8"))
             self.assertIn(f"QF_DATABASE_PASSWORD={'a' * 64}", first_content)
             self.assertIn(f"QF_API_TOKEN={'b' * 64}", first_content)
+            self.assertIn(f"QF_CURSOR_SIGNING_KEY={'c' * 64}", first_content)
             self.assertIn("QF_SERVER_HOST=0.0.0.0", first_content)
             self.assertIn("QF_SERVER_PORT=8000", first_content)
             self.assertIn("QF_WEB_HOST=127.0.0.1", first_content)
@@ -51,6 +59,7 @@ class SelfhostEnvironmentTestCase(unittest.TestCase):
                 "QF_DATABASE_URL=postgresql+psycopg://postgres:postgres@db/test\n"
                 "QF_DATABASE_PASSWORD=postgres\n"
                 "QF_API_TOKEN=short-token\n"
+                "QF_CURSOR_SIGNING_KEY=change-me\n"
                 "QF_SERVER_HOST=127.0.0.1\n"
                 "QF_SERVER_PORT=19000\n"
                 "QF_WEB_HOST=0.0.0.0\n"
@@ -60,21 +69,25 @@ class SelfhostEnvironmentTestCase(unittest.TestCase):
 
             with patch(
                 "scripts.selfhost_env.secrets.token_hex",
-                side_effect=("b" * 64, "c" * 64),
+                side_effect=("b" * 64, "c" * 64, "d" * 64),
             ):
                 generated = ensure_selfhost_environment(env, template)
             content = env.read_text(encoding="utf-8")
 
-            self.assertEqual(generated, {DATABASE_PASSWORD_KEY, API_TOKEN_KEY})
+            self.assertEqual(
+                generated,
+                {DATABASE_PASSWORD_KEY, API_TOKEN_KEY, CURSOR_SIGNING_KEY},
+            )
             self.assertNotIn("QF_DATABASE_URL", content)
             self.assertIn(f"QF_DATABASE_PASSWORD={'b' * 64}", content)
             self.assertIn(f"QF_API_TOKEN={'c' * 64}", content)
+            self.assertIn(f"QF_CURSOR_SIGNING_KEY={'d' * 64}", content)
             self.assertIn("QF_SERVER_HOST=0.0.0.0", content)
             self.assertIn("QF_SERVER_PORT=19000", content)
             self.assertIn("QF_WEB_HOST=0.0.0.0", content)
             self.assertIn("QF_WEB_PORT=9090", content)
 
-    def test_preserves_custom_server_host(self) -> None:
+    def test_preserves_existing_strong_secrets_on_upgrade(self) -> None:
         with tempfile.TemporaryDirectory() as temporary_directory:
             root = Path(temporary_directory)
             template = root / ".env.example"
@@ -83,13 +96,20 @@ class SelfhostEnvironmentTestCase(unittest.TestCase):
             env.write_text(
                 "QF_SERVER_HOST=10.8.0.5\n"
                 "QF_DATABASE_PASSWORD=strong-password\n"
-                f"QF_API_TOKEN={'d' * 64}\n",
+                f"QF_API_TOKEN={'d' * 64}\n"
+                f"QF_CURSOR_SIGNING_KEY={'e' * 64}\n",
                 encoding="utf-8",
             )
 
-            ensure_selfhost_environment(env, template)
+            generated = ensure_selfhost_environment(env, template)
 
-            self.assertIn("QF_SERVER_HOST=10.8.0.5", env.read_text(encoding="utf-8"))
+            content = env.read_text(encoding="utf-8")
+            self.assertEqual(generated, set())
+            self.assertIn("QF_SERVER_HOST=10.8.0.5", content)
+            self.assertIn("QF_DATABASE_PASSWORD=strong-password", content)
+            self.assertIn(f"QF_API_TOKEN={'d' * 64}", content)
+            # An upgrade must never replace operator-provided secrets.
+            self.assertIn(f"QF_CURSOR_SIGNING_KEY={'e' * 64}", content)
 
     def test_appends_new_template_keys_to_an_existing_environment(self) -> None:
         with tempfile.TemporaryDirectory() as temporary_directory:


### PR DESCRIPTION
## Summary

Task package 08: result detail records, stable cursor pagination, and the generic instrument abstraction for the backtesting engine.

- Ten immutable result DTOs (steps, decisions, orders, order updates, fills, non-zero positions, equity curve, metrics, data preflight reports, data chunks) with run-scoped unique keys, timezone-aware timestamps, Decimal-only numerics, and point-in-time instrument display snapshots keyed by `instrument_id` (no ETF-specific fields).
- Opaque cursor pagination: base64url tokens signed with a dedicated server-only `QF_CURSOR_SIGNING_KEY` (HMAC-SHA256), query digest bound to filters plus snapshot upper bound, first-page bound captured in a single statement via shared-window `first_value()`.
- ORM models registered in Alembic metadata with an independent migration (`20260822_02`); read-only HTTP endpoints under `/api/admin/backtest-runs/{run_id}/results/*` with Decimal-as-string serialization.
- Self-host flow generates and upgrades the new secret on init/upgrade/migrate; READMEs document it in both languages.

## Validation

- `cd backend && uv run python -m unittest discover` — 428 tests OK
- `python3 -m unittest discover -s tests` — 9 tests OK
- `cd frontend && pnpm build` — OK
- Alembic offline SQL verified against PostgreSQL dialect

## Scope notes

Run creation, strategy decision interpretation, matching/slippage/fees, accounting, and metric formulas are intentionally out of scope; endpoints only read persisted results. A required migration-time env key (`QF_CURSOR_SIGNING_KEY`) is added; `make selfhost` / `make selfhost-migrate` generate it automatically.