### PR TITLE
Add persistent ETF watchlists and daily quote facts

### DIFF
--- a/backend/app/data_ingestion/models/etf_daily.py
+++ b/backend/app/data_ingestion/models/etf_daily.py
@@ -41,6 +41,11 @@ class EtfDailyBar(Base):
     close: Mapped[Decimal | None] = mapped_column(Numeric(20, 6), nullable=True)
     vol: Mapped[Decimal | None] = mapped_column(Numeric(24, 4), nullable=True)
     amount: Mapped[Decimal | None] = mapped_column(Numeric(24, 4), nullable=True)
+    # Provider daily-change facts are a display supplement. They do not change
+    # the OHLCV revision contract consumed by frozen backtest evidence.
+    pre_close: Mapped[Decimal | None] = mapped_column(Numeric(20, 6), nullable=True)
+    change: Mapped[Decimal | None] = mapped_column(Numeric(20, 6), nullable=True)
+    pct_chg: Mapped[Decimal | None] = mapped_column(Numeric(20, 6), nullable=True)
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), server_default=func.now()
     )

--- a/backend/app/data_ingestion/models/etf_watchlist.py
+++ b/backend/app/data_ingestion/models/etf_watchlist.py
@@ -1,0 +1,26 @@
+"""Credential-owned ETF selections, independent of market-data lifecycle."""
+
+from datetime import datetime
+
+from sqlalchemy import DateTime, String, func
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.db.base import Base
+
+
+class EtfWatchlistEntry(Base):
+    """Removing a selection must never remove an instrument or its prices.
+
+    The authenticated principal supplies owner_scope; API callers cannot choose
+    another owner. Source and code remain explicit so a future data provider
+    cannot silently replace the series selected by the operator.
+    """
+
+    __tablename__ = "etf_watchlist_entries"
+
+    owner_scope: Mapped[str] = mapped_column(String(80), primary_key=True)
+    source: Mapped[str] = mapped_column(String(32), primary_key=True)
+    ts_code: Mapped[str] = mapped_column(String(16), primary_key=True)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now()
+    )

--- a/backend/app/data_ingestion/repositories/etf_daily.py
+++ b/backend/app/data_ingestion/repositories/etf_daily.py
@@ -61,6 +61,9 @@ class EtfDailyBarRepository:
                 "close": bar.close,
                 "vol": bar.vol,
                 "amount": bar.amount,
+                "pre_close": bar.pre_close,
+                "change": bar.change,
+                "pct_chg": bar.pct_chg,
                 "source_revision": revision,
             }
             if current is None:
@@ -74,7 +77,24 @@ class EtfDailyBarRepository:
             )
             old_revision = getattr(current, "source_revision", None)
             if old_revision == revision:
-                counts["unchanged"] += 1
+                # Display-only change facts do not invalidate a frozen OHLCV
+                # revision. Backfill them separately, preserving updated_at
+                # (the original-bar evidence timestamp) and its audit chain.
+                supplemental = {
+                    field: values[field] for field in ("pre_close", "change", "pct_chg")
+                    if getattr(current, field, None) != values[field]
+                }
+                if supplemental:
+                    self.session.execute(
+                        table.update().where(
+                            table.c.source == source,
+                            table.c.ts_code == bar.ts_code,
+                            table.c.trade_date == bar.trade_date,
+                        ).values(**supplemental, updated_at=table.c.updated_at)
+                    )
+                    counts["metadata_backfilled"] += 1
+                else:
+                    counts["unchanged"] += 1
                 continue
             if changed_fields:
                 kind = "correction"

--- a/backend/app/data_ingestion/repositories/etf_daily.py
+++ b/backend/app/data_ingestion/repositories/etf_daily.py
@@ -2,6 +2,7 @@
 
 from collections.abc import Iterable
 from datetime import UTC, date, datetime
+from decimal import Decimal, ROUND_HALF_UP
 
 from sqlalchemy import func, select
 from sqlalchemy.dialects.postgresql import insert
@@ -61,9 +62,12 @@ class EtfDailyBarRepository:
                 "close": bar.close,
                 "vol": bar.vol,
                 "amount": bar.amount,
