### PR TITLE
Support A-share market search and calendar details

### DIFF
--- a/backend/app/data_ingestion/repositories/etf_query.py
+++ b/backend/app/data_ingestion/repositories/etf_query.py
@@ -34,6 +34,7 @@ class EtfOverview:
     latest_list_date: date | None
     last_updated_at: datetime | None
     refreshed_at: datetime | None
+    exchanges: list[str]
 
 
 class EtfQueryRepository:
@@ -75,25 +76,33 @@ class EtfQueryRepository:
         summary = self.session.execute(
             select(
                 func.count(EtfCode.ts_code),
-                func.count(func.distinct(EtfCode.exchange)),
                 func.count(EtfCode.ts_code).filter(EtfCode.list_status == "L"),
                 func.min(EtfCode.list_date),
                 func.max(EtfCode.list_date),
                 func.max(EtfCode.last_seen_at),
             ).where(EtfCode.source == self.source)
         ).one()
+        # Report actual source-scoped markets, normalizing legacy aliases before
+        # counting so SH/SSE and SZ/SZSE cannot appear as different exchanges.
+        exchanges = sorted({
+            self._exchange_codes(exchange)[0]
+            for exchange in self.session.scalars(
+                select(EtfCode.exchange).where(EtfCode.source == self.source).distinct()
+            )
+        })
         checkpoint = self.session.get(
             DataSyncCheckpoint,
             {"sync_key": ETF_BASIC_SYNC_KEY, "scope_key": "market=CN"},
         )
         return EtfOverview(
             total_records=int(summary[0] or 0),
-            exchange_count=int(summary[1] or 0),
-            listed_count=int(summary[2] or 0),
-            first_list_date=summary[3],
-            latest_list_date=summary[4],
-            last_updated_at=summary[5],
+            exchange_count=len(exchanges),
+            listed_count=int(summary[1] or 0),
+            first_list_date=summary[2],
+            latest_list_date=summary[3],
+            last_updated_at=summary[4],
             refreshed_at=self._refresh_timestamp(checkpoint),
+            exchanges=exchanges,
         )
 
     def _filters(
@@ -106,15 +115,15 @@ class EtfQueryRepository:
         """Build predicates once so the list and count always agree."""
         filters: list[object] = [EtfCode.source == self.source]
         if keyword is not None:
-            pattern = f"%{keyword}%"
-            filters.append(
-                or_(
-                    EtfCode.ts_code.ilike(pattern),
-                    EtfCode.csname.ilike(pattern),
-                    EtfCode.extname.ilike(pattern),
-                    EtfCode.cname.ilike(pattern),
-                )
-            )
+            # Match the market workspace's literal substring search across fund,
+            # tracked-index and manager fields. Escape LIKE metacharacters so a
+            # typed '%' or '_' does not accidentally select the whole catalogue.
+            filters.append(or_(
+                *(column.icontains(keyword.strip(), autoescape=True) for column in (
+                    EtfCode.ts_code, EtfCode.csname, EtfCode.extname, EtfCode.cname,
+                    EtfCode.index_code, EtfCode.index_name, EtfCode.mgr_name,
+                ))
+            ))
         if exchange is not None:
             filters.append(EtfCode.exchange.in_(self._exchange_codes(exchange)))
         if list_status is not None:

--- a/backend/app/data_ingestion/repositories/trading_calendar_query.py
+++ b/backend/app/data_ingestion/repositories/trading_calendar_query.py
@@ -3,7 +3,7 @@
 from dataclasses import dataclass
 from datetime import date, datetime
 
-from sqlalchemy import Select, func, select
+from sqlalchemy import func, select
 from sqlalchemy.orm import Session
 
 from app.data_ingestion.constants import TRADE_CALENDAR_SYNC_KEY
@@ -61,6 +61,40 @@ class TradingCalendarQueryRepository:
             select(func.count()).select_from(TradingCalendarDay).where(*filters)
         )
         return items, int(total or 0)
