### PR TITLE
Upgrade A-share market workspace and trading calendar

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -10,7 +10,8 @@ import { BacktestPreflightPage } from "./pages/BacktestPreflightPage";
 import { BacktestRunsPage } from "./pages/BacktestRunsPage";
 import { DashboardPage } from "./pages/DashboardPage";
 import { DataSourcesPage } from "./pages/DataSourcesPage";
-import { DataCollectionPage, EtfBasicsPage } from "./pages/DataCollectionPage";
+import { DataCollectionPage } from "./pages/DataCollectionPage";
+import { MarketPage } from "./pages/MarketPage";
 import { EtfDetailPage } from "./pages/EtfDetailPage";
 import { LoginPage } from "./pages/LoginPage";
 import { LogPage } from "./pages/LogPage";
@@ -66,7 +67,7 @@ export function App() {
       />
       <Route
         path="/admin/data/trading-calendar"
-        element={<RequireAuth><AdminPage><DataCollectionPage page="trading-calendar" /></AdminPage></RequireAuth>}
+        element={<RequireAuth><Navigate to="/admin/data/etf-basics?calendar=open" replace /></RequireAuth>}
       />
       <Route
         path="/admin/data/daily-quotes"
@@ -74,7 +75,7 @@ export function App() {
       />
       <Route
         path="/admin/data/etf-basics"
-        element={<RequireAuth><AdminPage><EtfBasicsPage /></AdminPage></RequireAuth>}
+        element={<RequireAuth><OverviewShell title="A 股市场" section="MARKET DATA" className="qfm-root"><MarketPage /></OverviewShell></RequireAuth>}
       />
       <Route
         path="/admin/data/etf-basics/:tsCode"

--- a/frontend/src/api/dataCollections.ts
+++ b/frontend/src/api/dataCollections.ts
@@ -8,6 +8,10 @@ export interface TradingCalendarDay {
   updated_at: string;
 }
 
+export interface TradingCalendarDetail extends TradingCalendarDay {
+  next_trading_date: string | null;
+}
+
 export interface TradingCalendarPage {
   items: TradingCalendarDay[];
   total: number;
@@ -65,6 +69,7 @@ export interface EtfOverview {
   latest_list_date: string | null;
   last_updated_at: string | null;
   refreshed_at: string | null;
+  exchanges: string[];
 }
 
 export interface EtfFilters {
@@ -114,8 +119,10 @@ function headers(): HeadersInit {
   return token ? { Authorization: `Bearer ${token}` } : {};
 }
 
-async function request<T>(path: string): Promise<T> {
-  const response = await fetch(path, { headers: headers() });
+async function request<T>(path: string, signal?: AbortSignal): Promise<T> {
+  // Refreshes inspect persisted facts again; cancellation also guards callers
+  // against a response whose JSON finishes after the selection has changed.
+  const response = await fetch(path, { headers: headers(), cache: "no-store", signal });
   if (!response.ok) {
     let message = `请求失败（HTTP ${response.status}）。`;
     try {
@@ -126,14 +133,16 @@ async function request<T>(path: string): Promise<T> {
     }
     throw new DataCollectionApiError(message, response.status);
   }
-  return response.json() as Promise<T>;
+  const value = await response.json() as T;
+  signal?.throwIfAborted();
+  return value;
 }
 
 export function getTradingCalendarOverview(): Promise<TradingCalendarOverview> {
   return request<TradingCalendarOverview>("/api/admin/data-collections/trading-calendar/overview");
 }
 
-export function listTradingCalendarDays(filters: TradingCalendarFilters): Promise<TradingCalendarPage> {
+export function listTradingCalendarDays(filters: TradingCalendarFilters, signal?: AbortSignal): Promise<TradingCalendarPage> {
   const params = new URLSearchParams();
   if (filters.exchange) params.set("exchange", filters.exchange);
   if (filters.isOpen !== undefined) params.set("is_open", String(filters.isOpen));
@@ -141,21 +150,25 @@ export function listTradingCalendarDays(filters: TradingCalendarFilters): Promis
   if (filters.endDate) params.set("end_date", filters.endDate);
   params.set("limit", String(filters.limit ?? 50));
   params.set("offset", String(filters.offset ?? 0));
-  return request<TradingCalendarPage>(`/api/admin/data-collections/trading-calendar?${params}`);
+  return request<TradingCalendarPage>(`/api/admin/data-collections/trading-calendar?${params}`, signal);
 }
 
-export function getEtfOverview(): Promise<EtfOverview> {
-  return request<EtfOverview>("/api/admin/data-collections/etfs/overview");
+export function getTradingCalendarDay(exchange: string, date: string, signal?: AbortSignal): Promise<TradingCalendarDetail> {
+  return request<TradingCalendarDetail>(`/api/admin/data-collections/trading-calendar/${encodeURIComponent(exchange)}/${encodeURIComponent(date)}`, signal);
 }
 
-export function listEtfs(filters: EtfFilters): Promise<EtfPage> {
+export function getEtfOverview(signal?: AbortSignal): Promise<EtfOverview> {
+  return request<EtfOverview>("/api/admin/data-collections/etfs/overview", signal);
+}
+
+export function listEtfs(filters: EtfFilters, signal?: AbortSignal): Promise<EtfPage> {
   const params = new URLSearchParams();
   if (filters.keyword) params.set("keyword", filters.keyword);
   if (filters.exchange) params.set("exchange", filters.exchange);
   if (filters.listStatus) params.set("list_status", filters.listStatus);
   params.set("limit", String(filters.limit ?? 50));
   params.set("offset", String(filters.offset ?? 0));
-  return request<EtfPage>(`/api/admin/data-collections/etfs?${params}`);
+  return request<EtfPage>(`/api/admin/data-collections/etfs?${params}`, signal);
 }
 
 function timeSeriesParams(filters: EtfTimeSeriesFilters): string {

--- a/frontend/src/components/OverviewShell.tsx
+++ b/frontend/src/components/OverviewShell.tsx
@@ -11,7 +11,7 @@ const groups = [
     { label: "数据源", to: "/admin/data-sources", icon: Database },
     { label: "采集任务", to: "/admin/tasks", icon: Clock3 }
   ] },
-  { label: "市场数据", items: [{ label: "A 股市场", to: "", icon: ChartNoAxesColumn }] },
+  { label: "市场数据", items: [{ label: "A 股市场", to: "/admin/data/etf-basics", icon: ChartNoAxesColumn }] },
   { label: "策略研究", items: [
     { label: "策略工作台", to: "/admin/strategies", icon: Code2 },
     { label: "策略数据接口", to: "/admin/strategy-data", icon: BookOpen },
@@ -27,7 +27,6 @@ const toolItems = [
 ];
 const destinations = [
   ...groups.flatMap(group => group.items.filter(item => item.to).map(item => ({ ...item, group: group.label }))),
-  { label: "ETF 基础信息", to: "/admin/data/etf-basics", group: "市场数据" },
   { label: "交易日历", to: "/admin/data/trading-calendar", group: "数据资产" },
   { label: "回测预检", to: "/admin/backtest-preflight", group: "策略研究" },
   ...toolItems.map(item => ({ ...item, group: "运行与工具" }))
@@ -35,7 +34,7 @@ const destinations = [
 
 /** Reviewed overview, source and collection-task pages share this shell. Legacy routes retain their
  * existing theme setting until each page is reviewed and accepted separately. */
-export function OverviewShell({ children, title = "数据运营总览", section = "WORKBENCH" }: { children: React.ReactNode; title?: string; section?: string }) {
+export function OverviewShell({ children, title = "数据运营总览", section = "WORKBENCH", className = "" }: { children: React.ReactNode; title?: string; section?: string; className?: string }) {
   const { logout } = useAuth();
   const navigate = useNavigate();
   const location = useLocation();
@@ -87,7 +86,7 @@ export function OverviewShell({ children, title = "数据运营总览", section 
     if (item.to === "/docs") return <a key={item.label} className={className} aria-label={label} title={label} href="/docs" target="_blank" rel="noreferrer">{content}</a>;
     return <Link key={item.label} className={className} aria-label={label} title={label} to={item.to} aria-current={item.to === location.pathname ? "page" : undefined}>{content}</Link>;
   }
-  return <div className="qfo-root">
+  return <div className={`qfo-root ${className}`}>
     <div className={`qfo-app${collapsed ? " qfo-sidebar-collapsed" : ""}`} inert={open}>
       <aside className="qfo-sidebar" aria-label="工作区侧栏">
         <div className="qfo-brand"><div className="qfo-mark">QF</div><div className="qfo-brand-copy"><div className="qfo-brand-name">Quant Foundry</div><div className="qfo-brand-meta">RESEARCH SYSTEM</div></div></div>

--- a/frontend/src/pages/DataCollectionPage.tsx
+++ b/frontend/src/pages/DataCollectionPage.tsx
@@ -1,10 +1,10 @@
-import { CalendarDays, ChevronLeft, ChevronRight, Database, RefreshCw, Search } from "lucide-react";
-import { useCallback, useEffect, useRef, useState } from "react";
-import { Link, useNavigate } from "react-router-dom";
+import { CalendarDays, ChevronLeft, ChevronRight, Database, RefreshCw } from "lucide-react";
+import { useCallback, useEffect, useState } from "react";
+import { useNavigate } from "react-router-dom";
 
 import {
-  DataCollectionApiError, EtfOverview, EtfPage, getEtfOverview,
-  getTradingCalendarOverview, listEtfs, listTradingCalendarDays,
+  DataCollectionApiError,
+  getTradingCalendarOverview, listTradingCalendarDays,
   TradingCalendarOverview, TradingCalendarPage
 } from "../api/dataCollections";
 import { useAuth } from "../auth/AuthContext";
@@ -15,7 +15,6 @@ type CollectionPage = "trading-calendar" | "daily-quotes";
 type OpenFilter = "" | "open" | "closed";
 
 const EMPTY_PAGE: TradingCalendarPage = { items: [], total: 0, limit: PAGE_SIZE, offset: 0 };
-const EMPTY_ETF_PAGE: EtfPage = { items: [], total: 0, limit: PAGE_SIZE, offset: 0 };
 
 function formatDate(value: string | null): string {
   if (!value) return "—";
@@ -49,125 +48,6 @@ function DailyQuotesEmptyState() {
       <h3>日线行情尚未接入</h3>
       <p>当前版本尚未配置日线行情的数据模型和采集任务，因此没有可展示的数据库数据。</p>
     </div>
-  </section>;
-}
-
-function etfStatusLabel(value: string): string {
-  return { L: "上市", D: "退市", P: "待上市" }[value] ?? value;
-}
-
-function etfExchangeLabel(value: string): string {
-  return { SSE: "上交所", SZSE: "深交所", SH: "上交所", SZ: "深交所" }[value] ?? value;
-}
-
-function formatManagementFee(value: string | null): string {
-  if (!value) return "—";
-  const fee = Number(value);
-  return Number.isFinite(fee) ? `${fee.toLocaleString("zh-CN", { maximumFractionDigits: 4 })}%` : value;
-}
-
-function etfRefreshSummary(overview: EtfOverview | null): string {
-  if (!overview) return "正在加载 ETF 采集状态…";
-  const refreshedAt = overview.refreshed_at ?? overview.last_updated_at;
-  if (!refreshedAt) return "尚未完成 ETF 基础信息同步。";
-  return `Tushare ETF 基础信息已于 ${formatTimestamp(refreshedAt)} 同步完成。`;
-}
-
-/**
- * Display persisted ETF reference data only after fetching it from the admin API.
- *
- * This page deliberately keeps source filtering server-side so that future data
- * providers cannot be mixed with Tushare records without an explicit UI choice.
- */
-export function EtfBasicsPage() {
-  const { logout } = useAuth();
-  const navigate = useNavigate();
-  const [overview, setOverview] = useState<EtfOverview | null>(null);
-  const [result, setResult] = useState<EtfPage>(EMPTY_ETF_PAGE);
-  const [keyword, setKeyword] = useState("");
-  const [exchange, setExchange] = useState("");
-  const [listStatus, setListStatus] = useState("");
-  const [offset, setOffset] = useState(0);
-  const [loading, setLoading] = useState(true);
-  const [refreshing, setRefreshing] = useState(false);
-  const [error, setError] = useState<string | null>(null);
-  const hasLoadedRef = useRef(false);
-  const latestRequestRef = useRef(0);
-
-  const load = useCallback(async (background = false) => {
-    const requestId = latestRequestRef.current + 1;
-    latestRequestRef.current = requestId;
-    const initialLoad = !hasLoadedRef.current;
-    if (initialLoad && !background) setLoading(true); else setRefreshing(true);
-    setError(null);
-    try {
-      const [nextOverview, nextResult] = await Promise.all([
-        getEtfOverview(),
-        listEtfs({
-          keyword: keyword.trim() || undefined,
-          exchange: exchange || undefined,
-          listStatus: listStatus || undefined,
-          limit: PAGE_SIZE,
-          offset
-        })
-      ]);
-      if (requestId !== latestRequestRef.current) return;
-      setOverview(nextOverview);
-      setResult(nextResult);
-      hasLoadedRef.current = true;
-    } catch (caught) {
-      if (requestId !== latestRequestRef.current) return;
-      if (caught instanceof DataCollectionApiError && caught.status === 401) {
-        logout(); navigate("/login", { replace: true }); return;
-      }
-      setError(caught instanceof Error ? caught.message : "ETF 数据加载失败。");
-    } finally {
-      if (requestId === latestRequestRef.current) {
-        setLoading(false); setRefreshing(false);
-      }
-    }
-  }, [exchange, keyword, listStatus, logout, navigate, offset]);
-
-  useEffect(() => { void load(); }, [load]);
-
-  const currentPage = Math.floor(result.offset / PAGE_SIZE) + 1;
-  const pageCount = Math.max(1, Math.ceil(result.total / PAGE_SIZE));
-  const visibleStart = result.total === 0 ? 0 : result.offset + 1;
-  const visibleEnd = Math.min(result.offset + result.items.length, result.total);
-  const refreshTime = overview?.refreshed_at ?? overview?.last_updated_at ?? null;
-
-  function resetFilters() {
-    setKeyword(""); setExchange(""); setListStatus(""); setOffset(0);
-  }
-
-  return <section className="collection-page" aria-labelledby="collection-title">
-    <div className="page-heading">
-      <div><h2 id="collection-title">ETF 基础信息</h2><p>查看 ETF 标识、上市状态及跟踪指数等基础资料</p></div>
-      <button className="toolbar-button" type="button" disabled={refreshing} onClick={() => void load(true)}>
-        <RefreshCw className={refreshing ? "spin" : ""} aria-hidden="true" />刷新数据
-      </button>
-    </div>
-    {error && <div className="page-error" role="alert">{error}</div>}
-    <section className="collection-status" aria-labelledby="etf-status-title">
-      <div className="collection-status__heading"><div><h3 id="etf-status-title">采集情况</h3><p>ETF 基础信息的数据库覆盖与最近同步状态</p></div><span>{formatTimestamp(refreshTime)} 更新</span></div>
-      <div className="collection-status__stats">
-        <div><span>上市日期范围</span><strong>{overview?.first_list_date ? `${formatDate(overview.first_list_date)} — ${formatDate(overview.latest_list_date)}` : "暂无数据"}</strong><small>仅统计已提供上市日期的 ETF</small></div>
-        <div><span>数据库记录</span><strong>{(overview?.total_records ?? 0).toLocaleString("zh-CN")}</strong><small>共 {overview?.exchange_count ?? 0} 个交易所</small></div>
-        <div><span>上市 ETF</span><strong>{(overview?.listed_count ?? 0).toLocaleString("zh-CN")}</strong><small>当前上市状态为上市</small></div>
-      </div>
-      <div className="collection-status__checkpoint"><CalendarDays aria-hidden="true" /><div><strong>最近同步</strong><span>{etfRefreshSummary(overview)}</span></div></div>
-    </section>
-    <section className="collection-table etf-table" aria-labelledby="etf-list-title">
-      <div className="collection-table__heading"><div><h3 id="etf-list-title">ETF 列表</h3><span>筛选条件在服务端执行</span></div><strong aria-live="polite">{refreshing ? "正在更新…" : `${result.total.toLocaleString("zh-CN")} 条`}</strong></div>
-      <div className="collection-filter collection-filter--etf" aria-label="ETF 筛选">
-        <label>代码或名称<div className="etf-search-field"><Search aria-hidden="true" /><input type="search" value={keyword} placeholder="例如：510300 或 沪深300" onChange={(event) => { setKeyword(event.target.value); setOffset(0); }} /></div></label>
-        <label>交易所<select value={exchange} onChange={(event) => { setExchange(event.target.value); setOffset(0); }}><option value="">全部交易所</option><option value="SSE">上交所</option><option value="SZSE">深交所</option></select></label>
-        <label>上市状态<select value={listStatus} onChange={(event) => { setListStatus(event.target.value); setOffset(0); }}><option value="">全部状态</option><option value="L">上市</option><option value="D">退市</option><option value="P">待上市</option></select></label>
-        <button type="button" onClick={resetFilters}>重置筛选</button>
-      </div>
-      <div className="collection-table__scroll"><table className="etf-data-table" aria-busy={loading || refreshing}><thead><tr><th>基金代码</th><th>名称</th><th>交易所</th><th>上市状态</th><th>上市日期</th><th>跟踪指数</th><th>管理人</th><th>管理费率</th><th>更新时间</th></tr></thead><tbody>{loading ? <tr><td colSpan={9} className="collection-table__empty">正在加载 ETF 数据…</td></tr> : result.items.length === 0 ? <tr><td colSpan={9} className="collection-table__empty">没有符合筛选条件的数据</td></tr> : result.items.map((etf) => <tr key={etf.ts_code}><td><Link className="etf-detail-link etf-code" to={`/admin/data/etf-basics/${encodeURIComponent(etf.ts_code)}`}>{etf.ts_code}</Link><small>{etf.etf_type ?? "—"}</small></td><td><Link className="etf-detail-link" to={`/admin/data/etf-basics/${encodeURIComponent(etf.ts_code)}`}>{etf.csname ?? etf.extname ?? "—"}</Link><small>{etf.cname ?? ""}</small></td><td>{etfExchangeLabel(etf.exchange)}</td><td><span className={`etf-status etf-status--${etf.list_status.toLowerCase()}`}>{etfStatusLabel(etf.list_status)}</span></td><td>{formatDate(etf.list_date)}</td><td><strong>{etf.index_name ?? "—"}</strong><small>{etf.index_code ?? ""}</small></td><td>{etf.mgr_name ?? "—"}</td><td>{formatManagementFee(etf.mgt_fee)}</td><td>{formatTimestamp(etf.updated_at)}</td></tr>)}</tbody></table></div>
-      <div className="collection-table__pagination"><span>显示 {visibleStart}–{visibleEnd} 条，共 {result.total.toLocaleString("zh-CN")} 条</span><div><button type="button" aria-label="上一页" disabled={offset === 0} onClick={() => setOffset((value) => Math.max(0, value - PAGE_SIZE))}><ChevronLeft aria-hidden="true" /></button><span>{currentPage} / {pageCount}</span><button type="button" aria-label="下一页" disabled={offset + PAGE_SIZE >= result.total} onClick={() => setOffset((value) => value + PAGE_SIZE)}><ChevronRight aria-hidden="true" /></button></div></div>
-    </section>
   </section>;
 }
 

--- a/frontend/src/pages/EtfDetailPage.tsx
+++ b/frontend/src/pages/EtfDetailPage.tsx
@@ -7,7 +7,8 @@ import {
   type KLineData
 } from "klinecharts";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { useNavigate, useParams, useSearchParams } from "react-router-dom";
+import { useLocation, useNavigate, useParams, useSearchParams } from "react-router-dom";
+import { marketReturnTo } from "./market/marketPresentation";
 
 import {
   DataCollectionApiError,
@@ -503,6 +504,7 @@ function InteractiveKLineChart({
 
 export function EtfDetailPage() {
   const { tsCode = "" } = useParams();
+  const location = useLocation();
   const { logout } = useAuth();
   const navigate = useNavigate();
   const [searchParams, setSearchParams] = useSearchParams();
@@ -605,10 +607,11 @@ export function EtfDetailPage() {
   if (!etf) return <section className="collection-page"><div className="collection-empty-state">{error ?? "ETF 不存在。"}</div></section>;
 
   return <section className="collection-page etf-detail-page" aria-labelledby="etf-detail-title">
-    <button className="etf-detail__back" type="button" onClick={() => navigate("/admin/data/etf-basics") }><ChevronLeft aria-hidden="true" />返回 ETF 列表</button>
+    <button className="etf-detail__back" type="button" onClick={() => navigate(marketReturnTo(location.state?.marketReturnTo)) }><ChevronLeft aria-hidden="true" />返回 ETF 列表</button>
     <div className="page-heading etf-detail__heading"><div><div className="etf-detail__title"><h2 id="etf-detail-title">{displayName}</h2><span>{etf.ts_code}</span></div><p>查看该 ETF 的基础资料、日线行情与复权因子</p></div></div>
     {error && <div className="page-error" role="alert">{error}</div>}
-    <div className="etf-detail__tabs" role="tablist" aria-label="ETF 详情页签">{TABS.map((item) => <button key={item.key} className={tab === item.key ? "active" : ""} type="button" role="tab" aria-selected={tab === item.key} onClick={() => setSearchParams(item.key === "basic" ? {} : { tab: item.key })}>{item.label}</button>)}</div>
+    {/* Tab URL changes must retain the originating market filters in history. */}
+    <div className="etf-detail__tabs" role="tablist" aria-label="ETF 详情页签">{TABS.map((item) => <button key={item.key} className={tab === item.key ? "active" : ""} type="button" role="tab" aria-selected={tab === item.key} onClick={() => setSearchParams(item.key === "basic" ? {} : { tab: item.key }, { state: location.state })}>{item.label}</button>)}</div>
     {tab === "basic" && <section className="collection-table etf-detail__basic"><div className="collection-table__heading"><div><h3>基础资料</h3><span>ETF 基础信息的当前数据</span></div></div><dl><div><dt>交易所</dt><dd>{exchangeLabel(etf.exchange)}</dd></div><div><dt>上市状态</dt><dd>{statusLabel(etf.list_status)}</dd></div><div><dt>上市日期</dt><dd>{formatDate(etf.list_date)}</dd></div><div><dt>跟踪指数</dt><dd>{etf.index_name ?? "—"}</dd></div><div><dt>管理人</dt><dd>{etf.mgr_name ?? "—"}</dd></div><div><dt>管理费率</dt><dd>{etf.mgt_fee ? `${numberText(etf.mgt_fee)}%` : "—"}</dd></div></dl></section>}
     {tab !== "basic" && <>
       <div className="etf-detail__filters">

--- a/frontend/src/pages/Market.css
+++ b/frontend/src/pages/Market.css
@@ -1,0 +1,133 @@
+/* The approved A-share B baseline is scoped to this route. Other reviewed
+   pages keep their own density and responsive layout decisions. */
+.qfo-root.qfm-root { --canvas:#F5F2EC; --surface:#FFFCF7; --surface-2:#F4F0E9; --surface-3:#EEEAE3; --text:#20262B; --text-2:#414B53; --muted:#626D76; --muted-2:#626D76; --orange-600:#B24323; font-variant-numeric:tabular-nums; }
+.qfm-root .qfo-main { overflow:auto; padding:20px 24px; }
+.qfm-root .qfo-topbar { background:var(--canvas); backdrop-filter:none; }
+.qfm-root .qfo-sidebar { background:#EEEAE3; }
+.qfm-root .qfo-icon-btn,.qfm-root .qfo-secondary-btn { height:36px; }
+.qfm-root .qfo-icon-btn { width:36px; }
+.qfm-root .qfo-secondary-btn { font-size:14px; font-weight:650; }
+.qfm-root .qfo-secondary-btn svg { width:18px; height:18px; }
+/* Pending list requests keep controls and keyboard focus in place. Native
+   disabled styling is reserved for unavailable actions, such as page boundaries. */
+.qfm-root .qfm-page-head button[aria-disabled="true"]:not(:disabled),.qfm-root .qfm-pagination button[aria-disabled="true"]:not(:disabled) { cursor:progress; }
+.qfm-root .qfm-content { height:100%; min-height:560px; width:min(100%,1580px); margin:0 auto; display:flex; flex-direction:column; gap:16px; }
+.qfm-root .qfm-page-head { margin:0; align-items:center; gap:16px; }
+.qfm-root .qfm-page-head h1 { font-size:32px; line-height:40px; font-weight:700; }
+.qfm-root .qfm-page-head .qfo-page-desc { font-size:13px; line-height:20px; margin-top:4px; }
+.qfm-root .qfm-market-band { flex-shrink:0; min-height:104px; display:grid; grid-template-columns:1fr .7fr 1.45fr 1fr; background:var(--surface); border:1px solid var(--border); border-radius:10px; overflow:hidden; }
+.qfm-root .qfm-metric { padding:12px 16px; min-width:0; }
+.qfm-root .qfm-metric+.qfm-metric { border-left:1px solid var(--border); }
+.qfm-root .qfm-metric-label { font-size:12px; line-height:18px; color:var(--muted); margin-bottom:6px; font-weight:600; }
+.qfm-root .qfm-metric-value { font-size:22px; line-height:30px; font-weight:650; letter-spacing:-.02em; overflow-wrap:anywhere; }
+.qfm-root .qfm-metric-value.qfm-mono { font-size:14px; line-height:30px; letter-spacing:-.01em; }
+.qfm-root .qfm-metric-sub { font-size:12px; line-height:18px; color:var(--muted); margin-top:4px; }
+.qfm-root .qfm-mono { font-family:"Geist Mono","SFMono-Regular",monospace; font-size:12px; }
+.qfm-root .qfm-muted { color:var(--muted); }
+.qfm-root .qfm-workspace { flex:1; min-height:260px; display:flex; flex-direction:column; background:var(--surface); border:1px solid var(--border); border-radius:10px; overflow:hidden; }
+.qfm-root .qfm-workspace-head { height:48px; flex-shrink:0; border-bottom:1px solid var(--border); display:flex; align-items:center; gap:14px; padding:0 16px; }
+.qfm-root .qfm-workspace-head h2 { font-size:16px; line-height:24px; font-weight:650; }
+.qfm-root .qfm-workspace-meta { margin-left:auto; color:var(--muted); font-size:12px; }
+.qfm-root .qfm-workspace-meta strong { color:var(--text); }
+.qfm-root .qfm-toolbar { min-height:60px; flex-shrink:0; display:flex; align-items:center; flex-wrap:wrap; gap:8px; padding:12px; border-bottom:1px solid var(--border); background:var(--surface-2); }
+.qfm-root .qfm-search { width:280px; max-width:100%; height:36px; display:flex; align-items:center; gap:8px; padding:0 10px; border:1px solid var(--border); border-radius:8px; background:var(--surface); color:var(--muted); }
+.qfm-root .qfm-search:focus-within { border-color:var(--orange); outline:2px solid var(--orange-100); outline-offset:1px; }
+.qfm-root .qfm-search svg { width:15px; height:15px; flex-shrink:0; }
+.qfm-root .qfm-search input { width:100%; min-width:0; padding:0; border:0; outline:0; box-shadow:none; border-radius:0; background:transparent; color:var(--text); font-size:14px; }
+.qfm-root .qfm-search input::placeholder { color:var(--muted); }
+.qfm-root .qfm-filter { position:relative; }
+.qfm-root .qfm-filter-trigger { height:36px; min-width:148px; border:1px solid var(--border); border-radius:8px; background:var(--surface); display:flex; align-items:center; gap:8px; padding:0 10px; cursor:pointer; font-size:13px; }
+.qfm-root .qfm-filter-trigger:hover,.qfm-root .qfm-filter-trigger[aria-expanded=true] { border-color:var(--border-strong); background:#fff; }
+.qfm-root .qfm-filter-prefix { color:var(--muted); }
+.qfm-root .qfm-filter-trigger svg { margin-left:auto; width:14px; height:14px; color:var(--muted); transition:transform .12s ease-out; }
+.qfm-root .qfm-filter-trigger[aria-expanded=true] svg { transform:rotate(180deg); }
+.qfm-root .qfm-filter-menu { position:absolute; top:42px; left:0; min-width:180px; padding:5px; border:1px solid var(--border); border-radius:9px; background:var(--surface); box-shadow:0 12px 34px #20262B1F; z-index:20; }
+.qfm-root .qfm-filter-option { width:100%; height:36px; padding:0 9px; border:0; border-radius:6px; background:transparent; display:flex; align-items:center; gap:8px; cursor:pointer; text-align:left; font-size:14px; }
+.qfm-root .qfm-filter-option:hover { background:var(--surface-2); }
+.qfm-root .qfm-filter-option[aria-selected=true] { background:var(--orange-50); font-weight:650; }
+.qfm-root .qfm-filter-option svg { width:15px; height:15px; color:transparent; }
+.qfm-root .qfm-filter-option[aria-selected=true] svg { color:var(--orange); }
+.qfm-root .qfm-chips { display:flex; gap:4px; }
+.qfm-root .qfm-chip { height:36px; padding:0 10px; border:1px solid transparent; border-radius:7px; background:transparent; color:var(--muted); font-size:13px; cursor:pointer; }
+.qfm-root .qfm-chip:hover { background:var(--surface); }
+.qfm-root .qfm-chip[aria-pressed=true] { background:var(--orange-50); color:var(--orange-600); border-color:var(--orange-100); }
+.qfm-root .qfm-toolbar-count { margin-left:auto; color:var(--muted); font-size:12px; }
+.qfm-root .qfm-table-wrap { flex:1; min-height:0; overflow:auto; scrollbar-gutter:stable; scrollbar-width:thin; scrollbar-color:#D6D0C8 transparent; }
+.qfm-root .qfm-table { width:100%; min-width:1040px; border-collapse:separate; border-spacing:0; table-layout:fixed; font-size:14px; }
+.qfm-root .qfm-table th { position:sticky; top:0; z-index:1; height:36px; padding:0 12px; background:var(--surface-2); text-align:left; font-size:12px; font-weight:600; color:var(--muted); border-bottom:1px solid var(--border); }
+.qfm-root .qfm-table td { height:64px; padding:8px 12px; border-bottom:1px solid #ECE8E1; color:var(--text-2); vertical-align:middle; overflow:hidden; }
+.qfm-root .qfm-table th:last-child,.qfm-root .qfm-table td:last-child { text-align:right; }
+.qfm-root .qfm-table tbody tr[data-code] { cursor:pointer; transition:background .1s ease-out; }
+.qfm-root .qfm-table tbody tr[data-code]:hover,.qfm-root .qfm-table tr:focus-within { background:var(--orange-50); }
+.qfm-root .qfm-code { font:600 12px/18px "Geist Mono","SFMono-Regular",monospace; white-space:nowrap; }
+.qfm-root .qfm-name { display:block; font-size:14px; line-height:22px; font-weight:500; white-space:nowrap; overflow:hidden; text-overflow:ellipsis; color:var(--text); }
+.qfm-root a.qfm-name:hover,.qfm-root .qfm-code:hover { text-decoration:underline; }
+.qfm-root .qfm-name-sub { font-size:13px; line-height:20px; margin-top:2px; color:var(--muted); }
+.qfm-root .qfm-state { display:inline-flex; align-items:center; gap:6px; font-size:13px; font-weight:500; white-space:nowrap; color:var(--muted); }
+.qfm-root .qfm-state-L { color:#326543; }
+.qfm-root .qfm-state-P { color:#80601E; }
+.qfm-root .qfm-state i,.qfm-root .qfm-aside-state i,.qfm-root .qfm-day-state i { width:6px; height:6px; border-radius:50%; background:currentColor; flex-shrink:0; }
+.qfm-root .qfm-pagination { flex-shrink:0; display:flex; align-items:center; justify-content:space-between; gap:12px; flex-wrap:wrap; padding:10px 12px; border-top:1px solid var(--border); font-size:12px; }
+.qfm-root .qfm-pagination-controls { display:flex; align-items:center; gap:8px; }
+.qfm-root .qfm-pagination select { height:36px; padding:0 8px; border:1px solid var(--border); border-radius:8px; color:var(--text); background:var(--surface); font:inherit; }
+.qfm-root .qfm-error { flex-shrink:0; padding:12px 16px; background:var(--red-bg); color:#A2463F; border-bottom:1px solid #E0BFB8; font-size:13px; line-height:20px; }
+.qfm-root .qfm-error span { display:block; }
+.qfm-root .qfm-text-button { padding:0; margin-left:8px; border:0; background:transparent; color:inherit; text-decoration:underline; cursor:pointer; font:inherit; }
+.qfm-root .qfm-table td.qfm-empty { height:160px; text-align:center; color:var(--muted); cursor:default; white-space:normal; }
+.qfm-root .qfm-empty a { text-decoration:underline; }
+.qfm-root .qfm-skeleton { display:block; width:85%; height:14px; border-radius:4px; background:var(--surface-3); }
+.qfm-root .qfm-toast { left:50%; right:auto; transform:translateX(-50%); bottom:22px; text-align:center; }
+.qfm-root .qfm-spin { animation:qfm-spin 1s linear infinite; }
+@keyframes qfm-spin { to { transform:rotate(360deg); } }
+.qfm-root button:focus-visible,.qfm-root a:focus-visible,.qfm-root select:focus-visible,.qfm-root [tabindex]:focus-visible { outline:2px solid var(--orange); outline-offset:2px; }
+.qfm-root .qfm-table-wrap:focus-visible { outline-offset:-2px; }
+/* Native dialog provides focus containment without changing the approved
+   centered month grid and date inspector composition. */
+.qfm-root .qfm-calendar-dialog { width:min(1040px,calc(100vw - 32px)); height:min(740px,calc(100dvh - 32px)); max-width:none; max-height:none; margin:auto; padding:0; background:var(--surface); color:var(--text); border:1px solid var(--border); border-radius:12px; box-shadow:0 20px 60px #20262B26; overflow:hidden; }
+.qfm-root .qfm-calendar-dialog[open] { display:grid; grid-template-rows:64px auto minmax(0,1fr); }
+.qfm-root .qfm-calendar-dialog::backdrop { background:#20262B38; }
+.qfm-root .qfm-calendar-head { display:flex; align-items:center; justify-content:space-between; padding:0 20px; border-bottom:1px solid var(--border); }
+.qfm-root .qfm-dialog-kicker { color:var(--orange); font:650 11px/16px "Geist Mono",monospace; letter-spacing:.13em; }
+.qfm-root .qfm-calendar-head h2 { font-size:22px; line-height:30px; font-weight:650; }
+.qfm-root .qfm-calendar-toolbar { display:flex; flex-wrap:wrap; align-items:center; min-height:60px; gap:8px; padding:12px 16px; background:var(--surface-2); border-bottom:1px solid var(--border); }
+.qfm-root .qfm-month-nav { display:flex; align-items:center; margin-left:4px; border:1px solid var(--border); border-radius:8px; background:var(--surface); overflow:hidden; }
+.qfm-root .qfm-month-nav button { width:34px; height:34px; border:0; background:transparent; display:grid; place-items:center; cursor:pointer; }
+.qfm-root .qfm-month-nav button:hover { background:var(--surface-2); }
+.qfm-root .qfm-month-nav svg { width:14px; height:14px; }
+.qfm-root .qfm-month-label { min-width:104px; text-align:center; font:650 13px/18px "Geist Mono",monospace; border-left:1px solid var(--border); border-right:1px solid var(--border); }
+.qfm-root .qfm-legend { margin-left:auto; display:flex; align-items:center; gap:12px; color:var(--muted); font-size:12px; }
+.qfm-root .qfm-legend span { display:flex; align-items:center; gap:6px; }
+.qfm-root .qfm-legend i { width:8px; height:8px; border-radius:2px; border:1px solid #BFD5C5; background:var(--green-bg); }
+.qfm-root .qfm-legend i.qfm-closed { background:var(--surface-3); border-color:var(--border); }
+.qfm-root .qfm-legend i.qfm-today { background:var(--orange-50); border-color:#F0A387; }
+.qfm-root .qfm-calendar-body { min-height:0; display:grid; grid-template-columns:minmax(0,1fr) 264px; overflow:auto; }
+.qfm-root .qfm-calendar-main { display:flex; flex-direction:column; min-width:0; min-height:0; padding:12px; gap:8px; border-right:1px solid var(--border); }
+.qfm-root .qfm-calendar-main .qfm-error { padding:8px; }
+.qfm-root .qfm-weekdays { display:grid; grid-template-columns:repeat(7,minmax(0,1fr)); gap:6px; height:28px; flex-shrink:0; align-items:center; text-align:center; color:var(--muted); font-size:12px; }
+.qfm-root .qfm-calendar-grid { flex:1; display:grid; grid-template-columns:repeat(7,minmax(0,1fr)); grid-template-rows:repeat(6,minmax(56px,1fr)); gap:6px; }
+.qfm-root .qfm-day { min-width:0; min-height:56px; border:1px solid var(--border); border-radius:7px; background:var(--surface); padding:8px; display:flex; flex-direction:column; justify-content:space-between; cursor:pointer; transition:border .1s ease-out,background .1s ease-out; }
+.qfm-root .qfm-day:hover { border-color:var(--border-strong); background:#fff; }
+.qfm-root .qfm-day.qfm-out { opacity:.38; }
+.qfm-root .qfm-day.qfm-closed { background:var(--surface-2); }
+.qfm-root .qfm-day.qfm-unknown { border-style:dashed; }
+.qfm-root .qfm-day.qfm-today { background:var(--orange-50); border-color:#F0A387; }
+.qfm-root .qfm-day.qfm-selected { border-color:var(--orange); box-shadow:0 0 0 2px #E85F3226; }
+.qfm-root .qfm-day-num { font:650 13px/18px "Geist Mono",monospace; }
+.qfm-root .qfm-day-state { display:flex; align-items:center; gap:4px; font-size:12px; color:var(--muted); }
+.qfm-root .qfm-day.qfm-open .qfm-day-state { color:var(--green); }
+.qfm-root .qfm-calendar-aside { display:flex; flex-direction:column; min-height:0; padding:16px; background:var(--surface-2); }
+.qfm-root .qfm-aside-date { margin-top:7px; font-size:22px; line-height:30px; font-weight:650; }
+.qfm-root .qfm-aside-state { align-self:flex-start; display:flex; align-items:center; gap:6px; padding:5px 8px; margin-top:7px; border-radius:6px; font-size:13px; color:var(--green); background:var(--green-bg); }
+.qfm-root .qfm-aside-state.qfm-closed,.qfm-root .qfm-aside-state.qfm-unknown { background:var(--surface-3); color:var(--muted); }
+.qfm-root .qfm-detail-list { margin:16px 0 0; border-top:1px solid var(--border); }
+.qfm-root .qfm-detail-list div { display:flex; justify-content:space-between; align-items:center; min-height:52px; gap:12px; padding:10px 0; border-bottom:1px solid var(--border); }
+.qfm-root .qfm-detail-list dt { color:var(--muted); font-size:13px; }
+.qfm-root .qfm-detail-list dd { margin:0; font-size:13px; text-align:right; font-weight:650; }
+.qfm-root .qfm-detail-list dd.qfm-mono { font-size:12px; }
+.qfm-root .qfm-aside-note { margin:16px 0 0; font-size:12px; line-height:18px; color:var(--muted); }
+@media(min-width:1880px) { .qfm-root .qfo-main { padding:24px 32px; } .qfm-root .qfm-content { width:min(100%,1640px); } }
+@media(max-width:1380px) { .qfm-root .qfo-main { padding:16px 18px; } .qfm-root .qfm-search { width:248px; } .qfm-root .qfm-market-band { grid-template-columns:1fr .65fr 1.4fr 1fr; } .qfm-root .qfm-metric { padding:12px; } .qfm-root .qfm-metric-value { font-size:20px; } }
+@media(max-height:820px) and (min-width:981px) { .qfm-root .qfo-main { padding-top:14px; padding-bottom:14px; } .qfm-root .qfm-content { gap:12px; } .qfm-root .qfm-page-head h1 { font-size:28px; line-height:36px; } .qfm-root .qfm-market-band { min-height:96px; } .qfm-root .qfm-metric-label { margin-bottom:4px; } .qfm-root .qfm-metric-value { font-size:20px; } .qfm-root .qfm-table td { height:60px; } .qfm-root .qfm-calendar-dialog { height:calc(100dvh - 24px); } .qfm-root .qfm-day { padding:6px; } }
+@media(max-width:980px) { .qfm-root .qfo-main { padding:16px 12px; } .qfm-root .qfm-content { height:auto; min-height:100%; } .qfm-root .qfm-page-head { grid-template-columns:1fr; gap:12px; } .qfm-root .qfm-market-band { grid-template-columns:repeat(2,minmax(0,1fr)); } .qfm-root .qfm-metric:nth-child(n+3) { border-top:1px solid var(--border); } .qfm-root .qfm-metric:nth-child(3) { border-left:0; } .qfm-root .qfm-workspace { min-height:420px; } .qfm-root .qfm-table-wrap { flex:auto; max-height:55vh; min-height:220px; } .qfm-root .qfm-toolbar-count { margin-left:0; } .qfm-root .qfm-calendar-body { display:block; } .qfm-root .qfm-calendar-main { border-right:0; min-height:440px; } .qfm-root .qfm-calendar-grid { min-height:380px; } .qfm-root .qfm-calendar-aside { border-top:1px solid var(--border); } .qfm-root .qfm-detail-list { display:grid; grid-template-columns:1fr 1fr; gap:0 20px; margin-top:12px; } .qfm-root .qfm-legend { flex-wrap:wrap; margin-left:0; } }
+@media(max-width:620px) { .qfm-root .qfm-content { gap:12px; } .qfm-root .qfm-market-band { grid-template-columns:1fr; } .qfm-root .qfm-metric+.qfm-metric { border-left:0; border-top:1px solid var(--border); } .qfm-root .qfm-page-head h1 { font-size:28px; line-height:36px; } .qfm-root .qfm-metric-value { font-size:22px; } .qfm-root .qfm-workspace-head { flex-wrap:wrap; height:auto; min-height:56px; padding:8px 12px; gap:4px; } .qfm-root .qfm-workspace-meta { margin-left:0; width:100%; } .qfm-root .qfm-toolbar { align-items:flex-start; } .qfm-root .qfm-search { width:100%; } .qfm-root .qfm-chips,.qfm-root .qfm-pagination-controls { flex-wrap:wrap; } .qfm-root .qfm-calendar-dialog { width:calc(100vw - 16px); height:calc(100dvh - 16px); } .qfm-root .qfm-calendar-head { padding:0 12px; } .qfm-root .qfm-calendar-toolbar { padding:8px; } .qfm-root .qfm-calendar-toolbar .qfm-filter-trigger { min-width:128px; } .qfm-root .qfm-month-nav { margin-left:0; } .qfm-root .qfm-month-label { min-width:86px; } .qfm-root .qfm-calendar-main { padding:8px; gap:4px; } .qfm-root .qfm-calendar-grid,.qfm-root .qfm-weekdays { gap:3px; } .qfm-root .qfm-day { padding:5px 2px; } .qfm-root .qfm-day-state { gap:0; justify-content:center; } .qfm-root .qfm-day-state i { display:none; } .qfm-root .qfm-day-num { font-size:12px; } .qfm-root .qfm-detail-list { grid-template-columns:1fr; } .qfm-root .qfm-calendar-aside { padding:12px; } .qfm-root .qfm-legend { gap:8px; } }
+@media(prefers-reduced-motion:reduce) { .qfm-root *,.qfm-root *::before,.qfm-root *::after { transition:none!important; animation:none!important; } }

--- a/frontend/src/pages/MarketPage.tsx
+++ b/frontend/src/pages/MarketPage.tsx
@@ -1,0 +1,151 @@
+import { CalendarDays, ChevronLeft, ChevronRight, RefreshCw, Search } from "lucide-react";
+import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
+import { useNavigate, useSearchParams } from "react-router-dom";
+import { DataCollectionApiError, getEtfOverview, listEtfs, type EtfOverview, type EtfPage } from "../api/dataCollections";
+import { useAuth } from "../auth/AuthContext";
+import { ExchangeFilter } from "./market/ExchangeFilter";
+import { MarketCalendar } from "./market/MarketCalendar";
+import { MarketTable } from "./market/MarketTable";
+import { exchangeName, filterDescription, LIST_STATES, MARKET_PATH, marketDate, marketFilters, marketQuery, syncPresentation, type MarketFilters } from "./market/marketPresentation";
+import "./Market.css";
+
+interface Snapshot { overview: EtfOverview; result: EtfPage; filters: MarketFilters; key: string }
+interface Position { key: string; top: number; left: number; mainTop: number; code: string }
+const POSITION_KEY = "quant-foundry.market-position";
+
+function readPosition(): Position | null {
+  try {
+    const value = JSON.parse(sessionStorage.getItem(POSITION_KEY) || "null");
+    return value && typeof value.key === "string" && typeof value.code === "string" && [value.top, value.left, value.mainTop].every((number: unknown) => typeof number === "number" && Number.isFinite(number) && number >= 0) ? value : null;
+  } catch { return null; }
+}
+
+/** This page only queries collected facts. It never starts ingestion as a
+ * side effect of refreshing, changing a filter, or opening the calendar. */
+export function MarketPage() {
+  const { logout } = useAuth();
+  const navigate = useNavigate();
+  const [params, setParams] = useSearchParams();
+  const serialized = params.toString();
+  const filters = useMemo(() => marketFilters(new URLSearchParams(serialized)), [serialized]);
+  const key = marketQuery(filters);
+  const [query, setQuery] = useState(filters.keyword);
+  const [snapshot, setSnapshot] = useState<Snapshot | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(false);
+  const [revision, setRevision] = useState(0);
+  const [toast, setToast] = useState("");
+  const [calendar, setCalendar] = useState(params.get("calendar") === "open");
+  const table = useRef<HTMLDivElement>(null);
+  const root = useRef<HTMLElement>(null);
+  const restore = useRef(readPosition());
+  const restored = useRef(false);
+  const previousKey = useRef(key);
+  const refreshRequested = useRef(false);
+  const overviewCache = useRef<EtfOverview | null>(null);
+  const onUnauthorized = useCallback(() => { logout(); navigate("/login", { replace: true }); }, [logout, navigate]);
+  const pendingQuery = query.trim() !== filters.keyword.trim();
+  const busy = loading || pendingQuery;
+  const refreshing = loading && refreshRequested.current;
+  // Pagination changes the visible slice, not the matching record count.
+  // Keep that count while paging; a new search or filter must wait for its own total.
+  const sameSelection = snapshot && filters.keyword.trim() === snapshot.filters.keyword.trim()
+    && filters.exchange === snapshot.filters.exchange && filters.listStatus === snapshot.filters.listStatus;
+  const countPending = busy && (pendingQuery || !sameSelection);
+  const overview = snapshot?.overview ?? null;
+  const result = snapshot?.result ?? null;
+  const sync = syncPresentation(overview);
+  const returnTo = MARKET_PATH + (key ? `?${key}` : "");
+
+  useEffect(() => { setQuery(filters.keyword); }, [filters.keyword]);
+  useEffect(() => { if (new URLSearchParams(serialized).get("calendar") === "open") setCalendar(true); }, [serialized]);
+  useEffect(() => {
+    if (!pendingQuery) return;
+    // Cancel the old query before debouncing the next one, so an older response
+    // cannot become a fresh-looking result while the user is still typing.
+    const timer = window.setTimeout(() => {
+      const next = marketQuery({ ...filters, keyword: query.trim(), offset: 0 });
+      setParams(next, { replace: true });
+    }, 250);
+    return () => window.clearTimeout(timer);
+  }, [pendingQuery, query, filters, setParams]);
+  useEffect(() => {
+    if (pendingQuery) return;
+    const controller = new AbortController();
+    const requestedFilters = marketFilters(new URLSearchParams(key));
+    setLoading(true); setError(false); setToast("");
+    // The market overview is independent of list filters and pagination.
+    // Reload it only on entry or an explicit refresh, retaining an atomic snapshot.
+    const overviewRequest = overviewCache.current && !refreshRequested.current
+      ? Promise.resolve(overviewCache.current) : getEtfOverview(controller.signal);
+    void Promise.all([overviewRequest, listEtfs(requestedFilters, controller.signal)])
+      .then(([nextOverview, nextResult]) => {
+        if (controller.signal.aborted) return;
+        overviewCache.current = nextOverview;
+        // A collection may shrink since the bookmarked page was visited.
+        // Correct that position before presenting a misleading empty result.
+        if (requestedFilters.offset > 0 && requestedFilters.offset >= nextResult.total) {
+          setParams(marketQuery({ ...requestedFilters, offset: Math.max(0, Math.floor((nextResult.total - 1) / requestedFilters.limit)) * requestedFilters.limit }), { replace: true });
+          return;
+        }
+        setSnapshot({ overview: nextOverview, result: nextResult, filters: requestedFilters, key });
+        if (refreshRequested.current) { setToast("数据已刷新"); refreshRequested.current = false; }
+      }).catch(caught => {
+        if (controller.signal.aborted) return;
+        if (caught instanceof DataCollectionApiError && caught.status === 401) onUnauthorized();
+        else { setError(true); refreshRequested.current = false; }
+      }).finally(() => { if (!controller.signal.aborted) setLoading(false); });
+    return () => controller.abort();
+  }, [key, revision, pendingQuery, setParams, onUnauthorized]);
+  useEffect(() => {
+    if (!toast) return;
+    const timer = window.setTimeout(() => setToast(""), 2200);
+    return () => window.clearTimeout(timer);
+  }, [toast]);
+
+  useLayoutEffect(() => {
+    if (!snapshot || snapshot.key !== key) return;
+    const saved = restore.current;
+    const main = root.current?.closest<HTMLElement>(".qfo-main");
+    if (!restored.current && saved?.key === key) {
+      table.current?.scrollTo(saved.left, saved.top); main?.scrollTo(0, saved.mainTop);
+      const row = [...(table.current?.querySelectorAll<HTMLTableRowElement>("tr[data-code]") ?? [])].find(item => item.dataset.code === saved.code);
+      row?.querySelector<HTMLAnchorElement>("a")?.focus({ preventScroll: true });
+    } else if (previousKey.current !== key) table.current?.scrollTo(0, 0);
+    restored.current = true; previousKey.current = key;
+  }, [snapshot, key]);
+
+  function change(patch: Partial<MarketFilters>) {
+    refreshRequested.current = false;
+    setParams(marketQuery({ ...filters, keyword: query.trim(), offset: 0, ...patch }), { replace: true });
+  }
+  function remember(code: string) {
+    if (!table.current) return;
+    const value: Position = { key: snapshot?.key ?? key, top: table.current.scrollTop, left: table.current.scrollLeft, mainTop: root.current?.closest<HTMLElement>(".qfo-main")?.scrollTop ?? 0, code };
+    try { sessionStorage.setItem(POSITION_KEY, JSON.stringify(value)); } catch { /* URL filters still work when optional position storage is unavailable. */ }
+  }
+  function refresh() { if (!busy) { refreshRequested.current = true; setRevision(value => value + 1); } }
+  const shownPage = result ? Math.floor(result.offset / result.limit) + 1 : 1;
+  const pageCount = result ? Math.max(1, Math.ceil(result.total / result.limit)) : 1;
+  const loadedReturnTo = MARKET_PATH + (snapshot?.key ? `?${snapshot.key}` : "");
+  // aria-disabled announces pending actions without dimming controls on every
+  // page change. The handlers block duplicate mouse and keyboard activation.
+
+  return <section ref={root} className="qfm-content" aria-labelledby="qfm-title">
+    <header className="qfo-page-head qfm-page-head"><div><div className="qfo-eyebrow">CHINA A-SHARE MARKET</div><h1 id="qfm-title">A 股市场</h1><p className="qfo-page-desc">查看 A 股市场基础资料与 ETF 数据。</p></div><div className="qfo-page-actions"><button className="qfo-secondary-btn" type="button" aria-haspopup="dialog" onClick={() => setCalendar(true)}><CalendarDays aria-hidden="true" />交易日历</button><button className="qfo-secondary-btn" type="button" disabled={(!snapshot && busy) || refreshing} aria-disabled={busy} aria-busy={refreshing} onClick={refresh}><RefreshCw className={refreshing ? "qfm-spin" : ""} aria-hidden="true" />刷新数据</button></div></header>
+    <section className="qfm-market-band" aria-label="市场数据概览">
+      <div className="qfm-metric"><div className="qfm-metric-label">交易所</div><div className="qfm-metric-value">{overview ? overview.exchanges.map(exchangeName).join(" · ") || "—" : "—"}</div><div className="qfm-metric-sub">{overview ? overview.exchanges.join(" / ") || "尚无交易所记录" : "等待加载"}</div></div>
+      <div className="qfm-metric"><div className="qfm-metric-label">上市 ETF</div><div className="qfm-metric-value">{overview?.listed_count.toLocaleString("zh-CN") ?? "—"}</div><div className="qfm-metric-sub">当前上市状态</div></div>
+      <div className="qfm-metric"><div className="qfm-metric-label">ETF 数据覆盖</div><div className="qfm-metric-value qfm-mono">{overview?.first_list_date ? `${marketDate(overview.first_list_date)} → ${marketDate(overview.latest_list_date)}` : "—"}</div><div className="qfm-metric-sub">上市日期范围</div></div>
+      <div className="qfm-metric"><div className="qfm-metric-label">{sync.label}</div><div className="qfm-metric-value qfm-mono">{sync.value}</div><div className="qfm-metric-sub">{sync.note}</div></div>
+    </section>
+    <section className="qfm-workspace" aria-labelledby="qfm-list-title"><header className="qfm-workspace-head"><h2 id="qfm-list-title">ETF 基础资料</h2><div className="qfm-workspace-meta">ETF 记录 <strong>{overview?.total_records.toLocaleString("zh-CN") ?? "—"}</strong> 条</div></header>
+      {error && <div className="qfm-error" role="alert">{snapshot ? "刷新失败，当前保留上次成功加载的数据。" : "ETF 数据加载失败，请检查连接后重试。"}{snapshot && snapshot.key !== key && <span>上次筛选：{filterDescription(snapshot.filters)}。</span>}<button className="qfm-text-button" type="button" disabled={busy} onClick={refresh}>重新加载</button></div>}
+      <div className="qfm-toolbar"><label className="qfm-search"><Search aria-hidden="true" /><input type="search" aria-label="搜索 ETF" placeholder="搜索基金代码、名称或跟踪指数" maxLength={200} value={query} onChange={event => setQuery(event.target.value)} /></label><ExchangeFilter value={filters.exchange} onChange={exchange => change({ exchange })} allowAll /><div className="qfm-chips" role="group" aria-label="上市状态筛选">{LIST_STATES.map(([value, label]) => <button key={value} className="qfm-chip" type="button" aria-pressed={filters.listStatus === value} onClick={() => change({ listStatus: value })}>{label}</button>)}</div><span className="qfm-toolbar-count" role="status">{countPending ? "正在加载…" : result ? `显示 ${result.total.toLocaleString("zh-CN")} 条` : "尚未加载"}</span></div>
+      <div ref={table} className="qfm-table-wrap" tabIndex={0} role="region" aria-label="ETF 表格，可横向滚动"><MarketTable result={result} loading={busy} error={error} empty={overview?.total_records === 0} returnTo={snapshot ? loadedReturnTo : returnTo} onOpen={remember} /></div>
+      <footer className="qfm-pagination"><span>{result ? `显示 ${result.total ? result.offset + 1 : 0}–${Math.min(result.offset + result.items.length, result.total)} 条，共 ${result.total.toLocaleString("zh-CN")} 条` : "等待加载 ETF 数据"}</span><div className="qfm-pagination-controls"><label>每页 <select aria-label="每页条数" value={filters.limit} onChange={event => change({ limit: Number(event.target.value) })}>{[20, 50, 100].map(size => <option key={size} value={size}>{size} 条</option>)}</select></label><button className="qfo-icon-btn" type="button" aria-label="上一页" title="上一页" disabled={error || !result || result.offset === 0} aria-disabled={busy || error || !result || result.offset === 0} onClick={() => { if (!busy) change({ offset: Math.max(0, filters.offset - filters.limit) }); }}><ChevronLeft aria-hidden="true" /></button><span>{shownPage} / {pageCount}</span><button className="qfo-icon-btn" type="button" aria-label="下一页" title="下一页" disabled={error || !result || result.offset + result.limit >= result.total} aria-disabled={busy || error || !result || result.offset + result.limit >= result.total} onClick={() => { if (!busy) change({ offset: filters.offset + filters.limit }); }}><ChevronRight aria-hidden="true" /></button></div></footer>
+    </section>
+    {toast && <div className="qfo-toast qfo-show qfm-toast" role="status">{toast}</div>}
+    {calendar && <MarketCalendar onClose={() => { setCalendar(false); if (params.has("calendar")) setParams(key, { replace: true }); }} onUnauthorized={onUnauthorized} />}
+  </section>;
+}

--- a/frontend/src/pages/market/ExchangeFilter.tsx
+++ b/frontend/src/pages/market/ExchangeFilter.tsx
@@ -1,0 +1,38 @@
+import { Check, ChevronDown } from "lucide-react";
+import { useEffect, useId, useRef, useState } from "react";
+import { EXCHANGES } from "./marketPresentation";
+
+/** Reuse the approved menu's keyboard model: exploring options does not
+ * commit a filter until Enter, Space, or a pointer click selects one. */
+export function ExchangeFilter({ value, onChange, allowAll = false }: { value: string; onChange: (value: string) => void; allowAll?: boolean }) {
+  const options = allowAll ? [{ key: "", name: "全部交易所" }, ...EXCHANGES] : EXCHANGES;
+  const selected = Math.max(0, options.findIndex(option => option.key === value));
+  const [open, setOpen] = useState(false);
+  const [focused, setFocused] = useState(selected);
+  const root = useRef<HTMLDivElement>(null);
+  const trigger = useRef<HTMLButtonElement>(null);
+  const items = useRef<(HTMLButtonElement | null)[]>([]);
+  const id = useId();
+  function close(restore = false) { setOpen(false); if (restore) trigger.current?.focus(); }
+  function show() { setFocused(selected); setOpen(true); }
+  useEffect(() => { if (open) items.current[focused]?.focus(); }, [open, focused]);
+  useEffect(() => {
+    if (!open) return;
+    const outside = (event: PointerEvent) => { if (!root.current?.contains(event.target as Node)) setOpen(false); };
+    document.addEventListener("pointerdown", outside);
+    return () => document.removeEventListener("pointerdown", outside);
+  }, [open]);
+  return <div className="qfm-filter" ref={root} onBlur={event => { if (!event.currentTarget.contains(event.relatedTarget as Node | null)) setOpen(false); }}>
+    <button ref={trigger} className="qfm-filter-trigger" type="button" aria-label={`筛选交易所：${options[selected].name}`} aria-haspopup="listbox" aria-expanded={open} aria-controls={open ? id : undefined}
+      onClick={() => open ? close() : show()} onKeyDown={event => {
+        if (["ArrowDown", "ArrowUp"].includes(event.key)) { event.preventDefault(); show(); }
+      }}><span><span className="qfm-filter-prefix">交易所</span> {value ? options[selected].name : "全部"}</span><ChevronDown aria-hidden="true" /></button>
+    {open && <div className="qfm-filter-menu" id={id} role="listbox" aria-label="交易所筛选" onKeyDown={event => {
+      if (["ArrowDown", "ArrowUp", "Home", "End"].includes(event.key)) {
+        event.preventDefault(); setFocused(current => event.key === "Home" ? 0 : event.key === "End" ? options.length - 1 : (current + (event.key === "ArrowDown" ? 1 : -1) + options.length) % options.length);
+      } else if (event.key === "Escape") { event.preventDefault(); event.stopPropagation(); close(true); }
+      else if (event.key === "Tab") close(true);
+    }}>{options.map((option, index) => <button key={option.key} ref={node => { items.current[index] = node; }} type="button" className="qfm-filter-option" role="option" aria-selected={value === option.key} tabIndex={focused === index ? 0 : -1}
+      onFocus={() => setFocused(index)} onClick={() => { onChange(option.key); close(true); }}><Check aria-hidden="true" /><span>{option.name}</span></button>)}</div>}
+  </div>;
+}

--- a/frontend/src/pages/market/MarketCalendar.tsx
+++ b/frontend/src/pages/market/MarketCalendar.tsx
@@ -1,0 +1,93 @@
+import { ChevronLeft, ChevronRight, X } from "lucide-react";
+import { useEffect, useMemo, useRef, useState } from "react";
+import { DataCollectionApiError, getTradingCalendarDay, listTradingCalendarDays, type TradingCalendarPage } from "../../api/dataCollections";
+import { ExchangeFilter } from "./ExchangeFilter";
+import { MarketCalendarDetail, type CalendarDetailSnapshot } from "./MarketCalendarDetail";
+import { CALENDAR_LABELS, calendarDates, calendarState, exchangeName, marketDate, shanghaiToday, shiftMonth } from "./marketPresentation";
+
+export function MarketCalendar({ onClose, onUnauthorized }: { onClose: () => void; onUnauthorized: () => void }) {
+  const today = shanghaiToday();
+  const [month, setMonth] = useState(today.slice(0, 7));
+  const [selected, setSelected] = useState(today);
+  const [exchange, setExchange] = useState("SSE");
+  const [revision, setRevision] = useState(0);
+  const [days, setDays] = useState<{ key: string; value: TradingCalendarPage } | null>(null);
+  const [detail, setDetail] = useState<CalendarDetailSnapshot | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [detailLoading, setDetailLoading] = useState(true);
+  const [error, setError] = useState("");
+  const [detailError, setDetailError] = useState("");
+  const dialog = useRef<HTMLDialogElement>(null);
+  const dates = useMemo(() => calendarDates(month), [month]);
+  const gridKey = `${exchange}:${month}`;
+  const detailKey = `${exchange}:${selected}`;
+  const visibleDays = days?.key === gridKey ? days.value : null;
+  const dayMap = new Map(visibleDays?.items.map(day => [day.calendar_date, day]));
+  const detailPending = detailLoading || (!detailError && detail?.key !== detailKey);
+
+  useEffect(() => {
+    const node = dialog.current;
+    const previous = document.activeElement as HTMLElement | null;
+    // A native modal makes the entire shell inert and contains focus, including
+    // when an exchange menu is open. The approved calendar is a browsing exception.
+    node?.showModal();
+    return () => { node?.close(); requestAnimationFrame(() => { if (previous?.isConnected) previous.focus({ preventScroll: true }); }); };
+  }, []);
+  useEffect(() => {
+    const controller = new AbortController();
+    setLoading(true); setError("");
+    void listTradingCalendarDays({ exchange, startDate: dates[0], endDate: dates[41], limit: 42 }, controller.signal)
+      .then(value => { if (!controller.signal.aborted) setDays({ key: gridKey, value }); })
+      .catch(caught => {
+        if (controller.signal.aborted) return;
+        if (caught instanceof DataCollectionApiError && caught.status === 401) onUnauthorized();
+        else setError("交易日历加载失败，请重试。");
+      }).finally(() => { if (!controller.signal.aborted) setLoading(false); });
+    return () => controller.abort();
+  }, [exchange, dates, gridKey, revision, onUnauthorized]);
+  useEffect(() => {
+    const controller = new AbortController();
+    setDetailLoading(true); setDetailError("");
+    void getTradingCalendarDay(exchange, selected, controller.signal)
+      .then(value => { if (!controller.signal.aborted) setDetail({ key: detailKey, date: selected, exchange, value }); })
+      .catch(caught => {
+        if (controller.signal.aborted) return;
+        if (caught instanceof DataCollectionApiError && caught.status === 401) onUnauthorized();
+        else if (caught instanceof DataCollectionApiError && caught.status === 404) setDetail({ key: detailKey, date: selected, exchange, value: null });
+        else setDetailError(`${exchangeName(exchange)} ${marketDate(selected)} 的日期详情加载失败，请重试。`);
+      }).finally(() => { if (!controller.signal.aborted) setDetailLoading(false); });
+    return () => controller.abort();
+  }, [exchange, selected, detailKey, revision, onUnauthorized]);
+
+  return <dialog ref={dialog} className="qfm-calendar-dialog" aria-labelledby="qfm-calendar-title" onCancel={event => { event.preventDefault(); onClose(); }} onKeyDown={event => {
+    if (event.key !== "Tab") return;
+    // Native modal inertness blocks background controls, but browsers can
+    // still move to their chrome at the boundary. Match the approved loop.
+    const controls = [...event.currentTarget.querySelectorAll<HTMLElement>("button:not(:disabled),a[href],input,select,[tabindex]")]
+      .filter(element => element.tabIndex >= 0 && element.getClientRects().length > 0);
+    const next = controls.indexOf(document.activeElement as HTMLElement) + (event.shiftKey ? -1 : 1);
+    if (next < 0 || next >= controls.length) {
+      event.preventDefault(); controls[(next + controls.length) % controls.length]?.focus();
+    }
+  }} onClick={event => {
+    // Ignore inside padding and only dismiss real backdrop clicks.
+    if (event.target !== event.currentTarget) return;
+    const rect = event.currentTarget.getBoundingClientRect();
+    if (event.clientX < rect.left || event.clientX > rect.right || event.clientY < rect.top || event.clientY > rect.bottom) onClose();
+  }}>
+    <header className="qfm-calendar-head"><div><div className="qfm-dialog-kicker">MARKET CALENDAR</div><h2 id="qfm-calendar-title">交易日历</h2></div><button className="qfo-icon-btn" type="button" aria-label="关闭交易日历" title="关闭交易日历" autoFocus onClick={onClose}><X aria-hidden="true" /></button></header>
+    <div className="qfm-calendar-toolbar"><ExchangeFilter value={exchange} onChange={setExchange} /><div className="qfm-month-nav" aria-label="月份切换"><button type="button" aria-label="上个月" title="上个月" disabled={month <= "1900-01"} onClick={() => setMonth(value => shiftMonth(value, -1))}><ChevronLeft aria-hidden="true" /></button><span className="qfm-month-label" aria-live="polite">{month.replace("-", " / ")}</span><button type="button" aria-label="下个月" title="下个月" disabled={month >= "2199-12"} onClick={() => setMonth(value => shiftMonth(value, 1))}><ChevronRight aria-hidden="true" /></button></div><div className="qfm-legend"><span><i />交易日</span><span><i className="qfm-closed" />休市</span><span><i className="qfm-today" />当前日期</span></div></div>
+    <div className="qfm-calendar-body">
+      <section className="qfm-calendar-main" aria-label={`${exchangeName(exchange)} ${month} 月历`} aria-busy={loading}>
+        {error && <div className="qfm-error" role="alert">{error}{visibleDays && " 保留本月上次数据。"}<button type="button" className="qfm-text-button" onClick={() => setRevision(value => value + 1)}>重试</button></div>}
+        <div className="qfm-weekdays">{["周一", "周二", "周三", "周四", "周五", "周六", "周日"].map(day => <span key={day}>{day}</span>)}</div>
+        <div className="qfm-calendar-grid">{dates.map(date => {
+          const dayState = calendarState(dayMap.get(date));
+          const label = !visibleDays ? loading ? "加载中" : error ? "不可用" : "未采集" : CALENDAR_LABELS[dayState];
+          return <button type="button" key={date} className={`qfm-day qfm-${dayState}${date.slice(0, 7) !== month ? " qfm-out" : ""}${date === today ? " qfm-today" : ""}${date === selected ? " qfm-selected" : ""}`} aria-label={`${marketDate(date)} ${label}`} aria-pressed={selected === date} aria-current={date === today ? "date" : undefined} onClick={() => setSelected(date)}><span className="qfm-day-num">{date.slice(8)}</span><span className="qfm-day-state"><i />{label}</span></button>;
+        })}</div>
+      </section>
+      <MarketCalendarDetail detail={detail} date={selected} exchange={exchange} loading={detailPending} error={detailError} onRetry={() => setRevision(value => value + 1)} />
+    </div>
+  </dialog>;
+}

--- a/frontend/src/pages/market/MarketCalendarDetail.tsx
+++ b/frontend/src/pages/market/MarketCalendarDetail.tsx
@@ -1,0 +1,46 @@
+import { useEffect, useState } from "react";
+import type { TradingCalendarDetail } from "../../api/dataCollections";
+import { CALENDAR_LABELS, calendarState, exchangeName, marketDate, marketTime } from "./marketPresentation";
+
+export interface CalendarDetailSnapshot {
+  key: string;
+  date: string;
+  exchange: string;
+  value: TradingCalendarDetail | null;
+}
+
+/** Keep the date, exchange, and facts in one snapshot while another date loads.
+ * Mixing a newly selected heading with the previous date's facts would be misleading. */
+export function MarketCalendarDetail({ detail, date, exchange, loading, error, onRetry }: {
+  detail: CalendarDetailSnapshot | null;
+  date: string;
+  exchange: string;
+  loading: boolean;
+  error: string;
+  onRetry: () => void;
+}) {
+  const pendingKey = loading ? `${exchange}:${date}` : null;
+  const [delayedKey, setDelayedKey] = useState<string | null>(null);
+  useEffect(() => {
+    setDelayedKey(null);
+    if (!pendingKey) return;
+    // Fast responses replace the facts directly. A slow request gets a separate
+    // scoped message without clearing or recoloring the last successful detail.
+    const timer = window.setTimeout(() => setDelayedKey(pendingKey), 350);
+    return () => window.clearTimeout(timer);
+  }, [pendingKey]);
+  const shownDate = detail?.date ?? date;
+  const shownExchange = detail?.exchange ?? exchange;
+  const state = calendarState(detail?.value);
+  const targetLabel = `${exchangeName(exchange)} ${marketDate(date)}`;
+  const retainedLabel = detail ? `当前显示 ${exchangeName(shownExchange)} ${marketDate(shownDate)} 的详情。` : "";
+
+  return <aside className="qfm-calendar-aside" aria-label="日期详情" aria-busy={loading}>
+    <div className="qfm-dialog-kicker">TRADING DAY</div><div className="qfm-aside-date">{marketDate(shownDate)}</div>
+    <div className={`qfm-aside-state qfm-${state}`} role="status"><i />{detail ? CALENDAR_LABELS[state] : loading ? "加载中" : error ? "暂不可用" : "未采集"}</div>
+    {error && <div className="qfm-error" role="alert">{error}{retainedLabel}<button type="button" className="qfm-text-button" onClick={onRetry}>重试</button></div>}
+    <dl className="qfm-detail-list"><div><dt>交易所</dt><dd>{exchangeName(shownExchange)}</dd></div><div><dt>前一交易日</dt><dd className="qfm-mono">{marketDate(detail?.value?.previous_trading_date)}</dd></div><div><dt>下一交易日</dt><dd className="qfm-mono">{marketDate(detail?.value?.next_trading_date)}</dd></div><div><dt>更新时间</dt><dd className="qfm-mono" title={detail?.value?.updated_at}>{marketTime(detail?.value?.updated_at)}</dd></div></dl>
+    {detail && (!detail.value || !detail.value.next_trading_date) && <p className="qfm-aside-note">{detail.value ? "后续日期覆盖不足，下一交易日暂未知。" : "此日期尚未采集，交易状态和前后交易日暂未知。"}</p>}
+    {pendingKey && delayedKey === pendingKey && <p className="qfm-aside-note" role="status">正在加载 {targetLabel} 的日期详情…{retainedLabel}</p>}
+  </aside>;
+}

--- a/frontend/src/pages/market/MarketTable.tsx
+++ b/frontend/src/pages/market/MarketTable.tsx
@@ -1,0 +1,23 @@
+import { Link } from "react-router-dom";
+import type { EtfPage } from "../../api/dataCollections";
+import { exchangeName, managementFee, MARKET_PATH, marketDate, statusName } from "./marketPresentation";
+
+export function MarketTable({ result, loading, error, empty, returnTo, onOpen }: {
+  result: EtfPage | null; loading: boolean; error: boolean; empty: boolean; returnTo: string; onOpen: (code: string) => void;
+}) {
+  return <table className="qfm-table" aria-label="ETF 基础资料" aria-busy={loading}>
+    <colgroup>{[12, 23, 8, 9, 11, 17, 12, 8].map((width, index) => <col key={index} style={{ width: `${width}%` }} />)}</colgroup>
+    <thead><tr>{["基金代码", "名称", "交易所", "上市状态", "上市日期", "跟踪指数", "管理人", "管理费率"].map(label => <th scope="col" key={label}>{label}</th>)}</tr></thead>
+    <tbody>{result?.items.map(etf => {
+      const name = etf.csname || etf.extname || etf.cname || "未提供名称";
+      const target = `${MARKET_PATH}/${encodeURIComponent(etf.ts_code)}`;
+      return <tr key={etf.ts_code} data-code={etf.ts_code} onClick={event => {
+        // Native links preserve open-in-new-tab and browser context menus.
+        if (!(event.target as HTMLElement).closest("a") && !window.getSelection()?.toString()) event.currentTarget.querySelector<HTMLAnchorElement>("a")?.click();
+      }}><td><Link className="qfm-code" to={target} state={{ marketReturnTo: returnTo }} onClick={() => onOpen(etf.ts_code)} aria-label={`查看 ${etf.ts_code} ${name} 详情`}>{etf.ts_code}</Link></td><td><Link className="qfm-name" to={target} state={{ marketReturnTo: returnTo }} onClick={() => onOpen(etf.ts_code)} title={etf.cname || name}>{name}</Link><div className="qfm-name-sub">{etf.etf_type || "—"}</div></td><td>{exchangeName(etf.exchange)}</td><td><span className={`qfm-state qfm-state-${etf.list_status}`}><i />{statusName(etf.list_status)}</span></td><td className="qfm-mono qfm-muted">{marketDate(etf.list_date)}</td><td><span className="qfm-name" title={[etf.index_name, etf.index_code].filter(Boolean).join(" · ")}>{etf.index_name || etf.index_code || "—"}</span></td><td title={etf.mgr_name || undefined}>{etf.mgr_name || "—"}</td><td className="qfm-mono">{managementFee(etf.mgt_fee)}</td></tr>;
+    })}
+    {!result && loading && Array.from({ length: 6 }, (_, index) => <tr key={index} aria-hidden="true" className="qfm-skeleton-row">{Array.from({ length: 8 }, (_, cell) => <td key={cell}><span className="qfm-skeleton" /></td>)}</tr>)}
+    {(!loading || result) && !result?.items.length && <tr><td className="qfm-empty" colSpan={8}>{error ? "ETF 数据暂不可用，请重新加载。" : empty ? <>尚未采集 ETF 基础资料，请先配置并运行<Link to="/admin/tasks">采集任务</Link>。</> : "没有符合当前筛选条件的 ETF，请调整搜索或筛选条件。"}</td></tr>}
+    </tbody>
+  </table>;
+}

--- a/frontend/src/pages/market/marketPresentation.ts
+++ b/frontend/src/pages/market/marketPresentation.ts
@@ -1,0 +1,93 @@
+import type { EtfOverview, TradingCalendarDay } from "../../api/dataCollections";
+
+export const MARKET_PATH = "/admin/data/etf-basics";
+export const EXCHANGES = [{ key: "SSE", name: "上交所" }, { key: "SZSE", name: "深交所" }];
+export const LIST_STATES = [["", "全部"], ["L", "上市"], ["D", "退市"], ["P", "待上市"]] as const;
+export interface MarketFilters { keyword: string; exchange: string; listStatus: string; limit: number; offset: number }
+
+/** Only accept supported filters and bounded integers from shareable URLs. */
+export function marketFilters(params: URLSearchParams): MarketFilters {
+  const limit = Number(params.get("limit") ?? 50);
+  const offset = Number(params.get("offset") ?? 0);
+  const pageSize = [20, 50, 100].includes(limit) ? limit : 50;
+  return {
+    keyword: (params.get("keyword") ?? "").slice(0, 200),
+    exchange: EXCHANGES.some(item => item.key === params.get("exchange")) ? params.get("exchange")! : "",
+    listStatus: ["L", "D", "P"].includes(params.get("status") ?? "") ? params.get("status")! : "",
+    limit: pageSize,
+    offset: Number.isSafeInteger(offset) && offset >= 0 && offset <= 10_000_000 ? Math.floor(offset / pageSize) * pageSize : 0
+  };
+}
+
+export function marketQuery(filters: MarketFilters): string {
+  const params = new URLSearchParams();
+  if (filters.keyword.trim()) params.set("keyword", filters.keyword.trim());
+  if (filters.exchange) params.set("exchange", filters.exchange);
+  if (filters.listStatus) params.set("status", filters.listStatus);
+  if (filters.limit !== 50) params.set("limit", String(filters.limit));
+  if (filters.offset) params.set("offset", String(filters.offset));
+  return params.toString();
+}
+
+/** A detail page may restore only the originating market route, never an
+ * arbitrary destination supplied by history state or an external URL. */
+export function marketReturnTo(value: unknown): string {
+  if (typeof value !== "string" || (value !== MARKET_PATH && !value.startsWith(`${MARKET_PATH}?`))) return MARKET_PATH;
+  const query = marketQuery(marketFilters(new URLSearchParams(value.split("?")[1])));
+  return MARKET_PATH + (query ? `?${query}` : "");
+}
+
+export function exchangeName(value: string): string {
+  return ({ SSE: "上交所", SH: "上交所", SZSE: "深交所", SZ: "深交所" } as Record<string, string>)[value] ?? value;
+}
+export function statusName(value: string): string {
+  return LIST_STATES.find(([key]) => key === value)?.[1] ?? "未知状态";
+}
+export function marketDate(value: string | null | undefined): string { return value ? value.replaceAll("-", "/") : "—"; }
+export function marketTime(value: string | null | undefined): string {
+  if (!value) return "—";
+  const date = new Date(value);
+  if (!Number.isFinite(date.getTime())) return "—";
+  return new Intl.DateTimeFormat("zh-CN", { timeZone: "Asia/Shanghai", month: "2-digit", day: "2-digit", hour: "2-digit", minute: "2-digit", hourCycle: "h23" }).format(date);
+}
+export function managementFee(value: string | null): string {
+  if (value === null || value.trim() === "") return "—";
+  const fee = Number(value);
+  return Number.isFinite(fee) ? `${fee.toLocaleString("zh-CN", { maximumFractionDigits: 4 })}%` : "—";
+}
+export function syncPresentation(overview: EtfOverview | null) {
+  if (!overview) return { label: "最近同步", value: "—", note: "等待加载" };
+  if (overview.refreshed_at) return { label: "最近同步", value: marketTime(overview.refreshed_at), note: "Tushare" };
+  // Record modification time is not evidence that an unchanged ingestion run
+  // succeeded. Keep the fallback explicitly labelled as a record update.
+  return overview.last_updated_at
+    ? { label: "记录更新", value: marketTime(overview.last_updated_at), note: "暂无成功同步时间" }
+    : { label: "最近同步", value: "—", note: "尚未完成同步" };
+}
+
+export function shanghaiToday(now = new Date()): string {
+  const parts = new Intl.DateTimeFormat("en-US", { timeZone: "Asia/Shanghai", year: "numeric", month: "2-digit", day: "2-digit" }).formatToParts(now);
+  const part = (type: string) => parts.find(item => item.type === type)!.value;
+  return `${part("year")}-${part("month")}-${part("day")}`;
+}
+
+/** UTC is used solely for date geometry; trading status always comes from
+ * persisted exchange records, including holidays and missing coverage. */
+export function calendarDates(month: string): string[] {
+  const first = new Date(`${month}-01T00:00:00Z`);
+  first.setUTCDate(1 - (first.getUTCDay() + 6) % 7);
+  return Array.from({ length: 42 }, (_, index) => new Date(first.getTime() + index * 86_400_000).toISOString().slice(0, 10));
+}
+export function shiftMonth(month: string, delta: number): string {
+  const date = new Date(`${month}-01T00:00:00Z`);
+  date.setUTCMonth(date.getUTCMonth() + delta);
+  return date.toISOString().slice(0, 7);
+}
+export function calendarState(day: TradingCalendarDay | null | undefined): "open" | "closed" | "unknown" {
+  return day ? day.is_open ? "open" : "closed" : "unknown";
+}
+export const CALENDAR_LABELS = { open: "交易日", closed: "休市", unknown: "未采集" };
+
+export function filterDescription(filters: MarketFilters): string {
+  return [filters.keyword.trim() ? `搜索“${filters.keyword.trim()}”` : "全部关键词", filters.exchange ? exchangeName(filters.exchange) : "全部交易所", filters.listStatus ? statusName(filters.listStatus) : "全部状态"].join(" · ");
+}

--- a/frontend/tests/market.test.cjs
+++ b/frontend/tests/market.test.cjs
@@ -1,0 +1,116 @@
+/* Fixtures exercise data semantics and wire contracts only. Production views
+   always load authenticated backend data instead of importing these samples. */
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const ts = require('typescript');
+for (const ext of ['.ts', '.tsx']) require.extensions[ext] = (module, filename) => module._compile(ts.transpileModule(fs.readFileSync(filename, 'utf8'), {
+  compilerOptions: { jsx: ts.JsxEmit.ReactJSX, module: ts.ModuleKind.CommonJS, target: ts.ScriptTarget.ES2022 }, fileName: filename
+}).outputText, filename);
+const view = require('../src/pages/market/marketPresentation.ts');
+const api = require('../src/api/dataCollections.ts');
+const { MarketTable } = require('../src/pages/market/MarketTable.tsx');
+const { MarketCalendarDetail } = require('../src/pages/market/MarketCalendarDetail.tsx');
+const { createElement } = require('react');
+const { renderToStaticMarkup } = require('react-dom/server');
+const { MemoryRouter } = require('react-router-dom');
+const render = props => renderToStaticMarkup(createElement(MemoryRouter,null,createElement(MarketTable,{result:null,loading:false,error:false,empty:false,returnTo:view.MARKET_PATH,onOpen(){},...props})));
+const renderDetail = props => renderToStaticMarkup(createElement(MarketCalendarDetail,{detail:null,date:'2026-08-27',exchange:'SSE',loading:false,error:'',onRetry(){},...props}));
+const calendarSnapshot = {key:'SSE:2026-08-27',date:'2026-08-27',exchange:'SSE',value:{is_open:true,previous_trading_date:'2026-08-26',next_trading_date:'2026-08-28',updated_at:'2026-08-30T17:05:00Z'}};
+
+test('pending date and exchange changes retain a coherent detail without flashing placeholders', () => {
+  const html=renderDetail({detail:calendarSnapshot,date:'2026-08-31',exchange:'SZSE',loading:true});
+  assert.match(html,/aria-busy="true"/);
+  assert.match(html,/qfm-aside-date">2026\/08\/27</);
+  for(const fact of ['交易日','上交所','2026/08/26','2026/08/28','08/31 01:05']) assert.ok(html.includes(fact),fact);
+  assert.doesNotMatch(html,/加载中|—|深交所|2026\/08\/31/);
+});
+test('settled, missing and failed dates never borrow another date or exchange label', () => {
+  const next={key:'SZSE:2026-08-31',date:'2026-08-31',exchange:'SZSE',value:{...calendarSnapshot.value,previous_trading_date:'2026-08-28',next_trading_date:null}};
+  const settled=renderDetail({detail:next,date:next.date,exchange:next.exchange});
+  assert.match(settled,/qfm-aside-date">2026\/08\/31</);assert.match(settled,/深交所/);assert.doesNotMatch(settled,/上交所|2026\/08\/27/);
+  assert.match(settled,/后续日期覆盖不足/);
+  const missing=renderDetail({detail:{...next,value:null},date:next.date,exchange:next.exchange});
+  assert.match(missing,/未采集/);assert.match(missing,/此日期尚未采集/);assert.doesNotMatch(missing,/2026\/08\/28/);
+  const failed=renderDetail({detail:calendarSnapshot,date:next.date,exchange:next.exchange,error:'深交所 2026/08/31 的日期详情加载失败，请重试。'});
+  assert.match(failed,/role="alert"/);assert.match(failed,/当前显示 上交所 2026\/08\/27 的详情/);
+  assert.match(failed,/qfm-aside-date">2026\/08\/27</);assert.match(failed,/2026\/08\/26/);
+});
+
+test('market filters round trip literal search, state and aligned page positions', () => {
+  const filters={keyword:'100%_ 指数',exchange:'SZSE',listStatus:'P',limit:100,offset:200};
+  assert.deepEqual(view.marketFilters(new URLSearchParams(view.marketQuery(filters))),filters);
+  const invalid=view.marketFilters(new URLSearchParams('exchange=bad&status=bad&limit=5&offset=-1'));
+  assert.deepEqual(invalid,{keyword:'',exchange:'',listStatus:'',limit:50,offset:0});
+  assert.equal(view.marketFilters(new URLSearchParams('limit=20&offset=29')).offset,20);
+  for(const offset of ['Infinity','NaN','100000000','-20','1.4']) assert.equal(view.marketFilters(new URLSearchParams({offset})).offset,0);
+});
+test('detail return navigation is restricted to the market route', () => {
+  for (const value of [null,{},'https://evil.test','//evil.test','/admin/data/etf-basics/elsewhere','/admin/logs']) assert.equal(view.marketReturnTo(value),view.MARKET_PATH);
+  assert.equal(view.marketReturnTo(view.MARKET_PATH+'?exchange=SSE&offset=50'),view.MARKET_PATH+'?exchange=SSE&offset=50');
+});
+test('calendar date geometry is Monday-first with six weeks across leap years', () => {
+  for (const month of ['2024-02','2026-09','2026-12','2027-01']) {
+    const dates=view.calendarDates(month);assert.equal(dates.length,42);assert.equal(new Set(dates).size,42);
+    assert.equal(new Date(dates[0]+'T00:00:00Z').getUTCDay(),1);
+    for(let i=1;i<42;i++) assert.equal(Date.parse(dates[i])-Date.parse(dates[i-1]),86400000);
+  }
+  assert.ok(view.calendarDates('2024-02').includes('2024-02-29'));
+  assert.equal(view.shiftMonth('2026-12',1),'2027-01');assert.equal(view.shiftMonth('2026-01',-1),'2025-12');
+});
+test('missing days never become closed or open through weekday inference', () => {
+  assert.equal(view.calendarState(undefined),'unknown');assert.equal(view.calendarState(null),'unknown');
+  assert.equal(view.calendarState({calendar_date:'2026-10-01',is_open:false}),'closed');
+  assert.equal(view.calendarState({calendar_date:'2026-08-31',is_open:true}),'open');
+  assert.equal(view.shanghaiToday(new Date('2026-09-10T16:01:00Z')),'2026-09-11');
+});
+test('fee zero, missing values and sync timestamps keep distinct meanings', () => {
+  assert.equal(view.managementFee('0'),'0%');assert.equal(view.managementFee('0.1500'),'0.15%');
+  for(const value of [null,'','invalid']) assert.equal(view.managementFee(value),'—');
+  assert.equal(view.syncPresentation(null).value,'—');
+  const value={refreshed_at:null,last_updated_at:'2026-09-10T16:01:00Z'};
+  assert.equal(view.syncPresentation(value).label,'记录更新');
+  assert.match(view.syncPresentation(value).value,/09\/11 00:01/);
+  assert.equal(view.syncPresentation({...value,refreshed_at:'2026-09-11T16:00:00Z'}).label,'最近同步');
+});
+test('initial loading, empty collection, no matches and unavailable are distinct', () => {
+  assert.match(render({loading:true}),/qfm-skeleton/);assert.doesNotMatch(render({loading:true}),/尚未采集|没有符合/);
+  assert.match(render({empty:true}),/尚未采集 ETF/);assert.match(render({empty:true}),/href="\/admin\/tasks"/);
+  assert.match(render({result:{items:[],total:0}}),/没有符合当前筛选/);
+  assert.match(render({error:true}),/暂不可用/);assert.doesNotMatch(render({error:true}),/尚未采集/);
+});
+test('table retains eight facts, status text, complete names and real detail links', () => {
+  const item={ts_code:'TEST.SH',csname:'测试ETF',cname:'基金完整名称',extname:null,etf_type:'纯境内',exchange:'SH',list_status:'P',list_date:null,index_name:'跟踪指数',index_code:'123.CSI',mgr_name:'管理人',mgt_fee:'0'};
+  const html=render({result:{items:[item],total:1,limit:50,offset:0}});
+  assert.equal((html.match(/scope="col"/g)||[]).length,8);
+  for(const fact of ['TEST.SH','测试ETF','基金完整名称','上交所','待上市','跟踪指数','123.CSI','管理人','0%']) assert.ok(html.includes(fact),fact);
+  assert.match(html,/href="\/admin\/data\/etf-basics\/TEST.SH"/);assert.doesNotMatch(html,/更新时间/);
+});
+test('market requests encode exact filters, 42-day ranges, auth and cancellation', async () => {
+  const originalFetch=global.fetch,originalWindow=global.window,calls=[];
+  global.window={sessionStorage:{getItem:()=> 'fixture-only'}};
+  global.fetch=async (path,options)=>{calls.push({path,options});return {ok:true,json:async()=>({items:[]})};};
+  try {
+    const signal=new AbortController().signal;
+    await api.listEtfs({keyword:'100%_ 指数',exchange:'SSE',listStatus:'P',limit:50,offset:100},signal);
+    const params=new URL(calls[0].path,'http://example.test').searchParams;
+    assert.equal(params.get('keyword'),'100%_ 指数');assert.equal(params.get('list_status'),'P');assert.equal(params.get('offset'),'100');
+    await api.listTradingCalendarDays({exchange:'SSE',startDate:'2026-08-31',endDate:'2026-10-11',limit:42},signal);
+    assert.match(calls[1].path,/limit=42/);assert.match(calls[1].path,/end_date=2026-10-11/);
+    await api.getTradingCalendarDay('SSE','2026-09-01',signal);assert.equal(calls[2].path,'/api/admin/data-collections/trading-calendar/SSE/2026-09-01');
+    await api.getEtfOverview(signal);
+    for(const {options} of calls) {assert.equal(options.signal,signal);assert.equal(options.cache,'no-store');assert.equal(options.headers.Authorization,'Bearer fixture-only');assert.equal(options.method,undefined);}
+  } finally {global.fetch=originalFetch;global.window=originalWindow;}
+});
+test('404 date coverage, expired auth and late cancelled bodies stay distinguishable', async () => {
+  const original=global.fetch;
+  try {
+    for(const status of [404,401,503]) {
+      global.fetch=async()=>({ok:false,status,json:async()=>({detail:'Unavailable'})});
+      await assert.rejects(api.getTradingCalendarDay('SSE','2026-09-01'),error=>error instanceof api.DataCollectionApiError && error.status===status);
+    }
+    const controller=new AbortController();
+    global.fetch=async()=>({ok:true,json:async()=>{controller.abort();return {items:[]};}});
+    await assert.rejects(api.listEtfs({},controller.signal),{name:'AbortError'});
+  } finally {global.fetch=original;}
+});


### PR DESCRIPTION
A 股市场原有 ETF 列表缺少已确认的新版布局、完整筛选上下文和辅助日历。本次按用户验收通过的 B 版替换该页面，接入已部署的真实后端接口。

- 提供四项市场概览、八列 ETF 资料、服务端搜索/筛选/分页，并保留详情返回时的筛选、页码及滚动位置。
- 交易日历支持按交易所浏览、前后交易日详情及未采集状态；兼容原日历入口，完善键盘焦点和旧请求取消。
- 分页保持按钮与总数稳定；日期切换保留完整详情，响应到齐后整体更新，失败时保留数据并说明对应日期。

验证：40 项前端测试、TypeScript/Vite production build、release metadata 校验；已连接测试后端验证搜索、分页、日历、详情返回、失败恢复和 6 类视口，用户已验收通过。构建仍有既存单包超过 500 kB 的提示。

本次无后端、迁移或配置变更，依赖已合并的 #34 接口。ETF 详情仅保留返回上下文，下一页面按用户要求暂不开始。设计文档按项目要求仅保存在本地。