-                "pre_close": bar.pre_close,
-                "change": bar.change,
-                "pct_chg": bar.pct_chg,
+                # Match PostgreSQL's stored precision before comparing so
+                # repeated provider values with extra decimals stay idempotent.
+                **{field: value.quantize(Decimal("0.000001"), rounding=ROUND_HALF_UP)
+                   if value is not None else None
+                   for field in ("pre_close", "change", "pct_chg")
+                   for value in (getattr(bar, field),)},
                 "source_revision": revision,
             }
             if current is None:

--- a/backend/app/data_ingestion/repositories/etf_watchlist.py
+++ b/backend/app/data_ingestion/repositories/etf_watchlist.py
@@ -1,0 +1,63 @@
+"""Bounded, owner-scoped selections and one latest stored bar per selection."""
+
+from sqlalchemy import delete, select, true
+from sqlalchemy.dialects.postgresql import insert
+from sqlalchemy.orm import Session
+
+from app.data_ingestion.constants import TUSHARE_SOURCE
+from app.data_ingestion.models.etf import EtfCode
+from app.data_ingestion.models.etf_daily import EtfDailyBar
+from app.data_ingestion.models.etf_watchlist import EtfWatchlistEntry
+
+
+class EtfWatchlistRepository:
+    def __init__(self, session: Session, owner_scope: str):
+        self.session = session
+        self.owner_scope = owner_scope
+
+    def add(self, ts_code: str) -> bool:
+        """Idempotent insertion is safe under concurrent requests/retries."""
+        result = self.session.execute(
+            insert(EtfWatchlistEntry).values(
+                owner_scope=self.owner_scope, source=TUSHARE_SOURCE, ts_code=ts_code
+            ).on_conflict_do_nothing().returning(EtfWatchlistEntry.ts_code)
+        )
+        return result.scalar_one_or_none() is not None
+
+    def remove(self, ts_code: str) -> bool:
+        """Delete only the authenticated owner's selected relation."""
+        result = self.session.execute(
+            delete(EtfWatchlistEntry).where(
+                EtfWatchlistEntry.owner_scope == self.owner_scope,
+                EtfWatchlistEntry.source == TUSHARE_SOURCE,
+                EtfWatchlistEntry.ts_code == ts_code,
+            ).returning(EtfWatchlistEntry.ts_code)
+        )
+        return result.scalar_one_or_none() is not None
+
+    def list_entries(self, *, limit: int, offset: int):
+        """Limit selections before lateral indexed lookups, avoiding N+1 calls.
+
+        The latest stored session is authoritative even when its close is null:
+        selecting an older valid price would conceal a source-data problem.
+        Outer joins retain a saved selection when reference data is missing.
+        """
+        entries = select(EtfWatchlistEntry).where(
+            EtfWatchlistEntry.owner_scope == self.owner_scope,
+            EtfWatchlistEntry.source == TUSHARE_SOURCE,
+        ).order_by(EtfWatchlistEntry.created_at, EtfWatchlistEntry.ts_code).limit(limit).offset(offset).subquery()
+        daily = select(
+            EtfDailyBar.trade_date, EtfDailyBar.close, EtfDailyBar.pre_close,
+            EtfDailyBar.change, EtfDailyBar.pct_chg,
+        ).where(
+            EtfDailyBar.source == entries.c.source,
+            EtfDailyBar.ts_code == entries.c.ts_code,
+        ).order_by(EtfDailyBar.trade_date.desc()).limit(1).lateral()
+        return self.session.execute(select(
+            entries.c.ts_code, entries.c.created_at,
+            EtfCode.csname, EtfCode.extname, EtfCode.cname, EtfCode.exchange,
+            daily.c.trade_date, daily.c.close, daily.c.pre_close,
+            daily.c.change, daily.c.pct_chg,
+        ).select_from(entries).outerjoin(EtfCode,
+            (EtfCode.source == entries.c.source) & (EtfCode.ts_code == entries.c.ts_code)
+        ).outerjoin(daily, true()).order_by(entries.c.created_at, entries.c.ts_code)).mappings().all()

--- a/backend/app/data_ingestion/router.py
+++ b/backend/app/data_ingestion/router.py
@@ -113,6 +113,11 @@ class EtfDailyBarResponse(BaseModel):
     close: Decimal | None
     vol: Decimal | None
     amount: Decimal | None