+
+    def get_day(
+        self, exchange: str, calendar_date: date
+    ) -> tuple[TradingCalendarDay | None, date | None]:
+        """Return a stored day and its next open day only with complete coverage.
+
+        A later known open day is not necessarily the next trading day: missing
+        dates in between may themselves be open. Count the intervening closed
+        records using the exchange/date primary key, and return unknown unless
+        every intervening calendar date is explicitly recorded as closed. This
+        also handles holidays and year boundaries without weekday assumptions.
+        """
+        day = self.session.get(TradingCalendarDay, (exchange, calendar_date))
+        if day is None:
+            return None, None
+        next_date = self.session.scalar(
+            select(func.min(TradingCalendarDay.calendar_date)).where(
+                TradingCalendarDay.exchange == exchange,
+                TradingCalendarDay.calendar_date > calendar_date,
+                TradingCalendarDay.is_open.is_(True),
+            )
+        )
+        if next_date is not None:
+            closed_count = self.session.scalar(
+                select(func.count()).select_from(TradingCalendarDay).where(
+                    TradingCalendarDay.exchange == exchange,
+                    TradingCalendarDay.calendar_date > calendar_date,
+                    TradingCalendarDay.calendar_date < next_date,
+                    TradingCalendarDay.is_open.is_(False),
+                )
+            )
+            if closed_count != (next_date - calendar_date).days - 1:
+                next_date = None
+        return day, next_date
 
     def overview(self) -> TradingCalendarOverview:
         """Return database coverage and committed cursors for operator status."""

--- a/backend/app/data_ingestion/router.py
+++ b/backend/app/data_ingestion/router.py
@@ -4,7 +4,7 @@ from datetime import date, datetime
 from decimal import Decimal
 from typing import Annotated
 
-from fastapi import APIRouter, Depends, HTTPException, Query, status
+from fastapi import APIRouter, Depends, HTTPException, Path, Query, status
 from pydantic import BaseModel, ConfigDict
 from sqlalchemy.orm import Session
 
@@ -29,6 +29,12 @@ class TradingCalendarDayResponse(BaseModel):
     is_open: bool
     previous_trading_date: date | None
     updated_at: datetime
+
+
+class TradingCalendarDetailResponse(TradingCalendarDayResponse):
+    """Selected date facts; a null next date means stored coverage is insufficient."""
+
+    next_trading_date: date | None
 
 
 class TradingCalendarPageResponse(BaseModel):
@@ -91,6 +97,7 @@ class EtfOverviewResponse(BaseModel):
     latest_list_date: date | None
     last_updated_at: datetime | None
     refreshed_at: datetime | None
+    exchanges: list[str]
 
 
 class EtfDailyBarResponse(BaseModel):
@@ -133,6 +140,7 @@ def list_trading_calendar_days(
     offset: Annotated[int, Query(ge=0)] = 0,
 ) -> TradingCalendarPageResponse:
     """List all stored calendar rows with server-side filters and pagination."""
+    _validate_date_range(start_date, end_date)
     items, total = TradingCalendarQueryRepository(session).list_days(
         exchange=exchange,
         is_open=is_open,
@@ -165,6 +173,30 @@ def get_trading_calendar_overview(
         end_date=overview.end_date,
         last_updated_at=overview.last_updated_at,
         checkpoints=overview.checkpoints,
+    )
+
+
+@router.get(
+    "/trading-calendar/{exchange}/{calendar_date}",
+    response_model=TradingCalendarDetailResponse,
+)
+def get_trading_calendar_day(
+    exchange: Annotated[str, Path(min_length=1, max_length=16)],
+    calendar_date: date,
+    session: Annotated[Session, Depends(get_db_session)],
+) -> TradingCalendarDetailResponse:
+    """Read selected-date facts without guessing holidays or missing calendar rows."""
+    day, next_date = TradingCalendarQueryRepository(session).get_day(
+        exchange, calendar_date
+    )
+    if day is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="该交易所的所选日期尚未采集，请先同步交易日历。",
+        )
+    return TradingCalendarDetailResponse(
+        **TradingCalendarDayResponse.model_validate(day).model_dump(),
+        next_trading_date=next_date,
     )
 
 
@@ -207,6 +239,7 @@ def get_etf_overview(
         latest_list_date=overview.latest_list_date,
         last_updated_at=overview.last_updated_at,
         refreshed_at=overview.refreshed_at,
+        exchanges=overview.exchanges,
     )
 
 

