### PR TITLE
feat: add accurate operations overview API

### DIFF
--- a/backend/app/data_ingestion/scheduler_tasks/corporate_action.py
+++ b/backend/app/data_ingestion/scheduler_tasks/corporate_action.py
@@ -293,6 +293,7 @@ def register_tasks(registry: TaskRegistry) -> None:
     ):
         registry.register(
             TaskDefinition(
+                source_key="tushare",
                 key=key,
                 name=name,
                 english_name=english_name,

--- a/backend/app/data_ingestion/scheduler_tasks/etf.py
+++ b/backend/app/data_ingestion/scheduler_tasks/etf.py
@@ -70,6 +70,7 @@ def register_tasks(registry: TaskRegistry) -> None:
     """Register Tushare ETF reference-data synchronization with the scheduler."""
     registry.register(
         TaskDefinition(
+            source_key="tushare",
             key="data.sync_etf_basics",
             name="ETF基础信息采集",
             english_name="Sync Tushare ETF basics",

--- a/backend/app/data_ingestion/scheduler_tasks/etf_adjustment.py
+++ b/backend/app/data_ingestion/scheduler_tasks/etf_adjustment.py
@@ -166,6 +166,7 @@ def register_tasks(registry: TaskRegistry) -> None:
     """Register the three market-level factor synchronization task types."""
     registry.register(
         TaskDefinition(
+            source_key="tushare",
             key="data.sync_etf_adjustment_incremental",
             name="ETF复权因子增量采集",
             english_name="Incremental Tushare ETF adjustment factors",
@@ -175,6 +176,7 @@ def register_tasks(registry: TaskRegistry) -> None:
     )
     registry.register(
         TaskDefinition(
+            source_key="tushare",
             key="data.sync_etf_adjustment_full",
             name="ETF复权因子全量采集",
             english_name="Full Tushare ETF adjustment factors",
@@ -184,6 +186,7 @@ def register_tasks(registry: TaskRegistry) -> None:
     )
     registry.register(
         TaskDefinition(
+            source_key="tushare",
             key="data.sync_etf_adjustment_reconciliation",
             name="ETF复权因子近期校验",
             english_name="Reconcile recent Tushare ETF adjustment factors",

--- a/backend/app/data_ingestion/scheduler_tasks/etf_daily.py
+++ b/backend/app/data_ingestion/scheduler_tasks/etf_daily.py
@@ -152,6 +152,7 @@ def register_tasks(registry: TaskRegistry) -> None:
     """Register independently checkpointed ETF daily-bar task types."""
     registry.register(
         TaskDefinition(
+            source_key="tushare",
             key="data.sync_etf_daily_incremental",
             name="ETF日线增量采集",
             english_name="Incremental Tushare ETF daily bars",
@@ -161,6 +162,7 @@ def register_tasks(registry: TaskRegistry) -> None:
     )
     registry.register(
         TaskDefinition(
+            source_key="tushare",
             key="data.sync_etf_daily_full",
             name="ETF日线全量采集",
             english_name="Full Tushare ETF daily bars",

--- a/backend/app/data_ingestion/scheduler_tasks/trade_calendar.py
+++ b/backend/app/data_ingestion/scheduler_tasks/trade_calendar.py
@@ -114,6 +114,7 @@ def register_tasks(registry: TaskRegistry) -> None:
     """Register Tushare trading calendar synchronization with the scheduler."""
     registry.register(
         TaskDefinition(
+            source_key="tushare",
             key="data.sync_trade_calendar",
             name="交易日历采集",
             english_name="Sync Tushare trade calendar",

--- a/backend/app/data_ingestion/scheduler_tasks/trading_status.py
+++ b/backend/app/data_ingestion/scheduler_tasks/trading_status.py
@@ -177,6 +177,7 @@ def register_tasks(registry: TaskRegistry) -> None:
 
     registry.register(
         TaskDefinition(
+            source_key="tushare",
             key="data.sync_trading_status",
             name="停牌交易状态采集",
             english_name="Trading status and suspension ingestion",

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -23,6 +23,7 @@ from app.backtesting.result_router import (
 from app.core.version import get_release_version
 from app.db.session import dispose_engine, get_db_session
 from app.logging.router import router as log_router
+from app.overview.router import router as overview_router
 from app.scheduling.router import router as scheduling_router
 from app.scheduling.runtime import SchedulerRuntime
 from app.strategies.router import router as strategies_router
@@ -65,6 +66,7 @@ def create_app(settings: Settings | None = None) -> FastAPI:
 
     protected_router = APIRouter(dependencies=[Depends(require_api_token)])
     protected_router.include_router(log_router)
+    protected_router.include_router(overview_router)
     protected_router.include_router(scheduling_router)
     protected_router.include_router(data_ingestion_router)
     protected_router.include_router(strategies_router)

--- a/backend/app/overview/__init__.py
+++ b/backend/app/overview/__init__.py
@@ -1,0 +1,1 @@
+"""Read-only operations overview; no source configuration or ingestion writes."""

--- a/backend/app/overview/router.py
+++ b/backend/app/overview/router.py
@@ -1,0 +1,28 @@
+"""Authenticated read-only overview. Source probes are deliberately not run."""
+
+from typing import Annotated
+
+from fastapi import APIRouter, Depends, Request, Response
+from sqlalchemy.orm import Session
+
+from app.db.session import get_db_session
+from app.overview.schemas import OperationsOverview
+from app.overview.service import OverviewService
+from app.scheduling.registry import task_registry
+
+
+router = APIRouter(prefix="/api/admin", tags=["admin-overview"])
+
+
+@router.get("/overview", response_model=OperationsOverview)
+def read_overview(request: Request, response: Response,
+                  session: Annotated[Session, Depends(get_db_session)]) -> OperationsOverview:
+    # Expose only presence, never the credential or third-party endpoint. A
+    # configured token is not evidence that the source is currently reachable.
+    token = request.app.state.settings.tushare_token
+    configured = token is not None and bool(token.get_secret_value().strip())
+    response.headers["Cache-Control"] = "no-store"
+    # This dependency supplies a fresh session. Pin all counts and bounded
+    # previews to one PostgreSQL snapshot while scheduler workers keep writing.
+    session.connection(execution_options={"isolation_level": "REPEATABLE READ"})
+    return OverviewService(session, task_registry).read(tushare_configured=configured)

--- a/backend/app/overview/schemas.py
+++ b/backend/app/overview/schemas.py
@@ -1,0 +1,60 @@
+"""Small, credential-free response models for the operations overview."""
+
+from datetime import datetime
+from typing import Literal
+from uuid import UUID
+
+from pydantic import BaseModel
+
+from app.scheduling.schemas import RunStatus
+
+
+class OverviewRun(BaseModel):
+    id: UUID
+    task_id: UUID
+    task_name: str
+    task_type: str
+    task_type_name: str
+    task_type_english_name: str
+    source_key: str
+    status: RunStatus
+    created_at: datetime
+    started_at: datetime | None
+    finished_at: datetime | None
+    duration_seconds: float | None
+
+
+class AttentionTask(BaseModel):
+    run: OverviewRun
+    retrying: bool
+
+
+class SourceOverview(BaseModel):
+    key: str
+    name: str
+    configured: bool
+    connection_status: Literal["not_checked"] = "not_checked"
+    active_tasks: int
+    last_success_at: datetime | None
+
+
+class OverviewMetrics(BaseModel):
+    configured_sources: int
+    total_sources: int
+    active_tasks: int
+    queued_runs: int
+    running_runs: int
+    today_runs: int
+    today_succeeded: int
+    attention_tasks: int
+
+
+class OperationsOverview(BaseModel):
+    generated_at: datetime
+    timezone: Literal["Asia/Shanghai"] = "Asia/Shanghai"
+    day_start: datetime
+    day_end: datetime
+    metrics: OverviewMetrics
+    sources: list[SourceOverview]
+    recent_runs: list[OverviewRun]
+    attention: list[AttentionTask]

--- a/backend/app/overview/service.py
+++ b/backend/app/overview/service.py
@@ -1,0 +1,137 @@
+"""Aggregate full scheduler history instead of counting a recent API page.
+
+Only bounded presentation lists are limited. Counts, source refresh timestamps,
+and latest-outcome selection operate on every matching persisted record.
+"""
+
+from datetime import UTC, datetime, time, timedelta
+from zoneinfo import ZoneInfo
+
+from sqlalchemy import func, select
+from sqlalchemy.orm import Session
+
+from app.scheduling.models import ScheduledTask, TaskRun
+from app.scheduling.registry import TaskRegistry
+from app.overview.schemas import (
+    AttentionTask, OperationsOverview, OverviewMetrics, OverviewRun, SourceOverview,
+)
+
+
+ATTENTION_STATUSES = ("failed", "interrupted", "timed_out", "indeterminate")
+
+
+def shanghai_day_bounds(now: datetime) -> tuple[datetime, datetime]:
+    """Use a half-open local calendar day, independent of the server timezone."""
+    if now.tzinfo is None or now.utcoffset() is None:
+        raise ValueError("overview time must be timezone-aware")
+    zone = ZoneInfo("Asia/Shanghai")
+    day = now.astimezone(zone).date()
+    start = datetime.combine(day, time.min, tzinfo=zone)
+    end = datetime.combine(day + timedelta(days=1), time.min, tzinfo=zone)
+    return start.astimezone(UTC), end.astimezone(UTC)
+
+
+class OverviewService:
+    def __init__(self, session: Session, registry: TaskRegistry) -> None:
+        self.session = session
+        # The application currently has one implemented provider. Adding a
+        # provider requires an explicit catalog/configuration mapping here;
+        # a registry entry alone must never imply an available connection.
+        self.definitions = {
+            item.key: item for item in registry.list() if item.source_key == "tushare"
+        }
+
+    def read(self, *, tushare_configured: bool, now: datetime | None = None) -> OperationsOverview:
+        now = now or datetime.now(UTC)
+        day_start, day_end = shanghai_day_bounds(now)
+        keys = tuple(self.definitions)
+        active = ScheduledTask.state != "archived"
+        task_scope = ScheduledTask.task_type.in_(keys)
+        run_scope = TaskRun.task_type.in_(keys)
+
+        active_tasks = self.session.scalar(select(func.count()).select_from(ScheduledTask).where(
+            task_scope, ScheduledTask.state == "active",
+        )) or 0
+        # Historical day totals include archived tasks: archiving a definition
+        # must not erase executions which actually started today.
+        today = self.session.execute(select(
+            func.count(TaskRun.id),
+            func.count(TaskRun.id).filter(TaskRun.status == "succeeded"),
+        ).where(run_scope, TaskRun.started_at >= day_start, TaskRun.started_at < day_end)).one()
+        pending = self.session.execute(select(
+            func.count(TaskRun.id).filter(TaskRun.status == "queued"),
+            func.count(TaskRun.id).filter(TaskRun.status == "running"),
+        ).join(ScheduledTask, ScheduledTask.id == TaskRun.task_id).where(
+            run_scope, task_scope, active,
+        )).one()
+
+        # Rank terminal *actual executions* before filtering for failures. A
+        # later success/cancellation clears an older error; a skipped dispatch
+        # does not. During a running retry, the last failure remains visible.
+        ranked = select(
+            TaskRun.id.label("run_id"),
+            func.row_number().over(
+                partition_by=TaskRun.task_id,
+                order_by=(TaskRun.started_at.desc(), TaskRun.created_at.desc(), TaskRun.id.desc()),
+            ).label("rank"),
+        ).where(
+            run_scope, TaskRun.started_at.is_not(None),
+            TaskRun.status.not_in(("queued", "running", "skipped")),
+        ).subquery()
+        issues = select(TaskRun.id).join(ranked, ranked.c.run_id == TaskRun.id).join(
+            ScheduledTask, ScheduledTask.id == TaskRun.task_id,
+        ).where(ranked.c.rank == 1, TaskRun.status.in_(ATTENTION_STATUSES), task_scope, active)
+        attention_count = self.session.scalar(select(func.count()).select_from(issues.subquery())) or 0
+        order = (TaskRun.created_at.desc(), TaskRun.id.desc())
+        issue_rows = self.session.execute(select(TaskRun, ScheduledTask.name).join(
+            ScheduledTask, ScheduledTask.id == TaskRun.task_id,
+        ).where(TaskRun.id.in_(issues)).order_by(*order).limit(10)).all()
+        issue_ids = [run.task_id for run, _ in issue_rows]
+        pending_attempts = self.session.execute(select(
+            TaskRun.task_id, TaskRun.created_at, TaskRun.started_at,
+        ).where(
+            run_scope, TaskRun.task_id.in_(issue_ids), TaskRun.status.in_(("queued", "running")),
+        )).all() if issue_ids else []
+        failures = {run.task_id: run for run, _ in issue_rows}
+        # An older concurrent execution is not a retry of a newer failure.
+        # Running attempts follow actual start order; queued attempts have no
+        # start time, so compare their enqueue time with the failed outcome.
+        retries = {
+            task_id for task_id, created_at, started_at in pending_attempts
+            if (started_at is not None and started_at > failures[task_id].started_at)
+            or (started_at is None and created_at > failures[task_id].finished_at)
+        }
+        recent = self.session.execute(select(TaskRun, ScheduledTask.name).join(
+            ScheduledTask, ScheduledTask.id == TaskRun.task_id,
+        ).where(run_scope).order_by(*order).limit(4)).all()
+        last_success = self.session.scalar(select(func.max(TaskRun.finished_at)).where(
+            run_scope, TaskRun.status == "succeeded", TaskRun.started_at.is_not(None),
+        ))
+        return OperationsOverview(
+            generated_at=now, day_start=day_start, day_end=day_end,
+            metrics=OverviewMetrics(
+                configured_sources=int(tushare_configured), total_sources=1,
+                active_tasks=active_tasks, queued_runs=pending[0], running_runs=pending[1],
+                today_runs=today[0], today_succeeded=today[1], attention_tasks=attention_count,
+            ),
+            sources=[SourceOverview(
+                key="tushare", name="Tushare", configured=tushare_configured,
+                active_tasks=active_tasks, last_success_at=last_success,
+            )],
+            recent_runs=[self._run(run, name) for run, name in recent],
+            attention=[AttentionTask(run=self._run(run, name), retrying=run.task_id in retries)
+                       for run, name in issue_rows],
+        )
+
+    def _run(self, run: TaskRun, task_name: str) -> OverviewRun:
+        definition = self.definitions[run.task_type]
+        duration = None
+        if run.started_at is not None and run.finished_at is not None:
+            duration = max(0.0, (run.finished_at - run.started_at).total_seconds())
+        return OverviewRun(
+            id=run.id, task_id=run.task_id, task_name=task_name, task_type=run.task_type,
+            task_type_name=definition.name, task_type_english_name=definition.english_name,
+            source_key=definition.source_key, status=run.status,
+            created_at=run.created_at, started_at=run.started_at, finished_at=run.finished_at,
+            duration_seconds=duration,
+        )

--- a/backend/app/scheduling/registry.py
+++ b/backend/app/scheduling/registry.py
@@ -34,6 +34,9 @@ class TaskDefinition:
     handler: TaskHandler
     english_name: str
     parameter_version: int = 1
+    # Explicit source ownership lets read models scope ingestion statistics
+    # without guessing from translated names or persisted task-key prefixes.
+    source_key: str | None = None
 
 
 class TaskRegistry:
@@ -49,6 +52,8 @@ class TaskRegistry:
                 raise ValueError(f"task type {field} must be non-blank text")
         if definition.key in self._definitions:
             raise ValueError(f"task type already registered: {definition.key}")
+        if definition.source_key is not None and not definition.source_key.strip():
+            raise ValueError("task type source_key must be non-blank when supplied")
         self._definitions[definition.key] = definition
 
     def get(self, key: str) -> TaskDefinition | None:

--- a/backend/tests/test_operations_overview.py
+++ b/backend/tests/test_operations_overview.py
@@ -1,0 +1,214 @@
+"""Exercise overview SQL against real rows, including PostgreSQL in CI.
+
+Local SQLite uses only column mirrors because production CHECK constraints use
+PostgreSQL JSON operators. CI runs the same assertions on the migrated schema;
+each test rolls back its fixture transaction and never touches deployed data.
+"""
+
+import os
+import unittest
+from datetime import UTC, datetime, timedelta
+from types import SimpleNamespace
+from unittest.mock import Mock, patch
+from uuid import uuid4
+
+from fastapi import Response
+from pydantic import BaseModel, SecretStr
+from sqlalchemy import Column, JSON, MetaData, Table, create_engine
+from sqlalchemy.dialects.postgresql import JSONB
+from sqlalchemy.orm import Session
+
+from app.core.config import get_settings
+from app.overview.router import read_overview
+from app.overview.service import OverviewService, shanghai_day_bounds
+from app.scheduling.models import ScheduledTask, TaskRun
+from app.scheduling.registry import TaskDefinition, TaskRegistry, task_registry
+
+
+NOW = datetime(2026, 9, 9, 6, tzinfo=UTC)
+
+
+class OverviewTest(unittest.TestCase):
+    def setUp(self):
+        if os.getenv("POSTGRES_TEST_ENABLED") == "1":
+            self.engine = create_engine(get_settings().database_url)
+        else:
+            self.engine = create_engine("sqlite://")
+            metadata = MetaData()
+            for model in (ScheduledTask, TaskRun):
+                Table(model.__tablename__, metadata, *[
+                    Column(column.name, JSON() if isinstance(column.type, JSONB) else column.type,
+                           primary_key=column.primary_key)
+                    for column in model.__table__.columns
+                ])
+            metadata.create_all(self.engine)
+        self.connection = self.engine.connect()
+        self.transaction = self.connection.begin()
+        self.session = Session(self.connection)
+        # Unique registered keys isolate counts from other CI fixtures without
+        # deleting pre-existing records in the disposable test database.
+        self.key = "test." + uuid4().hex
+        self.other_key = "test." + uuid4().hex
+        self.registry = TaskRegistry()
+        for key, source in ((self.key, "tushare"), (self.other_key, None)):
+            self.registry.register(TaskDefinition(key=key, name="测试采集",
+                english_name="Test ingestion", parameters_model=BaseModel,
+                handler=lambda *_: None, source_key=source))
+        self.service = OverviewService(self.session, self.registry)
+
+    def tearDown(self):
+        self.session.close()
+        if self.transaction.is_active:
+            self.transaction.rollback()
+        self.connection.close()
+        self.engine.dispose()
+
+    def task(self, *, state="active", key=None):
+        task = ScheduledTask(id=uuid4(), name="演示任务", task_type=key or self.key,
+            parameters={}, parameter_version=1,
+            schedule={"type": "interval", "seconds": 60, "start_at": NOW.isoformat()},
+            state=state, created_at=NOW-timedelta(days=10), updated_at=NOW)
+        self.session.add(task)
+        self.session.flush()
+        return task
+
+    def add_run(self, task, status="succeeded", *, at=NOW, created_at=None):
+        started = at if status not in ("queued", "skipped") else None
+        finished = at+timedelta(seconds=5) if status not in ("queued", "running") else None
+        run = TaskRun(id=uuid4(), task_id=task.id, task_type=task.task_type,
+            task_version=1, trigger_type="scheduled", status=status,
+            parameters={"sensitive": "never-return-this"}, parameter_version=1,
+            created_at=created_at or at-timedelta(seconds=1), available_at=at,
+            started_at=started, finished_at=finished, result={"private": "never-return-this"},
+            error_message="never-return-this")
+        self.session.add(run)
+        self.session.flush()
+        return run
+
+    def read(self, configured=False):
+        # Match a new request's database-loaded identity map. SQLite strips
+        # timezone offsets on load, unlike the production PostgreSQL dialect.
+        self.session.expire_all()
+        return self.service.read(tushare_configured=configured, now=NOW)
+
+    def test_empty_and_configuration_do_not_imply_connectivity(self):
+        result = self.read(True)
+        self.assertEqual(result.metrics.active_tasks, 0)
+        self.assertEqual(result.metrics.today_runs, 0)
+        self.assertEqual(result.metrics.attention_tasks, 0)
+        self.assertEqual(result.recent_runs, [])
+        self.assertEqual(result.metrics.configured_sources, 1)
+        self.assertEqual(result.sources[0].connection_status, "not_checked")
+        self.assertIsNone(result.sources[0].last_success_at)
+
+    def test_counts_more_than_one_hundred_tasks_and_runs(self):
+        for _ in range(105):
+            self.add_run(self.task())
+        result = self.read()
+        self.assertEqual(result.metrics.active_tasks, 105)
+        self.assertEqual(result.metrics.today_runs, 105)
+        self.assertEqual(result.metrics.today_succeeded, 105)
+        self.assertEqual(len(result.recent_runs), 4)
+        self.assertNotIn("never-return-this", result.model_dump_json())
+        self.assertEqual(result.recent_runs[0].duration_seconds, 5)
+        self.assertEqual(result.recent_runs[0].task_type_english_name, "Test ingestion")
+
+    def test_day_boundaries_use_start_not_creation_and_exclude_unstarted(self):
+        task = self.task()
+        start, end = shanghai_day_bounds(NOW)
+        self.assertEqual(start, datetime(2026, 9, 8, 16, tzinfo=UTC))
+        self.add_run(task, at=start-timedelta(microseconds=1))
+        self.add_run(task, at=start, created_at=start-timedelta(days=1))
+        self.add_run(task, at=end-timedelta(seconds=10))
+        self.add_run(task, at=end)
+        self.add_run(task, "skipped")
+        self.add_run(task, "queued")
+        self.add_run(task, "running")
+        result = self.read()
+        self.assertEqual((result.metrics.today_runs, result.metrics.today_succeeded), (3, 2))
+        self.assertEqual((result.metrics.queued_runs, result.metrics.running_runs), (1, 1))
+        with self.assertRaises(ValueError):
+            shanghai_day_bounds(NOW.replace(tzinfo=None))
+
+    def test_skip_does_not_clear_failure_and_retry_is_not_recovery(self):
+        task = self.task()
+        self.add_run(task, "failed", at=NOW-timedelta(minutes=5))
+        failed = self.add_run(task, "timed_out", at=NOW-timedelta(minutes=4))
+        self.add_run(task, "skipped", at=NOW-timedelta(minutes=3))
+        self.add_run(task, "running", at=NOW-timedelta(minutes=2))
+        result = self.read()
+        self.assertEqual(result.metrics.attention_tasks, 1)
+        self.assertEqual(result.attention[0].run.id, failed.id)
+        self.assertTrue(result.attention[0].retrying)
+        self.add_run(task, "succeeded")
+        self.assertEqual(self.read().metrics.attention_tasks, 0)
+
+    def test_cancelled_or_successful_latest_outcome_clears_older_error(self):
+        for status in ("succeeded", "cancelled"):
+            task = self.task()
+            self.add_run(task, "failed", at=NOW-timedelta(minutes=2))
+            self.add_run(task, status)
+        self.assertEqual(self.read().metrics.attention_tasks, 0)
+
+    def test_older_concurrent_run_is_not_a_retry(self):
+        task = self.task()
+        self.add_run(task, "running", at=NOW-timedelta(minutes=4))
+        self.add_run(task, "failed", at=NOW-timedelta(minutes=2))
+        self.assertFalse(self.read().attention[0].retrying)
+        self.add_run(task, "queued")
+        self.assertTrue(self.read().attention[0].retrying)
+
+    def test_archived_and_unrelated_tasks_are_not_active_or_attention(self):
+        archived = self.task(state="archived")
+        self.add_run(archived, "failed")
+        self.add_run(self.task(key=self.other_key), "failed")
+        self.add_run(self.task(state="paused"), "failed")
+        result = self.read()
+        self.assertEqual(result.metrics.active_tasks, 0)
+        self.assertEqual(result.metrics.attention_tasks, 1)
+        self.assertEqual(result.metrics.today_runs, 2)  # Includes archived history.
+
+    def test_attention_preview_limit_does_not_truncate_metric(self):
+        for i in range(12):
+            self.add_run(self.task(), ("failed", "interrupted", "timed_out", "indeterminate")[i % 4])
+        result = self.read()
+        self.assertEqual(result.metrics.attention_tasks, 12)
+        self.assertEqual(len(result.attention), 10)
+
+    def test_source_refresh_ignores_later_failures_and_skipped_runs(self):
+        task = self.task()
+        successful = self.add_run(task, at=NOW-timedelta(hours=1))
+        self.add_run(task, "failed")
+        self.add_run(task, "skipped", at=NOW+timedelta(minutes=1))
+        self.assertEqual(self.read().sources[0].last_success_at.replace(tzinfo=UTC),
+                         successful.finished_at.replace(tzinfo=UTC))
+
+
+class OverviewContractTest(unittest.TestCase):
+    def test_every_builtin_ingestion_task_has_explicit_source_metadata(self):
+        definitions = task_registry.list()
+        self.assertTrue(definitions)
+        for definition in definitions:
+            self.assertEqual(definition.source_key, "tushare")
+
+    def test_route_is_authenticated_and_has_no_write_methods(self):
+        from app.main import create_app
+        import asyncio
+        from tests.test_auth import request_status
+        app = create_app()
+        operations = app.openapi()["paths"]["/api/admin/overview"]
+        self.assertEqual(set(operations), {"get"})
+        self.assertEqual(operations["get"]["security"], [{"API Token": []}])
+        self.assertEqual(asyncio.run(request_status(app, "/api/admin/overview")), 401)
+
+    @patch("app.overview.router.OverviewService")
+    def test_route_passes_only_presence_and_disables_caching(self, service):
+        response = Response()
+        request = SimpleNamespace(app=SimpleNamespace(state=SimpleNamespace(settings=SimpleNamespace(
+            tushare_token=SecretStr("private-provider-credential")))))
+        session = Mock()
+        read_overview(request, response, session)
+        service.return_value.read.assert_called_once_with(tushare_configured=True)
+        session.connection.assert_called_once_with(
+            execution_options={"isolation_level": "REPEATABLE READ"})
+        self.assertEqual(response.headers["cache-control"], "no-store")


### PR DESCRIPTION
The operations overview currently derives totals from the latest 100 scheduler records and has no reliable source-configuration status. This adds authenticated `GET /api/admin/overview` with full-history aggregates, explicit Tushare task ownership, credential-free source configuration, and bounded recent-run/attention summaries.

Daily totals use actual start times within the Shanghai calendar day. Attention counts tasks by their latest actual terminal execution: skipped dispatches do not clear errors, successful or cancelled executions do, and later queued/running retries remain visible. Counts and previews share a repeatable-read database snapshot. Existing ETF/calendar APIs continue to provide asset totals; no schema migration or new environment key is required.

Validation: full local backend suite (2027 passed, 12 PostgreSQL-only skips, 204 subtests); final focused overview/scheduler suite (38 passed); root tests (12 passed); release metadata and diff checks. The overview tests execute their SQL against SQLite locally and the migrated PostgreSQL schema in CI, covering >100 records, day boundaries, archive behavior, recovery, retries, preview limits, authentication, and secret omission.

Frontend implementation and local design documents are excluded. After CI and merge, the test environment must deploy this main commit before the new overview frontend is integrated.