+    pre_close: Decimal | None = None
+    change: Decimal | None = None
+    pct_chg: Decimal | None = None
+    volume_unit: str = "手"
+    amount_unit: str = "千元"
     source: str
     updated_at: datetime
 

--- a/backend/app/data_ingestion/schemas/etf_daily.py
+++ b/backend/app/data_ingestion/schemas/etf_daily.py
@@ -23,6 +23,11 @@ class EtfDailyBarInput:
     close: Decimal | None
     vol: Decimal | None
     amount: Decimal | None
+    # Optional for older sources and existing fixtures. Never derive these
+    # values from adjacent stored bars, which may span missing sessions.
+    pre_close: Decimal | None = None
+    change: Decimal | None = None
+    pct_chg: Decimal | None = None
 
 
 def _canonical_decimal(

--- a/backend/app/data_ingestion/services/etf_daily.py
+++ b/backend/app/data_ingestion/services/etf_daily.py
@@ -38,7 +38,7 @@ if TYPE_CHECKING:
 
 
 # Keep this aligned with Tushare's documented single-ETF ``fund_daily`` example.
-ETF_DAILY_FIELDS = "trade_date,open,high,low,close,vol,amount"
+ETF_DAILY_FIELDS = "trade_date,open,high,low,close,vol,amount,pre_close,change,pct_chg"
 # The whole-market request needs the provider code to form the database key.
 ETF_DAILY_MARKET_FIELDS = f"ts_code,{ETF_DAILY_FIELDS}"
 ETF_DAILY_SCOPE_KEY = "market=CN"
@@ -749,6 +749,9 @@ def _normalize_etf_daily_row(row: object) -> EtfDailyBarInput:
         close=_parse_decimal(row.get("close"), "close"),
         vol=_parse_non_negative_decimal(row.get("vol"), "vol"),
         amount=_parse_non_negative_decimal(row.get("amount"), "amount"),
+        pre_close=_parse_decimal(row.get("pre_close"), "pre_close"),
+        change=_parse_decimal(row.get("change"), "change"),
+        pct_chg=_parse_decimal(row.get("pct_chg"), "pct_chg"),
     )
 
 

