### PR TITLE
feat: upgrade data source management interface

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -9,6 +9,7 @@ import { AccountProfilesPage } from "./pages/AccountProfilesPage";
 import { BacktestPreflightPage } from "./pages/BacktestPreflightPage";
 import { BacktestRunsPage } from "./pages/BacktestRunsPage";
 import { DashboardPage } from "./pages/DashboardPage";
+import { DataSourcesPage } from "./pages/DataSourcesPage";
 import { DataCollectionPage, EtfBasicsPage } from "./pages/DataCollectionPage";
 import { EtfDetailPage } from "./pages/EtfDetailPage";
 import { LoginPage } from "./pages/LoginPage";
@@ -54,6 +55,7 @@ export function App() {
           </RequireAuth>
         }
       />
+      <Route path="/admin/data-sources" element={<RequireAuth><OverviewShell title="数据源" section="DATA OPS"><DataSourcesPage /></OverviewShell></RequireAuth>} />
       <Route
         path="/admin/tasks"
         element={

--- a/frontend/src/api/dataSources.ts
+++ b/frontend/src/api/dataSources.ts
@@ -1,0 +1,98 @@
+import { readApiToken } from "../auth/tokenStorage";
+import type { OverviewRun } from "./overview";
+
+export interface SourceField {
+  key: string; label: string; type: "url" | "secret" | "string" | "integer" | "number" | "boolean";
+  required: boolean; default?: string | number | boolean; help?: string;
+}
+export interface SourceCapability {
+  key: string; name: string; english_name: string; task_count: number; available: boolean;
+  last_run: Pick<OverviewRun, "id" | "task_id" | "status" | "created_at" | "started_at" | "finished_at"> | null;
+}
+export interface DataSource {
+  key: string; name: string; fields: SourceField[]; values: Record<string, string | number | boolean>;
+  secret_fields_configured: string[]; configured: boolean; enabled: boolean; version: number;
+  checked_at: string | null; check_status: string; check_message: string | null;
+  capabilities: SourceCapability[]; skipped_runs?: number;
+}
+export interface SourceProbe {
+  ok: boolean; status: string; message: string; checked_at: string; version: number; saved: false;
+}
+export type SourceDraft = Record<string, string | number | boolean>;
+
+export class DataSourceApiError extends Error {
+  constructor(readonly status: number, message: string, readonly field?: string) {
+    super(message); this.name = "DataSourceApiError";
+  }
+}
+
+async function request<T>(path: string, method = "GET", body?: unknown, signal?: AbortSignal): Promise<T> {
+  const controller = new AbortController();
+  const abort = () => controller.abort();
+  signal?.addEventListener("abort", abort, { once: true });
+  if (signal?.aborted) abort();
+  const timer = setTimeout(abort, 35000);
+  try {
+    const token = readApiToken();
+    const response = await fetch(`/api/data-sources${path}`, {
+      method, headers: { ...(token ? { Authorization: `Bearer ${token}` } : {}),
+        ...(body === undefined ? {} : { "Content-Type": "application/json" }) },
+      body: body === undefined ? undefined : JSON.stringify(body), cache: "no-store", signal: controller.signal
+    });
+    if (!response.ok) {
+      // Only this API's sanitized Chinese error envelope is operator copy.
+      // Do not render proxy HTML, validation input, or unexpected server traces.
+      const payload = await response.json().catch(() => null);
+      const detail = payload?.detail;
+      const message = typeof detail?.message === "string" && detail.message.length <= 500 && /[\u4e00-\u9fff]/.test(detail.message)
+        ? detail.message : `请求未完成（HTTP ${response.status}），请刷新后重试。`;
+      throw new DataSourceApiError(response.status, message, typeof detail?.field === "string" ? detail.field : undefined);
+    }
+    return await response.json() as T;
+  } catch (error) {
+    if (signal?.aborted) throw new DOMException("Request aborted", "AbortError");
+    if (error instanceof DataSourceApiError) throw error;
+    throw new DataSourceApiError(0, method === "GET" ? "数据源加载失败，请检查网络后重试。"
+      : "未能确认请求结果，请重新加载配置后核对；不要重复提交。" );
+  } finally {
+    clearTimeout(timer); signal?.removeEventListener("abort", abort);
+  }
+}
+
+export const listDataSources = (signal?: AbortSignal) => request<{ items: DataSource[] }>("", "GET", undefined, signal);
+export const readDataSource = (key: string) => request<DataSource>(`/${encodeURIComponent(key)}`);
+export const testDataSource = (source: DataSource, fields: SourceDraft) => request<SourceProbe>(`/${encodeURIComponent(source.key)}/test`, "POST", { version: source.version, fields });
+export const saveDataSource = (source: DataSource, fields: SourceDraft) => request<DataSource>(`/${encodeURIComponent(source.key)}/config`, "PUT", { version: source.version, fields });
+export const setDataSourceEnabled = (source: DataSource, enabled: boolean) => request<DataSource>(`/${encodeURIComponent(source.key)}/state`, "PUT", { version: source.version, enabled });
+
+/** Provider schema drives the form. Secret values are never initialized from
+ * public metadata, even if an unexpected field appears in the response. */
+export function sourceDraft(source: DataSource): SourceDraft {
+  return Object.fromEntries(source.fields.map(field => [field.key, field.type === "secret" ? "" : source.values[field.key] ?? field.default ?? ""]));
+}
+export function validateSourceDraft(source: DataSource, draft: SourceDraft): Record<string, string> {
+  const errors: Record<string, string> = {};
+  for (const field of source.fields) {
+    const value = draft[field.key];
+    const blank = value === undefined || value === "" || typeof value === "string" && !value.trim();
+    if (field.required && blank && !(field.type === "secret" && source.secret_fields_configured.includes(field.key))) {
+      errors[field.key] = `请填写${field.label}。`; continue;
+    }
+    if (!blank && field.type === "url") {
+      try {
+        const url = new URL(String(value));
+        if (!["http:", "https:"].includes(url.protocol) || url.username || url.password || url.search || url.hash) throw new Error();
+      } catch { errors[field.key] = `${field.label}须为 HTTP(S) 地址，且不能包含凭据、查询参数或片段。`; }
+    }
+    if (!blank && (field.type === "integer" || field.type === "number") &&
+      (!Number.isFinite(Number(value)) || field.type === "integer" && !Number.isInteger(Number(value)))) errors[field.key] = `请填写有效的${field.label}。`;
+  }
+  return errors;
+}
+export function sourceState(source: DataSource): { label: string; tone: "neutral" | "ok" | "warn" } {
+  if (!source.enabled) return { label: "已停用", tone: "neutral" };
+  if (!source.configured) return { label: "待配置", tone: "warn" };
+  if (source.check_status === "connected") return { label: "连接正常", tone: "ok" };
+  if (source.check_status === "not_checked") return { label: "未检测", tone: "neutral" };
+  return { label: "检查异常", tone: "warn" };
+}

--- a/frontend/src/components/OverviewContent.tsx
+++ b/frontend/src/components/OverviewContent.tsx
@@ -25,21 +25,21 @@ export function OverviewContent({ snapshot, loading, errors, refreshed, onRefres
     {errors.length > 0 && <div className="qfo-review-error" role="alert">{errors.join("、")}加载失败，已保留已有数据；尚未加载的数据以“—”显示。请刷新重试。</div>}
     <div className="qfo-sr-only" role="status">{loading ? "正在刷新总览" : errors.length ? "部分数据未能刷新" : refreshed ? "总览状态已刷新" : ""}</div>
     <section className="qfo-metric-band" aria-label="运营指标">
-      <div className="qfo-metric"><div className="qfo-metric-label"><Database aria-hidden="true" />已配置数据源</div><div className="qfo-metric-line"><div className="qfo-metric-value">{count(metrics?.configured_sources)}</div><div className="qfo-metric-unit">/ {count(metrics?.total_sources)}</div><div className="qfo-metric-note">{metrics ? "连接未检测" : "等待数据"}</div></div></div>
+      <div className="qfo-metric"><div className="qfo-metric-label"><Database aria-hidden="true" />已配置数据源</div><div className="qfo-metric-line"><div className="qfo-metric-value">{count(metrics?.configured_sources)}</div><div className="qfo-metric-unit">/ {count(metrics?.total_sources)}</div><div className="qfo-metric-note">{metrics ? "配置状态汇总" : "等待数据"}</div></div></div>
       <div className="qfo-metric"><div className="qfo-metric-label"><Clock3 aria-hidden="true" />启用采集任务</div><div className="qfo-metric-line"><div className="qfo-metric-value">{count(metrics?.active_tasks)}</div><div className="qfo-metric-note">{metrics ? `${count(metrics.queued_runs)} 项等待 · ${count(metrics.running_runs)} 项运行中` : "等待数据"}</div></div></div>
       <div className="qfo-metric" title={operations ? `上海时间 ${overviewTime(operations.day_start, true)} 至 ${overviewTime(operations.day_end, true)}（不含结束时刻），按实际开始时间统计` : "上海时区，按实际开始时间统计"}><div className="qfo-metric-label"><TrendingUp aria-hidden="true" />今日运行<span className="qfo-sr-only">（上海时区，按实际开始）</span></div><div className="qfo-metric-line"><div className="qfo-metric-value">{count(metrics?.today_runs)}</div><div className="qfo-metric-unit">次</div><div className="qfo-metric-note qfo-ok">{metrics ? `${count(metrics.today_succeeded)} 次成功` : "等待数据"}</div></div></div>
       <div className="qfo-metric"><div className="qfo-metric-label"><TriangleAlert aria-hidden="true" />需要处理</div><div className="qfo-metric-line"><div className="qfo-metric-value">{count(metrics?.attention_tasks)}</div><div className="qfo-metric-unit">项</div><div className={`qfo-metric-note${metrics?.attention_tasks ? " qfo-warn" : ""}`}>{metrics ? metrics.attention_tasks ? "采集任务异常" : "暂无待处理" : "等待数据"}</div></div></div>
     </section>
     <div className="qfo-overview-grid">
       <section className="qfo-sheet qfo-sources" aria-labelledby="overview-sources-title">
-        <div className="qfo-sheet-head"><h2 className="qfo-sheet-title" id="overview-sources-title">数据源状态</h2><div className="qfo-sheet-meta">{count(metrics?.total_sources)} 个数据源 · 连接未检测</div><button type="button" className="qfo-sheet-link" aria-disabled="true" title="数据源管理尚未开放">管理数据源<ArrowRight aria-hidden="true" /></button></div>
+        <div className="qfo-sheet-head"><h2 className="qfo-sheet-title" id="overview-sources-title">数据源状态</h2><div className="qfo-sheet-meta">{count(metrics?.total_sources)} 个数据源 · 配置状态汇总</div><Link className="qfo-sheet-link" to="/admin/data-sources">管理数据源<ArrowRight aria-hidden="true" /></Link></div>
         <div className="qfo-source-table">{operations ? operations.sources.length ? operations.sources.map(source => <div className="qfo-source-row" key={source.key}>
           <div className="qfo-source-main"><div className="qfo-source-mark">{source.key === "tushare" ? "TS" : "DS"}</div><div><div className="qfo-source-name">{source.name}</div><div className="qfo-source-sub">ETF 基础信息、交易日历等结构化数据</div></div></div>
           <div className="qfo-source-stat"><span>配置状态</span><div className="qfo-source-status"><i aria-hidden="true" />{source.configured ? "已配置" : "未配置"}</div></div>
           <div className="qfo-source-stat"><span>启用任务</span><b>{count(source.active_tasks)}</b></div>
           <div className="qfo-source-stat"><span>最近成功同步</span><b><Timestamp value={source.last_success_at} /></b></div>
         </div>) : <div className="qfo-empty-body">暂无数据源</div> : <div className="qfo-empty-body">{pending}</div>}</div>
-        <p className="qfo-source-extra">已配置不代表连接可用；连接测试将在数据源管理中提供。</p>
+        <p className="qfo-source-extra">已配置不代表连接可用；请在数据源管理中查看检查结果或测试连接。</p>
       </section>
       <section className="qfo-sheet qfo-attention" aria-labelledby="overview-attention-title">
         <div className="qfo-sheet-head"><h2 className="qfo-sheet-title" id="overview-attention-title">需要处理</h2><Link className="qfo-sheet-link" to="/admin/tasks">查看任务<ArrowRight aria-hidden="true" /></Link></div>

--- a/frontend/src/components/OverviewShell.tsx
+++ b/frontend/src/components/OverviewShell.tsx
@@ -1,6 +1,6 @@
 import { BookOpen, ChartNoAxesColumn, Clock3, Code2, Database, FileSearch, LayoutDashboard, LineChart, LogOut, Menu, Search, WalletCards, X } from "lucide-react";
 import { useCallback, useEffect, useRef, useState } from "react";
-import { Link, useNavigate } from "react-router-dom";
+import { Link, useLocation, useNavigate } from "react-router-dom";
 import { useAuth } from "../auth/AuthContext";
 import { FRONTEND_VERSION } from "../version";
 import "./Overview.css";
@@ -8,7 +8,7 @@ import "./Overview.css";
 const groups = [
   { label: "工作台", items: [{ label: "总览", to: "/admin", icon: LayoutDashboard }] },
   { label: "数据采集", items: [
-    { label: "数据源", to: "", icon: Database },
+    { label: "数据源", to: "/admin/data-sources", icon: Database },
     { label: "采集任务", to: "/admin/tasks", icon: Clock3 }
   ] },
   { label: "市场数据", items: [{ label: "A 股市场", to: "", icon: ChartNoAxesColumn }] },
@@ -33,11 +33,12 @@ const destinations = [
   ...toolItems.map(item => ({ ...item, group: "运行与工具" }))
 ];
 
-/** Only the accepted overview uses this shell. Legacy routes retain their
+/** Reviewed overview and source pages share this shell. Legacy routes retain their
  * existing theme setting until each page is reviewed and accepted separately. */
-export function OverviewShell({ children }: { children: React.ReactNode }) {
+export function OverviewShell({ children, title = "数据运营总览", section = "WORKBENCH" }: { children: React.ReactNode; title?: string; section?: string }) {
   const { logout } = useAuth();
   const navigate = useNavigate();
+  const location = useLocation();
   const [collapsed, setCollapsed] = useState(() => window.innerWidth <= 1240);
   const [open, setOpen] = useState(false);
   const [query, setQuery] = useState("");
@@ -58,6 +59,7 @@ export function OverviewShell({ children }: { children: React.ReactNode }) {
   }, []);
   useEffect(() => {
     const onShortcut = (event: KeyboardEvent) => {
+      if (document.querySelector("dialog[open]")) return;
       if ((event.metaKey || event.ctrlKey) && event.key.toLowerCase() === "k") {
         event.preventDefault(); if (open) close(); else show();
       }
@@ -77,13 +79,13 @@ export function OverviewShell({ children }: { children: React.ReactNode }) {
   }
   function navItem(item: typeof toolItems[number], tool = false) {
     const Icon = item.icon;
-    const className = `qfo-nav-item${tool ? " qfo-tool-link" : ""}${item.to === "/admin" ? " qfo-active" : ""}${!item.to ? " qfo-nav-disabled" : ""}`;
+    const className = `qfo-nav-item${tool ? " qfo-tool-link" : ""}${item.to === location.pathname ? " qfo-active" : ""}${!item.to ? " qfo-nav-disabled" : ""}`;
     const label = item.to ? item.label : `${item.label}（尚未开放）`;
     const content = <><Icon aria-hidden="true" /><span>{item.label}</span></>;
     if (!item.to) return <button key={item.label} type="button" className={className} aria-disabled="true" aria-label={label} title={label}>{content}</button>;
     if (item.to === "logout") return <button key={item.label} type="button" className={className} aria-label={label} title={label} onClick={() => go(item.to)}>{content}</button>;
     if (item.to === "/docs") return <a key={item.label} className={className} aria-label={label} title={label} href="/docs" target="_blank" rel="noreferrer">{content}</a>;
-    return <Link key={item.label} className={className} aria-label={label} title={label} to={item.to} aria-current={item.to === "/admin" ? "page" : undefined}>{content}</Link>;
+    return <Link key={item.label} className={className} aria-label={label} title={label} to={item.to} aria-current={item.to === location.pathname ? "page" : undefined}>{content}</Link>;
   }
   return <div className="qfo-root">
     <div className={`qfo-app${collapsed ? " qfo-sidebar-collapsed" : ""}`} inert={open}>
@@ -95,7 +97,7 @@ export function OverviewShell({ children }: { children: React.ReactNode }) {
       <section className="qfo-shell">
         <header className="qfo-topbar">
           <button className="qfo-icon-btn qfo-sidebar-toggle" type="button" aria-label={collapsed ? "展开侧栏" : "收起侧栏"} title={collapsed ? "展开侧栏" : "收起侧栏"} aria-expanded={!collapsed} aria-controls="overview-navigation" onClick={() => setCollapsed(value => !value)}><Menu aria-hidden="true" /></button>
-          <div className="qfo-crumb"><span className="qfo-crumb-index">WORKBENCH</span><span className="qfo-crumb-sep">/</span><span className="qfo-crumb-title">数据运营总览</span></div>
+          <div className="qfo-crumb"><span className="qfo-crumb-index">{section}</span><span className="qfo-crumb-sep">/</span><span className="qfo-crumb-title">{title}</span></div>
           <div className="qfo-top-actions"><button className="qfo-quick" type="button" aria-label="快速跳转" aria-haspopup="dialog" onClick={show}><Search aria-hidden="true" /><span>快速跳转</span><span className="qfo-kbd">⌘ K</span></button></div>
         </header>
         <main className="qfo-main">{children}</main>

--- a/frontend/src/pages/DataSources.css
+++ b/frontend/src/pages/DataSources.css
@@ -1,0 +1,104 @@
+/* Source page follows the approved warm B tokens inherited from the shell.
+ * Content grows with bilingual labels; only the script grid scrolls locally. */
+.qfo-root .qfs-content{display:flex;flex-direction:column;gap:14px;min-height:100%}
+.qfo-root .qfs-content .qfo-page-head{margin-bottom:0}
+.qfo-root .qfs-page-actions{display:flex;align-items:center;gap:8px}
+.qfo-root .qfs-head-status{border:1px solid var(--border);border-radius:8px;background:var(--surface);padding:8px 10px;font-size:12px;color:var(--muted)}
+.qfo-root .qfs-layout{display:grid;grid-template-columns:280px minmax(0,1fr);gap:12px;flex:1;min-height:0}
+.qfo-root .qfs-sheet{border:1px solid var(--border);background:var(--surface);border-radius:10px;min-width:0;overflow:hidden}
+.qfo-root .qfs-sheet-head{min-height:50px;display:flex;align-items:center;gap:10px;padding:12px 14px;border-bottom:1px solid var(--border)}
+.qfo-root .qfs-sheet-head h2{font-size:14px;font-weight:750}
+.qfo-root .qfs-sheet-head>span{font-size:12px;color:var(--muted)}
+.qfo-root .qfs-list{display:flex;flex-direction:column}
+.qfo-root .qfs-list-body{padding:8px;display:flex;flex-direction:column;gap:6px;flex:1}
+.qfo-root .qfs-option{display:grid;grid-template-columns:36px minmax(0,1fr) auto;gap:10px;align-items:center;width:100%;border:1px solid transparent;border-radius:8px;background:transparent;text-align:left;padding:12px 10px;position:relative;cursor:pointer}
+.qfo-root .qfs-option:hover{background:var(--surface-2)}
+.qfo-root .qfs-option.qfs-selected{background:var(--orange-50);border-color:#e9b49f}
+.qfo-root .qfs-option.qfs-selected:before{content:"";position:absolute;left:-1px;top:11px;bottom:11px;width:3px;background:var(--orange);border-radius:2px}
+.qfo-root .qfs-option strong{display:block;font-size:14px;font-weight:720}
+.qfo-root .qfs-option small{display:block;margin-top:4px;font-size:12px;color:var(--muted)}
+.qfo-root .qfs-mark{width:36px;height:36px;flex-shrink:0;border:1px solid var(--border-strong);border-radius:8px;display:grid;place-items:center;background:var(--surface-2);color:var(--text-2);font:760 11px/1 "Geist Mono",monospace}
+.qfo-root .qfs-selected .qfs-mark{color:var(--orange);border-color:#e9a38b;background:var(--surface)}
+.qfo-root .qfs-list-footer{margin: auto 0 0;padding:14px 10px 6px;border-top:1px solid var(--border);font-size:12px;line-height:1.6;color:var(--muted)}
+.qfo-root .qfs-detail{display:flex;flex-direction:column;min-height:0}
+.qfo-root .qfs-detail-head{display:flex;align-items:center;gap:16px;padding:16px;border-bottom:1px solid var(--border);min-height:80px;flex-wrap:wrap}
+.qfo-root .qfs-identity{display:flex;align-items:center;gap:11px;min-width:0}
+.qfo-root .qfs-name-row{display:flex;align-items:center;flex-wrap:wrap;gap:8px}
+.qfo-root .qfs-name-row h2{font-size:18px;letter-spacing:-.015em;font-weight:760}
+.qfo-root .qfs-identity p{font-size:13px;color:var(--muted);margin:5px 0 0}
+.qfo-root .qfs-actions{margin-left:auto;display:flex;align-items:center;gap:14px;flex-wrap:wrap}
+.qfo-root .qfs-status{border-radius:999px;padding:3px 8px;display:inline-flex;align-items:center;gap:5px;line-height:18px;font-size:12px;white-space:nowrap}
+.qfo-root .qfs-status.qfs-neutral{background:var(--surface-3)}
+.qfo-root .qfs-status.qfs-ok{background:var(--green-bg)}
+.qfo-root .qfs-status.qfs-warn{background:var(--amber-bg)}
+.qfo-root .qfs-state{display:inline-flex;align-items:center;gap:5px;font-size:12px;white-space:nowrap}
+.qfo-root .qfs-state i,.qfo-root .qfs-status i{width:5px;height:5px;border-radius:50%;background:currentColor;flex-shrink:0}
+.qfo-root .qfs-ok{color:var(--green)}.qfo-root .qfs-warn{color:var(--amber)}.qfo-root .qfs-neutral,.qfo-root .qfs-muted{color:var(--muted)}
+.qfo-root .qfs-switch-wrap{display:flex;align-items:center;gap:8px;color:var(--muted);font-size:13px}
+/* Retain label geometry and control colors throughout a request;
+ * only the switch thumb moves after the server confirms the new state. */
+.qfo-root .qfs-switch-wrap>span{min-width:3em;text-align:right}
+.qfo-root .qfs-updating button:disabled{opacity:1}
+.qfo-root .qfs-actions [aria-disabled=true]{cursor:wait}
+.qfo-root .qfs-actions .qfo-secondary-btn[aria-disabled=true]{transform:none}
+.qfo-root .qfs-switch{width:36px;height:20px;padding:2px;border:0;border-radius:999px;position:relative;background:var(--border-strong);cursor:pointer;transition:background .15s}
+.qfo-root .qfs-switch:after{content:"";display:block;width:16px;height:16px;border-radius:50%;background:white;box-shadow:0 1px 3px #20262b33;transition:transform .15s}
+.qfo-root .qfs-switch.qfs-on{background:var(--orange)}.qfo-root .qfs-switch.qfs-on:after{transform:translateX(16px)}
+.qfo-root .qfs-connection-band{display:grid;grid-template-columns:1.35fr 1fr 1fr 1fr;background:var(--surface-2);border-bottom:1px solid var(--border)}
+.qfo-root .qfs-connection-item{padding:15px 16px;min-width:0}
+.qfo-root .qfs-connection-item+.qfs-connection-item{border-left:1px solid var(--border)}
+.qfo-root .qfs-connection-label{font-size:12px;font-weight:650;color:var(--muted);margin-bottom:7px}
+.qfo-root .qfs-connection-value{font-size:13px;font-weight:650;overflow-wrap:anywhere;line-height:1.5}
+.qfo-root .qfs-connection-item p{font-size:12px;color:var(--muted);line-height:1.5;margin:5px 0 0}
+.qfo-root .qfs-connection-item>div+div{margin-top:10px}
+.qfo-root .qfs-mono{font-family:"Geist Mono","SFMono-Regular",monospace;font-size:12px;font-variant-numeric:tabular-nums}
+.qfo-root .qfs-scripts-head{display:flex;align-items:center;flex-wrap:wrap;gap:8px;padding:14px;border-bottom:1px solid var(--border);min-height:50px}
+.qfo-root .qfs-scripts-head h3{font-size:14px;font-weight:750}
+.qfo-root .qfs-scripts-head>span{color:var(--muted);font-size:12px}
+.qfo-root .qfs-scripts-head small{font-size:12px;color:var(--muted);margin-left:auto}
+/* Reserve scrollbar space only when content actually overflows, so the header
+ * reaches the sheet edge instead of leaving an empty permanent gutter. */
+.qfo-root .qfs-table-wrap{overflow:auto;min-height:0;max-height:calc(100svh - 355px);flex:1}
+.qfo-root .qfs-table{width:100%;min-width:740px;border-collapse:collapse;table-layout:fixed}
+.qfo-root .qfs-table th{position:sticky;top:0;z-index:1;text-align:left;background:var(--surface-2);border-bottom:1px solid var(--border);font-size:12px;color:var(--muted);font-weight:650;padding:10px 14px}
+.qfo-root .qfs-table td{padding:12px 14px;border-bottom:1px solid var(--border);font-size:13px;vertical-align:middle}
+.qfo-root .qfs-table tbody tr:hover{background:var(--orange-50)}
+.qfo-root .qfs-table tbody tr:last-child td{border-bottom:0}
+.qfo-root .qfs-script-name{font-size:14px;font-weight:650;line-height:1.5;overflow-wrap:anywhere}
+.qfo-root .qfs-script-english{display:block;margin-top:3px;font-size:12px;color:var(--muted);font-weight:400;line-height:1.45}
+.qfo-root .qfs-run-status{display:block;font-size:12px;color:var(--muted);margin-top:4px}
+.qfo-root .qfs-task-link{display:inline-flex;justify-content:center;align-items:center;min-height:32px;border:1px solid var(--border);border-radius:7px;padding:5px 9px;background:var(--surface);white-space:nowrap;font-size:12px;font-weight:650}
+.qfo-root .qfs-task-link:hover{color:var(--orange);border-color:var(--orange);background:var(--orange-50)}
+.qfo-root .qfs-message{display:flex;align-items:center;flex-wrap:wrap;gap:10px;padding:12px 14px;border-radius:8px;font-size:13px;line-height:1.6}
+.qfo-root .qfs-message>svg{width:17px;height:17px;flex-shrink:0}
+.qfo-root .qfs-message>span{flex:1}
+.qfo-root .qfs-error{background:var(--red-bg);color:var(--red);border:1px solid #d4a49c}
+.qfo-root .qfs-success{background:var(--green-bg);color:var(--green);border:1px solid #a6c1aa}
+.qfo-root .qfs-toast{max-width:calc(100vw - 40px);font-size:13px;line-height:1.6;background:var(--text);overflow-wrap:anywhere}
+.qfo-root .qfs-empty{padding:48px 20px;text-align:center;color:var(--muted);font-size:14px;display:flex;justify-content:center;align-items:center;gap:10px}
+.qfo-root .qfs-empty svg{width:20px;height:20px}
+.qfo-root .qfs-sr-only{position:absolute;width:1px;height:1px;padding:0;overflow:hidden;clip:rect(0,0,0,0);white-space:nowrap;border:0}
+.qfo-root .qfs-dialog{width:min(480px,calc(100vw - 32px));max-height:calc(100svh - 32px);margin:auto;padding:0;background:var(--surface);color:var(--text);border:1px solid var(--border-strong);border-radius:12px;box-shadow:0 24px 70px #20262b33;overflow:auto}
+.qfo-root .qfs-dialog::backdrop{background:#20262b3d}
+.qfo-root .qfs-dialog-head{padding:12px 16px;min-height:54px;display:flex;align-items:center;gap:10px;border-bottom:1px solid var(--border)}
+.qfo-root .qfs-dialog-head h2{font-size:16px;font-weight:750}.qfo-root .qfs-dialog-head button{margin-left:auto;flex-shrink:0}
+.qfo-root .qfs-dialog-body{padding:16px}
+.qfo-root .qfs-fields{padding:0;margin:0;border:0;min-width:0}
+.qfo-root .qfs-field{margin-bottom:16px}.qfo-root .qfs-field:last-child{margin-bottom:0}
+.qfo-root .qfs-field label{display:block;font-size:13px;font-weight:650;margin-bottom:7px}
+.qfo-root .qfs-required,.qfo-root .qfs-field-error{color:var(--red)}
+.qfo-root .qfs-field input:not([type=checkbox]){display:block;width:100%;height:40px;border:1px solid var(--border-strong);border-radius:8px;background:var(--surface);padding:0 10px;font-size:14px;color:var(--text);box-shadow:none;outline:none}
+.qfo-root .qfs-field input:focus{border-color:var(--orange);outline:2px solid #e85f3233;outline-offset:1px}
+.qfo-root .qfs-field input[aria-invalid=true]{border-color:var(--red)}
+.qfo-root .qfs-field-help,.qfo-root .qfs-form-note,.qfo-root .qfs-field-error{font-size:12px;line-height:1.6;margin:6px 0 0;color:var(--muted)}
+.qfo-root .qfs-field-error{color:var(--red)}.qfo-root .qfs-form-note{margin-top:16px}
+.qfo-root .qfs-dialog .qfs-message{display:block;margin-bottom:14px}
+.qfo-root .qfs-dialog .qfs-message p{margin:6px 0 0}
+.qfo-root .qfs-dialog .qfs-message ul{padding-left:18px;margin:6px 0 0}
+.qfo-root .qfs-dialog .qfs-message a{text-decoration:underline}
+.qfo-root .qfs-dialog .qfs-message .qfo-secondary-btn{margin-top:10px}
+.qfo-root .qfs-dialog-foot{padding:12px 16px;display:flex;justify-content:flex-end;gap:8px;min-height:58px;background:var(--surface-2);border-top:1px solid var(--border)}
+@media(min-width:2100px){.qfo-root .qfs-layout{grid-template-columns:300px minmax(0,1fr)}}
+@media(max-width:1380px){.qfo-root .qfs-layout{grid-template-columns:250px minmax(0,1fr)}.qfo-root .qfs-connection-item{padding:14px 12px}.qfo-root .qfs-table td,.qfo-root .qfs-table th{padding-left:11px;padding-right:11px}}
+@media(max-width:1100px){.qfo-root .qfs-layout{grid-template-columns:220px minmax(0,1fr)}.qfo-root .qfs-option{grid-template-columns:32px 1fr;gap:8px}.qfo-root .qfs-option>.qfs-state{grid-column:2}.qfo-root .qfs-connection-band{grid-template-columns:1fr 1fr}.qfo-root .qfs-connection-item:nth-child(3){border-left:0}.qfo-root .qfs-connection-item:nth-child(n+3){border-top:1px solid var(--border)}.qfo-root .qfs-table-wrap{max-height:540px}}
+@media(max-width:780px){.qfo-root .qfs-layout{grid-template-columns:minmax(0,1fr)}.qfo-root .qfs-list-footer{margin-top:8px}.qfo-root .qfs-option{grid-template-columns:36px minmax(0,1fr) auto}.qfo-root .qfs-option>.qfs-state{grid-column:auto}.qfo-root .qfs-detail-head{padding:14px;gap:14px}.qfo-root .qfs-actions{margin-left:0;justify-content:space-between;width:100%}.qfo-root .qfs-table-wrap{max-height:600px}.qfo-root .qfs-scripts-head small{margin-left:0;width:100%}.qfo-root .qfs-connection-band{grid-template-columns:1fr}.qfo-root .qfs-connection-item+.qfs-connection-item{border-left:0;border-top:1px solid var(--border)}.qfo-root .qfs-connection-item{padding:12px 14px}.qfo-root .qfs-dialog-foot{flex-wrap:wrap}}

--- a/frontend/src/pages/DataSourcesPage.tsx
+++ b/frontend/src/pages/DataSourcesPage.tsx
@@ -1,0 +1,210 @@
+import { CircleAlert, Database, LoaderCircle, RefreshCw, Settings2, X } from "lucide-react";
+import { useCallback, useEffect, useRef, useState } from "react";
+import { Link, useNavigate } from "react-router-dom";
+import { DataSourceApiError, listDataSources, readDataSource, saveDataSource, setDataSourceEnabled,
+  sourceDraft, sourceState, testDataSource, validateSourceDraft } from "../api/dataSources";
+import type { DataSource, SourceDraft, SourceProbe } from "../api/dataSources";
+import { useAuth } from "../auth/AuthContext";
+import { RUN_LABELS } from "../components/overviewPresentation";
+import "./DataSources.css";
+
+export function sourceTime(value: string | null): string {
+  if (!value) return "尚未检查";
+  const date = new Date(value);
+  return Number.isNaN(date.getTime()) ? "时间未知" : new Intl.DateTimeFormat("zh-CN", {
+    timeZone: "Asia/Shanghai", month: "2-digit", day: "2-digit", hour: "2-digit", minute: "2-digit", hour12: false
+  }).format(date);
+}
+const sourceMark = (source: DataSource) => source.key === "tushare" ? "TS" : source.name.slice(0, 2).toUpperCase();
+
+/** Native modal dialogs make the whole shell inert and handle focus trapping,
+ * including background navigation. Drafts live only in this mounted component. */
+function ConnectionDialog({ source, onClose, onSaved, onUnauthorized }: {
+  source: DataSource; onClose: () => void; onSaved: (source: DataSource) => void; onUnauthorized: () => void;
+}) {
+  const dialog = useRef<HTMLDialogElement>(null);
+  const form = useRef<HTMLFormElement>(null);
+  const errorSummary = useRef<HTMLDivElement>(null);
+  const pending = useRef(false);
+  const [current, setCurrent] = useState(source);
+  const [draft, setDraft] = useState(() => sourceDraft(source));
+  const [busy, setBusy] = useState<"test" | "save" | "reload" | null>(null);
+  const [errors, setErrors] = useState<Record<string, string>>({});
+  const [error, setError] = useState("");
+  const [probe, setProbe] = useState<SourceProbe | null>(null);
+  const [needsRefresh, setNeedsRefresh] = useState(false);
+  useEffect(() => {
+    const element = dialog.current;
+    element?.showModal();
+    form.current?.querySelector<HTMLInputElement>("input")?.focus();
+    return () => element?.close();
+  }, []);
+
+  const focusError = () => requestAnimationFrame(() => errorSummary.current?.focus());
+  function update(key: string, value: SourceDraft[string]) {
+    setDraft(previous => ({ ...previous, [key]: value }));
+    setErrors(previous => { const next = { ...previous }; delete next[key]; return next; });
+    // A successful probe applies only to the exact submitted draft.
+    setProbe(null); setError("");
+  }
+  async function submit(mode: "test" | "save") {
+    if (pending.current || needsRefresh) return;
+    const validation = validateSourceDraft(current, draft);
+    setErrors(validation); setProbe(null); setError("");
+    if (Object.keys(validation).length) { setError("请检查以下配置项。"); focusError(); return; }
+    pending.current = true; setBusy(mode);
+    try {
+      if (mode === "test") setProbe(await testDataSource(current, draft));
+      else onSaved(await saveDataSource(current, draft));
+    } catch (caught) {
+      if (caught instanceof DataSourceApiError && caught.status === 401) { onUnauthorized(); return; }
+      setError(caught instanceof DataSourceApiError ? caught.message : "操作未完成，请稍后重试。");
+      if (caught instanceof DataSourceApiError && caught.field) setErrors({ [caught.field]: caught.message });
+      setNeedsRefresh(caught instanceof DataSourceApiError && (caught.status === 409 || caught.status === 0));
+      focusError();
+    } finally { pending.current = false; setBusy(null); }
+  }
+  async function reload() {
+    if (pending.current) return;
+    pending.current = true; setBusy("reload");
+    try {
+      const fresh = await readDataSource(current.key);
+      setCurrent(fresh); setDraft(sourceDraft(fresh)); setNeedsRefresh(false); setError(""); setErrors({}); setProbe(null);
+    } catch (caught) {
+      if (caught instanceof DataSourceApiError && caught.status === 401) onUnauthorized();
+      else { setError("重新加载失败，请稍后重试。"); focusError(); }
+    } finally { pending.current = false; setBusy(null); }
+  }
+  return <dialog ref={dialog} className="qfs-dialog" aria-labelledby="source-dialog-title"
+    onCancel={event => { event.preventDefault(); if (!pending.current) onClose(); }}
+    onClick={event => {
+      if (event.target !== event.currentTarget || pending.current) return;
+      const rect = event.currentTarget.getBoundingClientRect();
+      if (event.clientX < rect.left || event.clientX > rect.right || event.clientY < rect.top || event.clientY > rect.bottom) onClose();
+    }}>
+    <form ref={form} noValidate onSubmit={event => { event.preventDefault(); void submit("save"); }}>
+      <header className="qfs-dialog-head"><h2 id="source-dialog-title">配置 {current.name} 连接</h2><button className="qfo-icon-btn" type="button" aria-label="关闭连接配置" disabled={!!busy} onClick={onClose}><X aria-hidden="true" /></button></header>
+      <div className="qfs-dialog-body">
+        {error && <div ref={errorSummary} className="qfs-message qfs-error" tabIndex={-1} role="alert"><strong>{error}</strong>{Object.entries(errors).length > 0 && <ul>{Object.entries(errors).map(([key, message]) => <li key={key}><a href={`#source-field-${key}`}>{message}</a></li>)}</ul>}
+          {needsRefresh && <><p>重新加载会清空当前草稿，并读取已保存的配置。</p><button type="button" className="qfo-secondary-btn" disabled={!!busy} onClick={() => void reload()}>重新加载配置</button></>}
+        </div>}
+        <fieldset disabled={!!busy || needsRefresh} className="qfs-fields">
+          {current.fields.map(field => {
+            const id = `source-field-${field.key}`;
+            const configured = current.secret_fields_configured.includes(field.key);
+            return <div className="qfs-field" key={field.key}>
+              <label htmlFor={id}>{field.label}{field.required && !(field.type === "secret" && configured) && <span className="qfs-required"> *</span>}</label>
+              {field.type === "boolean" ? <input id={id} type="checkbox" checked={!!draft[field.key]} onChange={event => update(field.key, event.target.checked)} />
+                : <input id={id} type={field.type === "secret" ? "password" : field.type === "url" ? "url" : ["integer", "number"].includes(field.type) ? "number" : "text"}
+                  value={String(draft[field.key] ?? "")} autoComplete={field.type === "secret" ? "new-password" : "off"} spellCheck={false}
+                  step={field.type === "integer" ? 1 : "any"} maxLength={field.type === "secret" ? 4096 : 2048}
+                  aria-invalid={!!errors[field.key]} aria-describedby={`${id}-help${errors[field.key] ? ` ${id}-error` : ""}`}
+                  placeholder={field.type === "secret" && configured ? "已配置，留空沿用现有凭据" : undefined}
+                  onChange={event => update(field.key, event.target.value === "" ? "" : ["integer", "number"].includes(field.type) ? Number(event.target.value) : event.target.value)} />}
+              <p id={`${id}-help`} className="qfs-field-help">{field.help}</p>
+              {errors[field.key] && <p className="qfs-field-error" id={`${id}-error`}>{errors[field.key]}</p>}
+            </div>;
+          })}
+        </fieldset>
+        <p className="qfs-form-note">测试连接仅验证当前表单，不保存。保存时先验证，通过后才生效；失败保留原配置。</p>
+        {probe && <div className={`qfs-message ${probe.ok ? "qfs-success" : "qfs-error"}`} role="status"><strong>{probe.ok ? "测试通过 · 尚未保存" : "连接测试未通过"}</strong><p>{probe.message}</p></div>}
+        <span className="qfs-sr-only" role="status">{busy === "test" ? "正在测试连接" : busy === "save" ? "正在验证并保存配置" : ""}</span>
+      </div>
+      <footer className="qfs-dialog-foot"><button className="qfo-secondary-btn" type="button" disabled={!!busy || needsRefresh} onClick={() => void submit("test")}>{busy === "test" && <LoaderCircle className="spin" aria-hidden="true" />}{busy === "test" ? "测试中…" : "测试连接"}</button><button className="qfo-primary-btn" type="submit" disabled={!!busy || needsRefresh}>{busy === "save" && <LoaderCircle className="spin" aria-hidden="true" />}{busy === "save" ? "验证并保存中…" : "保存配置"}</button></footer>
+    </form>
+  </dialog>;
+}
+
+export function SourceDetail({ source, busy, onConfigure, onToggle }: {
+  source: DataSource; busy: boolean; onConfigure: () => void; onToggle: () => void;
+}) {
+  const state = sourceState(source);
+  const publicFields = source.fields.filter(field => field.type !== "secret");
+  return <section className="qfs-sheet qfs-detail" aria-label={`${source.name} 数据源详情`}>
+    <header className="qfs-detail-head"><div className="qfs-identity"><div className="qfs-mark">{sourceMark(source)}</div><div><div className="qfs-name-row"><h2>{source.name}</h2><span className={`qfs-status qfs-${state.tone}`}><i />{state.label}</span></div><p>结构化市场与基础数据接口</p></div></div>
+      {/* Keep labels and native button appearance stable during short requests.
+       * Aria-disabled preserves focus; guarded handlers still block interaction. */}
+      <div className="qfs-actions"><button className="qfo-secondary-btn" type="button" onClick={() => { if (!busy) onConfigure(); }} aria-disabled={busy}><Settings2 aria-hidden="true" />配置连接</button><label className="qfs-switch-wrap"><span>启用</span><button className={`qfs-switch${source.enabled ? " qfs-on" : ""}`} type="button" role="switch" aria-label={`启用 ${source.name} 数据源`} aria-checked={source.enabled} aria-disabled={busy} aria-busy={busy} disabled={!source.configured && !source.enabled} onClick={() => { if (!busy) onToggle(); }} title="停用会跳过等待运行；已开始的任务继续执行，任务计划保留。" /></label></div>
+    </header>
+    <div className="qfs-connection-band">
+      <div className="qfs-connection-item">{publicFields.map(field => <div key={field.key}><div className="qfs-connection-label">{field.label}</div><div className="qfs-connection-value qfs-mono" title={String(source.values[field.key] ?? "未配置")}>{String(source.values[field.key] ?? "未配置")}</div></div>)}<p>当前连接配置</p></div>
+      <div className="qfs-connection-item"><div className="qfs-connection-label">认证</div><div className="qfs-connection-value">{source.configured ? "凭据已配置" : "尚未配置"}</div><p>凭据不会在页面中明文显示</p></div>
+      <div className="qfs-connection-item"><div className="qfs-connection-label">最近检查</div><div className="qfs-connection-value qfs-mono">{sourceTime(source.checked_at)}</div><p>保存配置时检查 · 上海时间</p></div>
+      <div className="qfs-connection-item"><div className="qfs-connection-label">状态</div><span className={`qfs-state qfs-${state.tone}`}><i />{state.label}</span><p>{!source.enabled ? "已开始的任务继续执行" : !source.configured ? "请先配置连接" : source.check_status === "not_checked" ? "已配置不代表连接可用" : "最近检查结果，非实时状态"}</p></div>
+    </div>
+    <div className="qfs-scripts-head"><h3>采集脚本</h3><span>{source.capabilities.length} 个已注册脚本</span><small>从脚本创建采集任务</small></div>
+    <div className="qfs-table-wrap" tabIndex={0} role="region" aria-label="采集脚本表格，可横向和纵向滚动">
+      <table className="qfs-table"><colgroup><col style={{width:"43%"}} /><col style={{width:"11%"}} /><col style={{width:"13%"}} /><col style={{width:"19%"}} /><col style={{width:"14%"}} /></colgroup><thead><tr><th scope="col">脚本</th><th scope="col">关联任务</th><th scope="col">状态</th><th scope="col">最近运行</th><th scope="col"><span className="qfs-sr-only">操作</span></th></tr></thead>
+        <tbody>{source.capabilities.map(item => <tr key={item.key}>
+          <td><div className="qfs-script-name">{item.name}<span className="qfs-script-english">（{item.english_name}）</span></div></td>
+          <td><span className="qfs-mono">{item.task_count}</span> 个</td>
+          <td><span className={`qfs-state ${item.available ? "qfs-ok" : "qfs-neutral"}`}><i />{item.available ? "就绪" : source.enabled ? "待配置" : "已停用"}</span></td>
+          <td>{item.last_run ? <><div className="qfs-mono">{sourceTime(item.last_run.finished_at ?? item.last_run.started_at ?? item.last_run.created_at)}</div><span className="qfs-run-status">{RUN_LABELS[item.last_run.status] ?? "状态未知"}</span></> : <span className="qfs-muted">暂无运行</span>}</td>
+          <td><Link className="qfs-task-link" aria-label={`配置任务：${item.name}（${item.english_name}）`} to={`/admin/tasks?create_type=${encodeURIComponent(item.key)}`}>配置任务</Link></td>
+        </tr>)}</tbody>
+      </table>{!source.capabilities.length && <p className="qfs-empty">此数据源尚无已注册的采集脚本。</p>}
+    </div>
+  </section>;
+}
+
+export function DataSourcesPage() {
+  const { logout } = useAuth(); const navigate = useNavigate();
+  const [sources, setSources] = useState<DataSource[] | null>(null);
+  const [selected, setSelected] = useState("");
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState("");
+  const [message, setMessage] = useState("");
+  useEffect(() => {
+    if (!message) return;
+    // Successful feedback is transient and never participates in page layout.
+    // Cancel the previous expiry when another action replaces the message.
+    const timer = window.setTimeout(() => setMessage(""), 5000);
+    return () => window.clearTimeout(timer);
+  }, [message]);
+  const [editing, setEditing] = useState<DataSource | null>(null);
+  const [changing, setChanging] = useState(false);
+  const [stale, setStale] = useState(false);
+  const pending = useRef(false);
+  const request = useRef<AbortController | null>(null);
+  const returnFocus = useRef<HTMLElement | null>(null);
+  const source = sources?.find(item => item.key === selected) ?? sources?.[0];
+  const unauthorized = useCallback(() => { logout(); navigate("/login", { replace: true }); }, [logout, navigate]);
+  const load = useCallback(async () => {
+    request.current?.abort(); const controller = new AbortController(); request.current = controller;
+    setLoading(true); setError(""); setMessage("");
+    try {
+      const result = await listDataSources(controller.signal);
+      if (!controller.signal.aborted) { setSources(result.items); setStale(false); }
+    } catch (caught) {
+      if (controller.signal.aborted) return;
+      if (caught instanceof DataSourceApiError && caught.status === 401) unauthorized();
+      else { setStale(true); setError(caught instanceof DataSourceApiError ? caught.message : "数据源加载失败。"); }
+    } finally { if (!controller.signal.aborted) setLoading(false); }
+  }, [unauthorized]);
+  useEffect(() => { void load(); return () => request.current?.abort(); }, [load]);
+  function replace(updated: DataSource) { setSources(previous => previous?.map(item => item.key === updated.key ? updated : item) ?? [updated]); }
+  function close() { setEditing(null); requestAnimationFrame(() => returnFocus.current?.isConnected && returnFocus.current.focus()); }
+  async function toggle() {
+    if (!source || pending.current || stale || loading) return;
+    pending.current = true; setChanging(true); setError(""); setMessage("");
+    try {
+      const result = await setDataSourceEnabled(source, !source.enabled); replace(result);
+      setMessage(result.enabled ? `${result.name} 已启用，后续计划正常执行，不补跑停用期间的计划。`
+        : `${result.name} 已停用，已跳过 ${result.skipped_runs ?? 0} 个等待运行；已开始的任务继续执行，任务计划保留。`);
+    } catch (caught) {
+      if (caught instanceof DataSourceApiError && caught.status === 401) unauthorized();
+      else { setStale(true); setError(caught instanceof DataSourceApiError ? caught.message : "状态更新未完成，请刷新后核对。"); }
+    } finally { pending.current = false; setChanging(false); }
+  }
+  return <div className={`qfo-content qfs-content${changing ? " qfs-updating" : ""}`}>
+    <div className="qfo-page-head"><div><div className="qfo-eyebrow">Data Sources</div><h1>数据源</h1><p className="qfo-page-desc">查看连接状态、维护连接配置，并管理各数据源可用的采集脚本。</p></div><div className="qfs-page-actions"><span className="qfs-head-status">{sources ? `${sources.filter(item => item.configured).length} / ${sources.length} 个数据源已配置` : "正在读取数据源"}</span><button type="button" className="qfo-icon-btn" aria-label="刷新数据源" title="刷新数据源" disabled={loading || changing || !!editing} onClick={() => void load()}><RefreshCw className={loading ? "spin" : ""} aria-hidden="true" /></button></div></div>
+    {error && <div className="qfs-message qfs-error" role="alert"><CircleAlert aria-hidden="true" /><span>{error}{sources && " 当前显示上次读取的状态，刷新成功后可继续操作。"}</span><button className="qfo-secondary-btn" type="button" disabled={loading} onClick={() => void load()}>重试</button></div>}
+    <div className={`qfo-toast qfs-toast${message ? " qfo-show" : ""}`} role="status" aria-live="polite" aria-atomic="true">{message}</div>
+    {!sources ? <div className="qfs-sheet qfs-empty" role="status">{loading ? <><LoaderCircle className="spin" aria-hidden="true" />正在加载数据源…</> : "未能读取数据源，请重试。"}</div>
+      : sources.length === 0 ? <div className="qfs-sheet qfs-empty"><Database aria-hidden="true" /><p>暂无已接入的数据源。</p></div>
+      : <div className="qfs-layout"><section className="qfs-sheet qfs-list" aria-label="已接入数据源"><header className="qfs-sheet-head"><h2>已接入</h2><span>{sources.length} 个数据源</span></header><div className="qfs-list-body">{sources.map(item => { const state = sourceState(item); return <button type="button" key={item.key} className={`qfs-option${source?.key === item.key ? " qfs-selected" : ""}`} aria-pressed={source?.key === item.key} disabled={changing} onClick={() => { setSelected(item.key); setMessage(""); }}><span className="qfs-mark">{sourceMark(item)}</span><span><strong>{item.name}</strong><small>{item.capabilities.length} 个采集脚本</small></span><span className={`qfs-state qfs-${state.tone}`}><i />{state.label}</span></button>; })}<p className="qfs-list-footer">维护已接入数据源的连接配置与启用状态。</p></div></section>
+        {source && <SourceDetail source={source} busy={changing || loading || stale} onConfigure={() => { returnFocus.current = document.activeElement as HTMLElement; setEditing(source); }} onToggle={() => void toggle()} />}
+      </div>}
+    {editing && <ConnectionDialog source={editing} onClose={close} onUnauthorized={unauthorized} onSaved={updated => { replace(updated); close(); setMessage(`${updated.name} 连接已验证并保存。`); }} />}
+  </div>;
+}

--- a/frontend/src/pages/TaskSchedulerPage.tsx
+++ b/frontend/src/pages/TaskSchedulerPage.tsx
@@ -4,7 +4,7 @@ import {
 } from "lucide-react";
 import { useCallback, useEffect, useMemo, useState } from "react";
 import type { FormEvent } from "react";
-import { useNavigate } from "react-router-dom";
+import { Link, useNavigate, useSearchParams } from "react-router-dom";
 
 import {
   changeTaskState, createTask, listRecentTaskRuns, listTaskRuns, listTaskTypes, listTasks,
@@ -235,6 +235,8 @@ function RunIcon({ status }: { status: TaskRun["status"] }) {
 export function TaskSchedulerPage() {
   const { logout } = useAuth();
   const navigate = useNavigate();
+  const [searchParams, setSearchParams] = useSearchParams();
+  const [fromSource] = useState(() => searchParams.has("create_type"));
   const [tasks, setTasks] = useState<SchedulerTask[]>([]);
   const [taskTypes, setTaskTypes] = useState<TaskType[]>([]);
   const [runs, setRuns] = useState<TaskRun[]>([]);
@@ -274,6 +276,19 @@ export function TaskSchedulerPage() {
   }, [handleError]);
 
   useEffect(() => { void loadTasks(); }, [loadTasks]);
+  useEffect(() => {
+    const key = searchParams.get("create_type");
+    if (!key || loading || !taskTypes.length) return;
+    const selected = taskTypes.find(item => item.key === key);
+    if (selected) {
+      // A source-page entry preselects only a registered type. It never creates
+      // a task until the operator completes and submits this existing form.
+      setDraft(newTaskDraft([selected, ...taskTypes.filter(item => item.key !== key)]));
+      setModalMode("create");
+    } else setError("该采集脚本当前未注册，请返回数据源刷新后重试。");
+    const next = new URLSearchParams(searchParams); next.delete("create_type");
+    setSearchParams(next, { replace: true });
+  }, [loading, searchParams, setSearchParams, taskTypes]);
   useEffect(() => {
     if (!selectedTask) { setRuns([]); return; }
     setRuns([]);
@@ -325,6 +340,7 @@ export function TaskSchedulerPage() {
   }
 
   return <section className="tasks-page" aria-labelledby="tasks-title">
+    {fromSource && <Link className="toolbar-button" to="/admin/data-sources">返回数据源</Link>}
     <div className="page-heading tasks-page__heading"><div><h2 id="tasks-title">任务调度</h2><p>查看计划任务、执行队列和最近运行结果</p></div><div className="tasks-page__actions"><button className="toolbar-button" type="button" disabled={refreshing} onClick={() => void loadTasks(true)}><RefreshCw className={refreshing ? "spin" : ""} aria-hidden="true" />刷新</button><button className="task-create-button" type="button" disabled={loading || taskTypes.length === 0} title={taskTypes.length === 0 ? "请先在后端注册任务类型" : undefined} onClick={openCreate}><Plus aria-hidden="true" />新建任务</button></div></div>
     {error && <div className="task-message task-message--error" role="alert"><CircleAlert aria-hidden="true" />{error}</div>}
     {!loading && taskTypes.length === 0 && <div className="task-message" role="status">当前没有已注册的任务类型。请先在后端注册业务任务，随后即可在这里创建计划。</div>}

--- a/frontend/tests/data-sources.test.cjs
+++ b/frontend/tests/data-sources.test.cjs
@@ -1,0 +1,83 @@
+/* Isolated provider fixtures never enter the production app or real backend. */
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const ts = require('typescript');
+for (const ext of ['.ts', '.tsx']) require.extensions[ext] = (module, filename) => module._compile(ts.transpileModule(fs.readFileSync(filename, 'utf8'), {
+  compilerOptions: { jsx: ts.JsxEmit.ReactJSX, module: ts.ModuleKind.CommonJS, target: ts.ScriptTarget.ES2022 }, fileName: filename
+}).outputText, filename);
+require.extensions['.css'] = () => {};
+global.__QF_VERSION__ = fs.readFileSync(require('node:path').join(__dirname, '../../VERSION'), 'utf8').trim();
+const { createElement } = require('react');
+const { renderToStaticMarkup } = require('react-dom/server');
+const { MemoryRouter } = require('react-router-dom');
+const api = require('../src/api/dataSources.ts');
+const { SourceDetail, sourceTime } = require('../src/pages/DataSourcesPage.tsx');
+const source = {
+  key: 'fixture/source', name: 'Fixture', fields: [
+    { key: 'endpoint', label: '服务地址', type: 'url', required: true },
+    { key: 'credential', label: '访问凭据', type: 'secret', required: true },
+    { key: 'retries', label: '重试次数', type: 'integer', required: true, default: 0 },
+    { key: 'sandbox', label: '沙盒', type: 'boolean', required: true, default: false }
+  ], values: { endpoint: 'https://example.test', credential: 'must-not-display' },
+  secret_fields_configured: ['credential'], configured: true, enabled: true, version: 7,
+  checked_at: null, check_status: 'not_checked', check_message: null,
+  capabilities: [{ key: 'private_task_key', name: '交易日历采集', english_name: 'Trading Calendar Sync', task_count: 2, available: true,
+    last_run: { id: 'run-1', task_id: 'task-1', status: 'failed', created_at: '2026-09-08T16:00:00Z', started_at: null, finished_at: null } }]
+};
+const render = value => renderToStaticMarkup(createElement(MemoryRouter, null, createElement(SourceDetail, { source: value, busy: false, onConfigure() {}, onToggle() {} })));
+test('provider schemas preserve zero and false but never initialize a secret', () => {
+  const draft = api.sourceDraft(source);
+  assert.deepEqual(draft, { endpoint: 'https://example.test', credential: '', retries: 0, sandbox: false });
+  assert.deepEqual(api.validateSourceDraft(source, draft), {});
+  assert.match(api.validateSourceDraft({ ...source, secret_fields_configured: [] }, draft).credential, /请填写/);
+});
+test('invalid drafts fail locally', () => {
+  const draft = api.sourceDraft(source);
+  for (const endpoint of ['', 'ftp://example.test', 'https://user:pass@example.test', 'https://example.test?q=secret', 'https://example.test/#fragment']) assert.ok(api.validateSourceDraft(source, { ...draft, endpoint }).endpoint);
+  for (const retries of [1.5, 'invalid', Infinity]) assert.ok(api.validateSourceDraft(source, { ...draft, retries }).retries);
+  assert.deepEqual(api.validateSourceDraft(source, { ...draft, credential: ' ' }), {});
+});
+test('connection evidence and task history remain distinct from availability', () => {
+  for (const [change, label] of [[{}, '未检测'], [{check_status:'connected'}, '连接正常'], [{check_status:'rejected'}, '检查异常'], [{configured:false}, '待配置'], [{enabled:false,check_status:'connected'}, '已停用']]) assert.equal(api.sourceState({...source,...change}).label,label);
+  const html = render(source);
+  assert.match(html, /关联任务/); assert.match(html, />2<\/span> 个/);
+  assert.match(html, /交易日历采集/); assert.match(html, /Trading Calendar Sync/); assert.match(html, /create_type=private_task_key/);
+  assert.doesNotMatch(html.replace(/<[^>]*>/g, ''), /private_task_key|must-not-display/);
+  assert.match(html, /失败/); assert.match(html, /尚未检查/);
+  assert.match(render({ ...source, enabled: false, capabilities: [] }), /此数据源尚无已注册/);
+});
+test('timestamps use Shanghai', () => {
+  assert.equal(sourceTime(null), '尚未检查'); assert.equal(sourceTime('bad'), '时间未知'); assert.match(sourceTime('2026-09-08T16:00:00Z'), /09\/09 00:00/);
+});
+test('requests carry auth, current version and exact draft without caching', async () => {
+  const originalFetch = global.fetch, originalWindow = global.window, calls = [];
+  global.window = { sessionStorage: { getItem: () => 'fixture-login-token' } };
+  global.fetch = async (path, options) => { calls.push({path,options}); return {ok:true,json:async()=>source}; };
+  try {
+    const draft = api.sourceDraft(source);
+    await api.listDataSources(); await api.testDataSource(source,draft); await api.saveDataSource(source,draft); await api.setDataSourceEnabled(source,false);
+    assert.equal(calls[1].path,'/api/data-sources/fixture%2Fsource/test');
+    assert.deepEqual(JSON.parse(calls[2].options.body),{version:7,fields:draft}); assert.deepEqual(JSON.parse(calls[3].options.body),{version:7,enabled:false});
+    for (const {options} of calls) { assert.equal(options.cache,'no-store'); assert.equal(options.headers.Authorization,'Bearer fixture-login-token'); }
+  } finally { global.fetch=originalFetch; global.window=originalWindow; }
+});
+test('conflicts remain actionable while raw server errors stay hidden', async () => {
+  const originalFetch = global.fetch;
+  try {
+    global.fetch=async()=>({ok:false,status:409,json:async()=>({detail:{message:'配置已更新，请刷新。',field:'endpoint'}})});
+    await assert.rejects(api.saveDataSource(source,{}),e=>e.status===409&&e.field==='endpoint');
+    global.fetch=async()=>({ok:false,status:502,json:async()=>{throw new Error('private trace');}});
+    await assert.rejects(api.listDataSources(),e=>e.status===502&&!e.message.includes('private trace'));
+    global.fetch=async()=>({ok:false,status:401,json:async()=>({detail:'Unauthorized'})});
+    await assert.rejects(api.listDataSources(),e=>e.status===401);
+    global.fetch=async()=>{throw new TypeError('private network detail');};
+    await assert.rejects(api.saveDataSource(source,{}),e=>e.status===0&&e.message.includes('不要重复提交'));
+  } finally { global.fetch=originalFetch; }
+});
+test('caller cancellation remains recognizable', async () => {
+  const originalFetch=global.fetch;
+  global.fetch=async(_path,options)=>{if(options.signal.aborted)throw new DOMException('','AbortError');};
+  try { const controller=new AbortController(); controller.abort(); await assert.rejects(api.listDataSources(controller.signal),{name:'AbortError'}); }
+  finally { global.fetch=originalFetch; }
+});

--- a/frontend/tests/overview.test.cjs
+++ b/frontend/tests/overview.test.cjs
@@ -54,7 +54,7 @@ test('server aggregates, retry reminders and task display names survive renderin
   assert.match(html, /已有后续执行排队或运行中/);
   assert.match(html, /交易日历同步（Trading Calendar Sync）/);
   assert.doesNotMatch(html, /internal_task_key/);
-  assert.match(html, /连接未检测/);
+  assert.match(html, /配置状态汇总/);
   assert.match(html, /已配置不代表连接可用/);
 });
 


### PR DESCRIPTION
## Summary
Add the reviewed data source management page backed by the deployed provider configuration APIs. Operators can inspect registered ingestion scripts and linked task counts, test or save provider-specific connection fields without exposing credentials, and enable or disable sources with clear server-confirmed feedback.

Use the approved shared shell and brand tokens, transient success toasts, stable controls, and a task creation link that preselects the registered type. Keep designer documents local-only.

## Validation
- User acceptance completed for page 03, including feedback and table spacing fixes.
- 21 frontend tests passed; TypeScript and production build passed.
- Real test backend: migrated configuration read, failed save preserved configuration, source disable succeeded.
- Isolated browser checks: stable controls and layout across enable/disable, toast expiry verified.