--- a/backend/tests/test_auth.py
+++ b/backend/tests/test_auth.py
@@ -134,6 +134,7 @@ class AuthenticationTestCase(unittest.TestCase):
             ("/api/admin/task-runs", "get"),
             ("/api/admin/data-collections/trading-calendar", "get"),
             ("/api/admin/data-collections/trading-calendar/overview", "get"),
+            ("/api/admin/data-collections/trading-calendar/{exchange}/{calendar_date}", "get"),
             ("/api/admin/data-collections/etfs", "get"),
             ("/api/admin/data-collections/etfs/overview", "get"),
             ("/api/admin/data-collections/etfs/{ts_code}", "get"),

--- a/backend/tests/test_etf_query.py
+++ b/backend/tests/test_etf_query.py
@@ -46,11 +46,11 @@ class EtfQueryRepositoryTestCase(unittest.TestCase):
         session.execute.return_value.one.return_value = (
             3,
             2,
-            2,
             date(2024, 1, 1),
             date(2026, 8, 15),
             datetime(2026, 8, 16, 10, 0, tzinfo=UTC),
         )
+        session.scalars.return_value = ["SSE", "SH", "SZ"]
         session.get.return_value = DataSyncCheckpoint(
             sync_key="tushare.etf_basic",
             scope_key="market=CN",
@@ -61,6 +61,7 @@ class EtfQueryRepositoryTestCase(unittest.TestCase):
 
         self.assertEqual(overview.total_records, 3)
         self.assertEqual(overview.exchange_count, 2)
+        self.assertEqual(overview.exchanges, ["SSE", "SZSE"])
         self.assertEqual(overview.listed_count, 2)
         self.assertEqual(overview.first_list_date, date(2024, 1, 1))
         self.assertEqual(overview.latest_list_date, date(2026, 8, 15))

--- a/backend/tests/test_market_workspace.py
+++ b/backend/tests/test_market_workspace.py
@@ -1,0 +1,182 @@
+"""Run market workspace queries against real rows, using PostgreSQL in CI.
+
+Local column mirrors follow the existing overview tests because checkpoint
+constraints use PostgreSQL JSON operators. PostgreSQL uses the migrated schema;
+fixtures are isolated by source/exchange and rolled back after every test.
+"""
+
+import os
+import unittest
+from datetime import UTC, date, datetime, timedelta
+from unittest.mock import patch
+from uuid import uuid4
+
+from fastapi import HTTPException
+from sqlalchemy import Column, JSON, MetaData, Table, create_engine
+from sqlalchemy.dialects.postgresql import JSONB
+from sqlalchemy.orm import Session
+
+from app.core.config import get_settings
+from app.data_ingestion.models.etf import EtfCode, EtfEntity
+from app.data_ingestion.models.sync_checkpoint import DataSyncCheckpoint
+from app.data_ingestion.models.trading_calendar import TradingCalendarDay
+from app.data_ingestion.repositories.etf_query import EtfQueryRepository
+from app.data_ingestion.router import (
+    get_etf_overview,
+    get_trading_calendar_day,
+    list_etfs,
+    list_trading_calendar_days,
+)
+from app.instruments.models import Instrument
+
+
+NOW = datetime(2026, 9, 10, tzinfo=UTC)
+
+
+class MarketWorkspaceTest(unittest.TestCase):
+    def setUp(self):
+        postgres = os.getenv("POSTGRES_TEST_ENABLED") == "1"
+        self.engine = create_engine(get_settings().database_url if postgres else "sqlite://")
+        if not postgres:
+            metadata = MetaData()
+            for model in (Instrument, EtfEntity, EtfCode, TradingCalendarDay, DataSyncCheckpoint):
+                Table(model.__tablename__, metadata, *[
+                    Column(column.name, JSON() if isinstance(column.type, JSONB) else column.type,
+                           primary_key=column.primary_key)
+                    for column in model.__table__.columns
+                ])
+            metadata.create_all(self.engine)
+        self.connection = self.engine.connect()
+        self.transaction = self.connection.begin()
+        self.session = Session(self.connection)
+        self.source = "market-test." + uuid4().hex[:16]
+        self.exchange = "T" + uuid4().hex[:10]
+        self.repository = EtfQueryRepository(self.session, source=self.source)
+
+    def tearDown(self):
+        self.session.close()
+        if self.transaction.is_active:
+            self.transaction.rollback()
+        self.connection.close()
+        self.engine.dispose()
+
+    def etf(self, code, **fields):
+        identity = uuid4()
+        self.session.add(Instrument(id=identity, asset_class="etf", status="active", created_at=NOW))
+        self.session.flush()
+        self.session.add(EtfEntity(id=identity, created_at=NOW))
+        self.session.flush()
+        values = dict(source=self.source, ts_code=code, etf_id=identity,
+                      exchange="SH", list_status="L", list_date=date(2026, 9, 1),
+                      created_at=NOW, updated_at=NOW, first_seen_at=NOW, last_seen_at=NOW)
+        values.update(fields)
+        result = EtfCode(**values)
+        self.session.add(result)
+        self.session.flush()
+        return result
+
+    def query(self, **filters):
+        options = dict(keyword=None, exchange=None, list_status=None, limit=50, offset=0)
+        options.update(filters)
+        # Exercise response serialization and the actual query while isolating
+        # fixture totals from any other source in the disposable PostgreSQL DB.
+        with patch("app.data_ingestion.router.EtfQueryRepository", return_value=self.repository):
+            return list_etfs(session=self.session, **options)
+
+    def calendar(self, day, *, open=False, exchange=None, previous=None):
+        result = TradingCalendarDay(exchange=exchange or self.exchange, calendar_date=day,
+            is_open=open, previous_trading_date=previous, created_at=NOW, updated_at=NOW)
+        self.session.add(result)
+        self.session.flush()
+        return result
+
+    def detail(self, day):
+        return get_trading_calendar_day(self.exchange, day, self.session)
+
+    def test_search_matches_index_manager_and_existing_name_fields(self):
+        self.etf("510001.SH", csname="基金简称", extname="扩展名称", cname="基金完整名称",
+                 index_name="红利质量", index_code="CSI.DIV", mgr_name="测试管理人")
+        self.etf("510002.SH", csname="无关基金")
+        self.etf("510003.SH", source=self.source + "x", index_name="红利质量")
+        for query in ("510001.sh", "基金简称", "扩展名称", "完整名称", " 红利质量 ", "csi.div", "测试管理人"):
+            with self.subTest(query=query):
+                result = self.query(keyword=query)
+                self.assertEqual(result.total, 1)
+                self.assertEqual([item.ts_code for item in result.items], ["510001.SH"])
+
+    def test_search_keeps_exchange_status_and_paginated_totals_consistent(self):
+        self.etf("510001.SH", index_name="红利", exchange="SH", list_status="P")
+        self.etf("510002.SH", index_name="红利", exchange="SSE", list_status="P")
+        self.etf("159001.SZ", index_name="红利", exchange="SZ", list_status="P")
+        self.etf("510003.SH", index_name="红利", exchange="SH", list_status="D")
+        result = self.query(keyword="红利", exchange="SSE", list_status="P", limit=1, offset=1)
+        self.assertEqual((result.total, result.limit, result.offset), (2, 1, 1))
+        self.assertEqual([item.ts_code for item in result.items], ["510002.SH"])
+        self.assertEqual(self.query(keyword="不存在").total, 0)
+
+    def test_search_treats_percent_underscore_and_escape_as_literal_text(self):
+        self.etf("510001.SH", index_name="A%_B/C")
+        self.etf("510002.SH", index_name="AxxB")
+        for keyword in ("%", "_", "/", "%_B/"):
+            with self.subTest(keyword=keyword):
+                self.assertEqual([item.ts_code for item in self.query(keyword=keyword).items], ["510001.SH"])
+
+    def test_overview_returns_normalized_source_scoped_exchanges(self):
+        for index, exchange in enumerate(("SH", "SSE", "SZ", "SZSE")):
+            self.etf(f"{index:06}.SH", exchange=exchange, list_status="L" if index < 2 else "P")
+        self.etf("999999.SH", source=self.source + "x", exchange="OTHER")
+        with patch("app.data_ingestion.router.EtfQueryRepository", return_value=self.repository):
+            result = get_etf_overview(self.session)
+        self.assertEqual(result.exchanges, ["SSE", "SZSE"])
+        self.assertEqual((result.total_records, result.listed_count, result.exchange_count), (4, 2, 2))
+        empty = EtfQueryRepository(self.session, source="empty-" + uuid4().hex[:16]).overview()
+        self.assertEqual((empty.total_records, empty.exchanges, empty.exchange_count), (0, [], 0))
+        self.assertIsNone(empty.first_list_date)
+
+    def test_calendar_details_cross_holidays_months_and_years(self):
+        for start, distance in ((date(2026, 9, 30), 9), (date(2026, 12, 31), 4)):
+            with self.subTest(start=start):
+                self.calendar(start, open=True, previous=start - timedelta(days=1))
+                for offset in range(1, distance):
+                    self.calendar(start + timedelta(days=offset), previous=start)
+                next_day = start + timedelta(days=distance)
+                self.calendar(next_day, open=True, previous=start)
+                first = self.detail(start)
+                self.assertEqual(first.previous_trading_date, start - timedelta(days=1))
+                self.assertEqual(first.next_trading_date, next_day)
+                closed = self.detail(start + timedelta(days=1))
+                self.assertFalse(closed.is_open)
+                self.assertEqual(closed.next_trading_date, next_day)
+                self.assertIn("updated_at", closed.model_dump())
+
+    def test_calendar_missing_coverage_does_not_guess_next_trading_day(self):
+        start = date(2026, 10, 8)
+        self.calendar(start, open=True)
+        self.calendar(start + timedelta(days=2), open=True)
+        # Another exchange's row cannot fill the selected exchange's gap.
+        self.calendar(start + timedelta(days=1), exchange="X" + self.exchange)
+        self.assertIsNone(self.detail(start).next_trading_date)
+        self.calendar(start + timedelta(days=1))
+        # This fixture marks Saturday open: persisted facts must beat weekdays.
+        self.assertEqual(self.detail(start).next_trading_date, date(2026, 10, 10))
+        self.assertIsNone(self.detail(date(2026, 10, 10)).next_trading_date)
+        with self.assertRaises(HTTPException) as raised:
+            self.detail(date(2026, 10, 11))
+        self.assertEqual(raised.exception.status_code, 404)
+        self.assertIn("尚未采集", raised.exception.detail)
+
+    def test_calendar_list_keeps_missing_dates_absent_and_validates_ranges(self):
+        self.calendar(date(2026, 9, 1), open=True)
+        self.calendar(date(2026, 9, 3))
+        filters = dict(session=self.session, exchange=self.exchange, is_open=None,
+                       start_date=date(2026, 9, 1), end_date=date(2026, 9, 30), limit=42, offset=0)
+        result = list_trading_calendar_days(**filters)
+        self.assertEqual(result.total, 2)
+        self.assertEqual([item.calendar_date.day for item in result.items], [3, 1])
+        with self.assertRaises(HTTPException) as raised:
+            list_trading_calendar_days(**{**filters, "start_date": date(2026, 10, 1)})
+        self.assertEqual(raised.exception.status_code, 422)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
The A-share market workspace needs index/manager search, an accurate exchange summary, and selected-date calendar facts. ETF search now matches fund names/codes, tracked index names/codes, and managers with literal substring semantics; overview responses include normalized exchange identifiers and count legacy aliases as one market.

Adds `GET /api/admin/data-collections/trading-calendar/{exchange}/{calendar_date}` with stored day facts and `next_trading_date`. The next date is returned only when every intervening date is explicitly recorded closed for that exchange. Missing selected dates return 404, incomplete future coverage returns null, and reversed calendar list ranges return 422.

Validation:
- Full local backend suite: 2,064 passed, 217 subtests passed, 16 skipped (PostgreSQL-dependent checks run in CI).
- Focused market/query/auth suite after fetching and merging latest origin/main: 21 passed, 17 subtests passed.
- Release version check, 14 root tests, TypeScript and Vite production build passed.
- New real-row tests run on SQLite locally and the migrated PostgreSQL schema in CI.

No database migration, new environment setting, or frontend change. Deploy the merged backend before implementing and integrating the approved market page UI. Design documents remain local-only.