--- a/backend/app/data_ingestion/watchlist_router.py
+++ b/backend/app/data_ingestion/watchlist_router.py
@@ -1,0 +1,108 @@
+"""Authenticated personal ETF watchlists and explicit daily-price semantics."""
+
+from datetime import date, datetime
+from decimal import Decimal
+from typing import Annotated, Literal
+
+from fastapi import APIRouter, Depends, HTTPException, Path, Query
+from pydantic import BaseModel
+from sqlalchemy.orm import Session
+
+from app.core.auth import AuthenticatedPrincipal, require_api_token
+from app.data_ingestion.repositories.etf_detail import EtfDetailQueryRepository
+from app.data_ingestion.repositories.etf_watchlist import EtfWatchlistRepository
+from app.db.session import get_db_session
+
+router = APIRouter(prefix="/api/admin/etf-watchlist", tags=["admin-data"])
+Code = Annotated[str, Path(pattern=r"^\d{6}\.(SH|SZ)$")]
+
+
+class WatchlistItem(BaseModel):
+    ts_code: str
+    name: str | None
+    exchange: str | None
+    created_at: datetime
+    trade_date: date | None
+    close: Decimal | None
+    pre_close: Decimal | None
+    change: Decimal | None
+    pct_chg: Decimal | None
+    price_basis: Literal["raw_daily_close"] = "raw_daily_close"
+    message: str
+
+
+class WatchlistPage(BaseModel):
+    items: list[WatchlistItem]
+    limit: int
+    offset: int
+    has_more: bool
+
+
+class WatchlistMutation(BaseModel):
+    changed: bool
+    message: str
+
+
+def present_item(row) -> WatchlistItem:
+    """Unknown/invalid source facts stay unknown; zero change stays zero."""
+    close = row["close"]
+    valid_close = close is not None and close.is_finite() and close > 0
+    pre_close = row["pre_close"]
+    valid_previous = pre_close is not None and pre_close.is_finite() and pre_close > 0
+    change = row["change"]
+    pct = row["pct_chg"]
+    valid_change = valid_close and valid_previous and all(
+        value is not None and value.is_finite() for value in (change, pct)
+    )
+    if row["trade_date"] is None:
+        message = "尚未采集该 ETF 的日线行情，请检查采集任务。"
+    elif not valid_close:
+        message = f"{row['trade_date']} 的收盘价缺失或无效，请检查数据源。"
+    elif not valid_change:
+        message = f"显示 {row['trade_date']} 的收盘价；数据源涨跌字段缺失，待日线重新采集。"
+    else:
+        message = f"显示 {row['trade_date']} 的收盘价与数据源涨跌数据，非实时行情。"
+    return WatchlistItem(
+        ts_code=row["ts_code"], name=row["csname"] or row["extname"] or row["cname"],
+        exchange=row["exchange"], created_at=row["created_at"], trade_date=row["trade_date"],
+        close=close if valid_close else None,
+        pre_close=pre_close if valid_previous else None,
+        change=change if valid_change else None, pct_chg=pct if valid_change else None,
+        message=message,
+    )
+
+
+@router.get("", response_model=WatchlistPage)
+def list_watchlist(
+    session: Annotated[Session, Depends(get_db_session)],
+    principal: Annotated[AuthenticatedPrincipal, Depends(require_api_token)],
+    limit: Annotated[int, Query(ge=1, le=200)] = 50,
+    offset: Annotated[int, Query(ge=0)] = 0,
+):
+    rows = EtfWatchlistRepository(session, principal.owner_scope).list_entries(limit=limit + 1, offset=offset)
+    return WatchlistPage(items=[present_item(row) for row in rows[:limit]],
+                         limit=limit, offset=offset, has_more=len(rows) > limit)
+
+
+@router.put("/{ts_code}", response_model=WatchlistMutation)
+def add_watchlist(
+    ts_code: Code,
+    session: Annotated[Session, Depends(get_db_session)],
+    principal: Annotated[AuthenticatedPrincipal, Depends(require_api_token)],
+):
+    if EtfDetailQueryRepository(session).get_code(ts_code) is None:
+        raise HTTPException(status_code=404, detail="该 ETF 基础资料不存在，无法添加自选。")
+    changed = EtfWatchlistRepository(session, principal.owner_scope).add(ts_code)
+    session.commit()
+    return WatchlistMutation(changed=changed, message=f"ETF {ts_code} 已添加自选。" if changed else f"ETF {ts_code} 已在自选中。")
+
+
+@router.delete("/{ts_code}", response_model=WatchlistMutation)
+def remove_watchlist(
+    ts_code: Code,
+    session: Annotated[Session, Depends(get_db_session)],
+    principal: Annotated[AuthenticatedPrincipal, Depends(require_api_token)],
+):
+    changed = EtfWatchlistRepository(session, principal.owner_scope).remove(ts_code)
+    session.commit()
+    return WatchlistMutation(changed=changed, message=f"ETF {ts_code} 已移出自选。" if changed else f"ETF {ts_code} 不在自选中。")

--- a/backend/app/db/migrations/versions/20260914_01_etf_workspace.py
+++ b/backend/app/db/migrations/versions/20260914_01_etf_workspace.py
@@ -1,0 +1,30 @@
+"""Persist ETF watchlists and provider-supplied daily change facts."""
+
+from alembic import op
+import sqlalchemy as sa
+
+revision = "20260914_01"
+down_revision = "20260913_01"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.create_table(
+        "etf_watchlist_entries",
+        sa.Column("owner_scope", sa.String(80), primary_key=True),
+        sa.Column("source", sa.String(32), primary_key=True),
+        sa.Column("ts_code", sa.String(16), primary_key=True),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False,
+                  server_default=sa.func.now()),
+    )
+    # Legacy rows deliberately remain unknown. Migration must not invent a
+    # previous close across missing sessions or a corporate-action boundary.
+    for name in ("pre_close", "change", "pct_chg"):
+        op.add_column("etf_daily_bars", sa.Column(name, sa.Numeric(20, 6), nullable=True))
+
+
+def downgrade():
+    for name in ("pct_chg", "change", "pre_close"):
+        op.drop_column("etf_daily_bars", name)
+    op.drop_table("etf_watchlist_entries")

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -11,6 +11,7 @@ from app.core.config import Settings, get_settings
 from app.core.logging import configure_logging
 from app.core.request_logging import log_request
 from app.data_ingestion.router import router as data_ingestion_router
+from app.data_ingestion.watchlist_router import router as etf_watchlist_router
 from app.data_sources.router import router as data_sources_router
 from app.data_sources.service import initialize_sources
 from app.backtesting.router import router as backtesting_router
@@ -73,6 +74,7 @@ def create_app(settings: Settings | None = None) -> FastAPI:
     protected_router.include_router(overview_router)
     protected_router.include_router(scheduling_router)
     protected_router.include_router(data_ingestion_router)
+    protected_router.include_router(etf_watchlist_router)
     protected_router.include_router(data_sources_router)
     protected_router.include_router(strategies_router)
     protected_router.include_router(backtesting_router)

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -1,6 +1,7 @@
 """Import SQLAlchemy model modules here so Alembic can discover them."""
 
 from app.data_sources.models import DataSourceConfig
+from app.data_ingestion.models.etf_watchlist import EtfWatchlistEntry
 
 from app.data_ingestion.models import (
     DataSyncCheckpoint,
@@ -64,6 +65,7 @@ from app.backtesting.result_records import (
 
 
 __all__ = [
+    "EtfWatchlistEntry",
     "DataSourceConfig",
     "DataSyncCheckpoint",
     "BacktestAccountProfileRecord",

--- a/backend/tests/test_etf_watchlist.py
+++ b/backend/tests/test_etf_watchlist.py
@@ -1,0 +1,144 @@
+"""Watchlist isolation, price meaning and supplementary fact regression tests."""
+
+from dataclasses import replace, asdict
+from datetime import UTC, date, datetime
+from decimal import Decimal
+from types import SimpleNamespace
+from unittest.mock import Mock
+from unittest.mock import patch
+import asyncio
+
+import pytest
+from fastapi import HTTPException
+from sqlalchemy.dialects import postgresql
+
+from app.core.auth import AuthenticatedPrincipal
+from app.data_ingestion.repositories.etf_daily import EtfDailyBarRepository
+from app.data_ingestion.repositories.etf_watchlist import EtfWatchlistRepository
+from app.data_ingestion.schemas.etf_daily import canonical_row_revision
+from app.data_ingestion.watchlist_router import add_watchlist, present_item, remove_watchlist
+from tests.test_etf_daily_repository import make_bar
+from tests.test_auth import API_TOKEN, request_status
+from app.core.config import Settings
+from app.db.session import get_db_session
+from app.main import create_app
+
+
+def quote(**changes):
+    return dict(ts_code="510300.SH", csname="沪深300ETF", extname=None, cname=None,
+                exchange="SH", created_at=datetime.now(UTC), trade_date=date(2026, 8, 28),
+                close=Decimal("1.049"), pre_close=Decimal("1.043"),
+                change=Decimal("0.006"), pct_chg=Decimal("0.5753"), **changes)
+
+
+def test_price_uses_official_change_and_explicit_asof():
+    item = present_item(quote())
+    assert item.pct_chg == Decimal("0.5753")
+    assert item.price_basis == "raw_daily_close"
+    assert "2026-08-28" in item.message and "非实时" in item.message
+
+
+def test_watchlist_route_requires_authentication_and_is_in_openapi():
+    app = create_app(Settings(api_token=API_TOKEN, database_password="test-secret", _env_file=None))
+    session = Mock()
+    session.execute.return_value.mappings.return_value.all.return_value = []
+    app.dependency_overrides[get_db_session] = lambda: session
+    with patch("app.core.request_logging.logger"):
+        assert asyncio.run(request_status(app, "/api/admin/etf-watchlist")) == 401
+        session.execute.assert_not_called()
+        assert asyncio.run(request_status(app, "/api/admin/etf-watchlist", API_TOKEN)) == 200
+    paths = app.openapi()["paths"]
+    assert {"put", "delete"} <= paths["/api/admin/etf-watchlist/{ts_code}"].keys()
+
+
+@pytest.mark.parametrize("field,value", [
+    ("pre_close", None), ("pre_close", Decimal(0)),
+    ("pct_chg", None), ("change", Decimal("NaN")),
+    ("close", Decimal(-1)), ("close", None),
+])
+def test_missing_or_invalid_price_never_fabricates_change(field, value):
+    row = quote()
+    row[field] = value
+    item = present_item(row)
+    assert item.change is None and item.pct_chg is None
+    if field == "close":
+        assert item.close is None
+
+
+def test_flat_market_is_not_missing():
+    row = quote()
+    row.update(change=Decimal(0), pct_chg=Decimal(0))
+    assert present_item(row).pct_chg == 0
+
+
+def test_no_bars_keeps_saved_instrument_visible():
+    row = quote()
+    row.update(trade_date=None, close=None, pre_close=None, change=None, pct_chg=None)
+    assert "尚未采集" in present_item(row).message
+
+
+def test_batch_query_is_scoped_and_does_not_skip_invalid_latest_rows():
+    session = Mock()
+    session.execute.return_value.mappings.return_value.all.return_value = []
+    assert EtfWatchlistRepository(session, "owner-a").list_entries(limit=51, offset=50) == []
+    statement = session.execute.call_args.args[0].compile(dialect=postgresql.dialect())
+    assert "owner-a" in statement.params.values()
+    assert "LEFT OUTER JOIN LATERAL" in str(statement)
+    assert "trade_date DESC" in str(statement)
+    assert "close IS NOT NULL" not in str(statement)
+    assert session.execute.call_count == 1
+
+
+def test_idempotent_insert_and_owner_scoped_removal():
+    session = Mock()
+    session.execute.return_value.scalar_one_or_none.return_value = "510300.SH"
+    repo = EtfWatchlistRepository(session, "owner-a")
+    assert repo.add("510300.SH")
+    insert = session.execute.call_args.args[0].compile(dialect=postgresql.dialect())
+    assert "ON CONFLICT DO NOTHING" in str(insert)
+    assert insert.params["owner_scope"] == "owner-a"
+    assert repo.remove("510300.SH")
+    delete = session.execute.call_args.args[0].compile(dialect=postgresql.dialect())
+    assert "owner-a" in delete.params.values()
+    assert "etf_daily_bars" not in str(delete)
+    session.execute.return_value.scalar_one_or_none.return_value = None
+    assert not repo.remove("510300.SH")
+
+
+def test_unknown_etf_cannot_be_saved():
+    session = Mock()
+    session.scalar.return_value = None
+    with pytest.raises(HTTPException) as error:
+        add_watchlist("510300.SH", session, AuthenticatedPrincipal("owner-a"))
+    assert error.value.status_code == 404
+    session.commit.assert_not_called()
+    session.execute.assert_not_called()
+
+
+def test_delete_commits_only_authenticated_relation():
+    session = Mock()
+    session.execute.return_value.scalar_one_or_none.return_value = None
+    result = remove_watchlist("510300.SH", session, AuthenticatedPrincipal("owner-b"))
+    assert result.changed is False
+    assert "不在自选" in result.message
+    session.commit.assert_called_once()
+
+
+def test_display_backfill_preserves_bar_revision_and_original_timestamp():
+    original = make_bar()
+    enriched = replace(original, pre_close=Decimal("3.70"), change=Decimal("0.04"), pct_chg=Decimal("1.0811"))
+    revision = canonical_row_revision(original, source="tushare")
+    assert canonical_row_revision(enriched, source="tushare") == revision
+    session = Mock()
+    session.get.return_value = SimpleNamespace(**asdict(original), source_revision=revision)
+    result = EtfDailyBarRepository(session).upsert_bars([enriched], source="tushare")
+    assert result.changed == 1 and result.metadata_backfilled == 1
+    assert session.execute.call_count == 1
+    statement = session.execute.call_args.args[0].compile(dialect=postgresql.dialect())
+    assert "updated_at=etf_daily_bars.updated_at" in str(statement)
+    assert "source_revision" not in statement.params
+    session.get.return_value = SimpleNamespace(**asdict(enriched), source_revision=revision)
+    session.execute.reset_mock()
+    result = EtfDailyBarRepository(session).upsert_bars([enriched], source="tushare")
+    assert result.unchanged == 1
+    session.execute.assert_not_called()

--- a/backend/tests/test_etf_watchlist.py
+++ b/backend/tests/test_etf_watchlist.py
@@ -22,6 +22,8 @@ from tests.test_auth import API_TOKEN, request_status
 from app.core.config import Settings
 from app.db.session import get_db_session
 from app.main import create_app
+from app.data_ingestion.services.etf_daily import normalize_etf_daily
+from tests.test_etf_daily import make_dataframe
 
 
 def quote(**changes):
@@ -140,5 +142,20 @@ def test_display_backfill_preserves_bar_revision_and_original_timestamp():
     session.get.return_value = SimpleNamespace(**asdict(enriched), source_revision=revision)
     session.execute.reset_mock()
     result = EtfDailyBarRepository(session).upsert_bars([enriched], source="tushare")
+    assert result.unchanged == 1
+    session.execute.assert_not_called()
+
+
+def test_provider_change_facts_are_read_without_recalculation():
+    frame = make_dataframe()
+    frame.to_dict.return_value[0].update(pre_close="3.70", change="0.04", pct_chg="1.0810811")
+    bar = normalize_etf_daily(frame, expected_trade_date=date(2026, 8, 14))[0]
+    assert bar.pre_close == Decimal("3.70")
+    assert bar.change == Decimal("0.04")
+    assert bar.pct_chg == Decimal("1.0810811")
+    stored = replace(bar, pct_chg=Decimal("1.081081"))
+    session = Mock()
+    session.get.return_value = SimpleNamespace(**asdict(stored), source_revision=canonical_row_revision(bar, source="tushare"))
+    result = EtfDailyBarRepository(session).upsert_bars([bar], source="tushare")
     assert result.unchanged == 1
     session.execute.assert_not_called()

--- a/backend/tests/test_etf_watchlist_postgresql.py
+++ b/backend/tests/test_etf_watchlist_postgresql.py
@@ -1,0 +1,76 @@
+"""Real PostgreSQL coverage for lateral lookups, persistence and retry races."""
+
+from concurrent.futures import ThreadPoolExecutor
+from datetime import date
+from decimal import Decimal
+import os
+from uuid import uuid4
+
+import pytest
+from sqlalchemy import create_engine, delete, select
+from sqlalchemy.orm import Session
+
+from app.core.config import get_settings
+from app.data_ingestion.models.etf_daily import EtfDailyBar
+from app.data_ingestion.models.etf_watchlist import EtfWatchlistEntry
+from app.data_ingestion.repositories.etf_watchlist import EtfWatchlistRepository
+
+pytestmark = pytest.mark.skipif(os.getenv("POSTGRES_TEST_ENABLED") != "1", reason="requires disposable PostgreSQL")
+
+
+@pytest.fixture
+def database():
+    engine = create_engine(get_settings().database_url)
+    owner = "test:" + uuid4().hex
+    code = "T" + uuid4().hex[:10]
+    try:
+        yield engine, owner, code
+    finally:
+        with Session(engine) as session:
+            session.execute(delete(EtfWatchlistEntry).where(EtfWatchlistEntry.ts_code == code))
+            session.execute(delete(EtfDailyBar).where(EtfDailyBar.ts_code == code))
+            session.commit()
+        engine.dispose()
+
+
+def test_concurrent_add_is_idempotent_and_owner_deletion_is_isolated(database):
+    engine, owner, code = database
+    def add():
+        with Session(engine) as session:
+            changed = EtfWatchlistRepository(session, owner).add(code)
+            session.commit()
+            return changed
+    with ThreadPoolExecutor(max_workers=4) as pool:
+        results = list(pool.map(lambda _: add(), range(4)))
+    assert sum(results) == 1
+    with Session(engine) as session:
+        other = EtfWatchlistRepository(session, owner + ":other")
+        assert other.add(code)
+        assert EtfWatchlistRepository(session, owner).remove(code)
+        assert not EtfWatchlistRepository(session, owner).remove(code)
+        session.commit()
+    with Session(engine) as session:
+        assert len(EtfWatchlistRepository(session, owner + ":other").list_entries(limit=50, offset=0)) == 1
+        assert EtfWatchlistRepository(session, owner).list_entries(limit=50, offset=0) == []
+
+
+def test_latest_invalid_bar_is_not_replaced_by_older_or_other_source_quote(database):
+    engine, owner, code = database
+    with Session(engine) as session:
+        EtfWatchlistRepository(session, owner).add(code)
+        session.add_all([
+            EtfDailyBar(source="tushare", ts_code=code, trade_date=date(2026, 8, 27), close=Decimal("1.2")),
+            EtfDailyBar(source="tushare", ts_code=code, trade_date=date(2026, 8, 28), close=None),
+            EtfDailyBar(source="other", ts_code=code, trade_date=date(2026, 8, 29), close=Decimal("9")),
+        ])
+        session.commit()
+    with Session(engine) as session:
+        repo = EtfWatchlistRepository(session, owner)
+        rows = repo.list_entries(limit=50, offset=0)
+        assert len(rows) == 1
+        assert rows[0]["trade_date"] == date(2026, 8, 28)
+        assert rows[0]["close"] is None
+        assert repo.list_entries(limit=50, offset=1) == []
+        assert repo.remove(code)
+        session.commit()
+        assert len(session.scalars(select(EtfDailyBar).where(EtfDailyBar.ts_code == code)).all()) == 3

--- a/backend/tests/test_etf_workspace_migration.py
+++ b/backend/tests/test_etf_workspace_migration.py
@@ -1,0 +1,24 @@
+"""Upgrade/downgrade preserves original daily evidence and unknown facts."""
+
+import importlib
+
+from alembic.migration import MigrationContext
+from alembic.operations import Operations
+from sqlalchemy import create_engine, inspect, text
+
+
+def test_legacy_prices_survive_upgrade_and_downgrade():
+    engine = create_engine("sqlite://")
+    migration = importlib.import_module("app.db.migrations.versions.20260914_01_etf_workspace")
+    with engine.begin() as connection:
+        connection.execute(text("CREATE TABLE etf_daily_bars (ts_code TEXT PRIMARY KEY, close NUMERIC, source_revision TEXT)"))
+        connection.execute(text("INSERT INTO etf_daily_bars VALUES ('510300.SH', 1.049, 'original')"))
+        with Operations.context(MigrationContext.configure(connection)):
+            migration.upgrade()
+            row = connection.execute(text("SELECT close, source_revision, pre_close, change, pct_chg FROM etf_daily_bars")).one()
+            assert tuple(row) == (1.049, "original", None, None, None)
+            assert "etf_watchlist_entries" in inspect(connection).get_table_names()
+            migration.downgrade()
+            assert "etf_watchlist_entries" not in inspect(connection).get_table_names()
+            assert tuple(connection.execute(text("SELECT close, source_revision FROM etf_daily_bars")).one()) == (1.049, "original")
+    engine.dispose()


### PR DESCRIPTION
The ETF workspace needs a real personal watchlist and source daily changes instead of prototype symbols and calculated quote placeholders. Add authenticated, owner-scoped GET/PUT/DELETE watchlist endpoints with idempotent mutations and batched latest-bar lookups. Saved symbols remain visible when reference data or prices are missing; the API states the trading date and that prices are daily closes.

Collect and persist Tushare `pre_close`, `change`, and `pct_chg`, and expose volume/amount units. Migration `20260914_01` leaves legacy change fields null. Existing full daily recollection can populate them after deployment; no ingestion or backfill runs during migration. Display-only enrichment preserves the OHLCV revision and original-bar timestamp used by backtest evidence. No bid/ask or alert service is introduced.

Validation: local backend suite passed (2078 tests, 16 PostgreSQL-dependent skips before final test additions); final focused auth/watchlist/migration suite passed (16 tests); 14 root tests and release metadata validation passed. Added PostgreSQL integration tests for concurrent idempotent insertion, ownership isolation, latest-invalid-bar behavior, pagination, and preservation of market data on removal. CI must run those against the migrated PostgreSQL service before merge.

Deployment: apply migrations and deploy the backend first. Existing prices stay usable; source change fields remain explicitly unavailable until the relevant daily records are recollected through existing full daily collection. This PR contains backend changes only; approved design documents remain local.
