### PR TITLE
升级 ETF 行情研究工作区

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -79,7 +79,7 @@ export function App() {
       />
       <Route
         path="/admin/data/etf-basics/:tsCode"
-        element={<RequireAuth><AdminPage><EtfDetailPage /></AdminPage></RequireAuth>}
+        element={<RequireAuth><EtfDetailPage /></RequireAuth>}
       />
       <Route
         path="/admin/strategy-data"

--- a/frontend/src/api/dataCollections.ts
+++ b/frontend/src/api/dataCollections.ts
@@ -83,14 +83,19 @@ export interface EtfFilters {
 export interface EtfDailyBar {
   ts_code: string;
   trade_date: string;
-  open: string;
-  high: string;
-  low: string;
-  close: string;
-  vol: string;
-  amount: string;
+  open: string | null;
+  high: string | null;
+  low: string | null;
+  close: string | null;
+  vol: string | null;
+  amount: string | null;
   source: string;
   updated_at: string;
+  pre_close?: string | null;
+  change?: string | null;
+  pct_chg?: string | null;
+  volume_unit?: string;
+  amount_unit?: string;
 }
 
 export interface EtfAdjustmentFactor {
@@ -179,26 +184,28 @@ function timeSeriesParams(filters: EtfTimeSeriesFilters): string {
   return params.toString();
 }
 
-export function getEtf(tsCode: string): Promise<EtfCode> {
-  return request<EtfCode>(`/api/admin/data-collections/etfs/${encodeURIComponent(tsCode)}`);
+export function getEtf(tsCode: string, signal?: AbortSignal): Promise<EtfCode> {
+  return request<EtfCode>(`/api/admin/data-collections/etfs/${encodeURIComponent(tsCode)}`, signal);
 }
 
 export function listEtfDailyBars(
   tsCode: string,
-  filters: EtfTimeSeriesFilters
+  filters: EtfTimeSeriesFilters,
+  signal?: AbortSignal
 ): Promise<EtfDailyBar[]> {
   const params = timeSeriesParams(filters);
   return request<EtfDailyBar[]>(
-    `/api/admin/data-collections/etfs/${encodeURIComponent(tsCode)}/daily-bars${params ? `?${params}` : ""}`
+    `/api/admin/data-collections/etfs/${encodeURIComponent(tsCode)}/daily-bars${params ? `?${params}` : ""}`, signal
   );
 }
 
 export function listEtfAdjustmentFactors(
   tsCode: string,
-  filters: EtfTimeSeriesFilters
+  filters: EtfTimeSeriesFilters,
+  signal?: AbortSignal
 ): Promise<EtfAdjustmentFactor[]> {
   const params = timeSeriesParams(filters);
   return request<EtfAdjustmentFactor[]>(
-    `/api/admin/data-collections/etfs/${encodeURIComponent(tsCode)}/adjustment-factors${params ? `?${params}` : ""}`
+    `/api/admin/data-collections/etfs/${encodeURIComponent(tsCode)}/adjustment-factors${params ? `?${params}` : ""}`, signal
   );
 }

--- a/frontend/src/api/etfWatchlist.ts
+++ b/frontend/src/api/etfWatchlist.ts
@@ -1,0 +1,53 @@
+import { readApiToken } from "../auth/tokenStorage";
+import { DataCollectionApiError } from "./dataCollections";
+
+export interface WatchItem {
+  ts_code: string;
+  name: string | null;
+  exchange: string | null;
+  created_at: string;
+  trade_date: string | null;
+  close: string | null;
+  pre_close: string | null;
+  change: string | null;
+  pct_chg: string | null;
+  price_basis: "raw_daily_close";
+  message: string;
+}
+export interface WatchPage {
+  items: WatchItem[];
+  limit: number;
+  offset: number;
+  has_more: boolean;
+}
+
+async function request<T>(
+  path: string,
+  method: string,
+  signal?: AbortSignal,
+): Promise<T> {
+  const token = readApiToken();
+  const response = await fetch(`/api/admin/etf-watchlist${path}`, {
+    method,
+    signal,
+    cache: "no-store",
+    headers: token ? { Authorization: `Bearer ${token}` } : {},
+  });
+  const body = await response.json().catch(() => null);
+  if (!response.ok)
+    throw new DataCollectionApiError(
+      typeof body?.detail === "string"
+        ? body.detail
+        : `自选操作失败（HTTP ${response.status}）。`,
+      response.status,
+    );
+  signal?.throwIfAborted();
+  return body as T;
+}
+export const listWatchlist = (offset = 0, signal?: AbortSignal) =>
+  request<WatchPage>(`?limit=50&offset=${offset}`, "GET", signal);
+export const setWatched = (code: string, watched: boolean) =>
+  request<{ changed: boolean; message: string }>(
+    `/${encodeURIComponent(code)}`,
+    watched ? "PUT" : "DELETE",
+  );

--- a/frontend/src/pages/EtfDetailPage.tsx
+++ b/frontend/src/pages/EtfDetailPage.tsx
@@ -1,649 +1,1191 @@
-import { ChevronLeft, Expand, RefreshCw } from "lucide-react";
-import {
-  dispose as disposeKLineChart,
-  init as initKLineChart,
-  registerIndicator,
-  type IndicatorTemplate,
-  type KLineData
-} from "klinecharts";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { useLocation, useNavigate, useParams, useSearchParams } from "react-router-dom";
-import { marketReturnTo } from "./market/marketPresentation";
-
+import {
+  useLocation,
+  useNavigate,
+  useParams,
+  useSearchParams,
+} from "react-router-dom";
+import {
+  ArrowLeft,
+  Bell,
+  ChevronDown,
+  Expand,
+  Maximize,
+  MousePointer2,
+  PanelRight,
+  Pause,
+  Play,
+  RefreshCw,
+  Ruler,
+  SkipForward,
+  Slash,
+  TextCursorInput,
+  Trash2,
+  X,
+  ZoomIn,
+  Minus,
+  ChevronsUpDown,
+  ChartCandlestick,
+} from "lucide-react";
 import {
   DataCollectionApiError,
-  EtfAdjustmentFactor,
-  EtfCode,
-  EtfDailyBar,
   getEtf,
   listEtfAdjustmentFactors,
-  listEtfDailyBars
+  listEtfDailyBars,
+  type EtfAdjustmentFactor,
+  type EtfCode,
+  type EtfDailyBar,
 } from "../api/dataCollections";
 import { useAuth } from "../auth/AuthContext";
+import { marketReturnTo } from "./market/marketPresentation";
+import {
+  ADJUSTMENTS,
+  buildSeries,
+  dateText,
+  DEFAULT_INDICATORS,
+  direction,
+  exchangeName,
+  MA_COLORS,
+  numberText,
+  numeric,
+  PERIODS,
+  signed,
+  timeText,
+  validParams,
+  type Adjustment,
+  type Bar,
+  type IndicatorSettings,
+  type Period,
+} from "./etf/etfData";
+import { EtfChart, type ChartHandle } from "./etf/EtfChart";
+import { EtfPopover, type PopoverAnchor } from "./etf/EtfPopover";
+import { EtfWatchlist } from "./etf/EtfWatchlist";
+import "./etf/EtfWorkspace.css";
 
-type DetailTab = "basic" | "daily" | "factors";
-type ChartPeriod = "day" | "week" | "month" | "year";
-type AdjustmentMode = "raw" | "forward" | "backward";
-const MOVING_AVERAGE_LENGTHS = [5, 10, 20] as const;
-type MovingAverageLength = (typeof MOVING_AVERAGE_LENGTHS)[number];
-type KLineChartPeriod = "day" | "week" | "month" | "year";
-
-const KLINE_MA_INDICATOR_NAME = "ETF_MA";
-const KLINE_MA_COLORS: Record<MovingAverageLength, string> = {
-  5: "#10cae6",
-  10: "#ffb317",
-  20: "#ba94ff"
+interface Snapshot {
+  code: string;
+  etf: EtfCode;
+  daily: EtfDailyBar[];
+  factors: EtfAdjustmentFactor[];
+  factorError: string;
+}
+const EMPTY_DAILY: EtfDailyBar[] = [],
+  EMPTY_FACTORS: EtfAdjustmentFactor[] = [];
+const TOOL_LABELS: Record<string, string> = {
+  cursor: "光标",
+  segment: "趋势线",
+  parallelStraightLine: "平行通道",
+  fibonacciLine: "斐波那契",
+  simpleAnnotation: "标注",
+  qfRuler: "测量",
+  zoom: "缩放",
 };
-const KLINE_UP_COLOR = "#f35b69";
-const KLINE_DOWN_COLOR = "#45cc91";
-
-interface KLineChartBar extends KLineData {
-  ma5?: number;
-  ma10?: number;
-  ma20?: number;
-}
-
-interface KLineMovingAverageResult {
-  [key: string]: number | undefined;
-}
-
-// KLineChart's built-in MA indicator starts its calculation at the first bar
-// in the current data set.  This adapter renders values precomputed from the
-// complete history, so a date-filtered view keeps the correct MA warm-up data.
-const ETF_MA_INDICATOR = {
-  name: KLINE_MA_INDICATOR_NAME,
-  shortName: "MA",
-  series: "price",
-  precision: 4,
-  calcParams: [...MOVING_AVERAGE_LENGTHS],
-  figures: [],
-  regenerateFigures: (params: number[]) => params.map((length) => ({
-    key: `ma${length}`,
-    title: `MA${length}: `,
-    type: "line"
-  })),
-  calc: (dataList: KLineData[], indicator: { calcParams: number[] }): KLineMovingAverageResult[] => dataList.map((bar) => indicator.calcParams.reduce<KLineMovingAverageResult>((result, length) => {
-    const value = bar[`ma${length}`];
-    if (typeof value === "number") result[`ma${length}`] = value;
-    return result;
-  }, {}))
-} as unknown as IndicatorTemplate<KLineMovingAverageResult, number, unknown>;
-
-registerIndicator(ETF_MA_INDICATOR);
-
-interface NumericBar {
-  tradeDate: string;
-  open: number;
-  high: number;
-  low: number;
-  close: number;
-  vol: number;
-  amount: number;
-}
-
-interface MatchedAdjustmentBar {
-  bar: NumericBar;
-  factor: number;
-}
-
-interface AdjustmentFactorSummary {
-  first: number;
-  last: number;
-  changeCount: number;
-}
-
-const TABS: { key: DetailTab; label: string }[] = [
-  { key: "basic", label: "基础信息" },
-  { key: "daily", label: "日线 K 线" },
-  { key: "factors", label: "复权因子" }
-];
-
-const PERIOD_LABELS: Record<ChartPeriod, string> = {
-  day: "日",
-  week: "周",
-  month: "月",
-  year: "年"
+const TOOL_HINTS: Record<string, string> = {
+  segment: "点击两个锚点绘制趋势线",
+  parallelStraightLine: "点击两个方向锚点，再点击通道边界",
+  fibonacciLine: "点击起点和终点绘制斐波那契",
+  simpleAnnotation: "点击图表放置标注",
+  qfRuler: "点击两个锚点测量价差和时间",
 };
-
-const PERIOD_KLINE_LABELS: Record<ChartPeriod, string> = {
-  day: "日 K 线",
-  week: "周 K 线",
-  month: "月 K 线",
-  year: "年 K 线"
-};
-
-const ADJUSTMENT_LABELS: Record<AdjustmentMode, string> = {
-  raw: "不复权",
-  forward: "前复权",
-  backward: "后复权"
-};
-
-function formatDate(value: string | null): string {
-  if (!value) return "—";
-  const date = new Date(`${value}T00:00:00`);
-  return Number.isNaN(date.getTime()) ? value : new Intl.DateTimeFormat("zh-CN", {
-    year: "numeric", month: "2-digit", day: "2-digit"
-  }).format(date);
+function message(error: unknown) {
+  return error instanceof Error ? error.message : "数据加载失败，请重试。";
 }
-
-function formatTimestamp(value: string): string {
-  const date = new Date(value);
-  return Number.isNaN(date.getTime()) ? value : new Intl.DateTimeFormat("zh-CN", {
-    month: "2-digit", day: "2-digit", hour: "2-digit", minute: "2-digit", hour12: false
-  }).format(date);
-}
-
-function exchangeLabel(value: string): string {
-  return { SSE: "上交所", SZSE: "深交所", SH: "上交所", SZ: "深交所" }[value] ?? value;
-}
-
-function statusLabel(value: string): string {
-  return { L: "上市", D: "退市", P: "待上市" }[value] ?? value;
-}
-
-function decimal(value: string): number | null {
-  const parsed = Number(value);
-  return Number.isFinite(parsed) ? parsed : null;
-}
-
-function numberText(value: string, fractionDigits = 4): string {
-  const parsed = decimal(value);
-  return parsed === null ? value : parsed.toLocaleString("zh-CN", { maximumFractionDigits: fractionDigits });
-}
-
-function dateKey(value: string, period: ChartPeriod): string {
-  if (period === "day") return value;
-  if (period === "month") return value.slice(0, 7);
-  if (period === "year") return value.slice(0, 4);
-  const date = new Date(`${value}T00:00:00Z`);
-  const offset = (date.getUTCDay() + 6) % 7;
-  date.setUTCDate(date.getUTCDate() - offset);
-  return date.toISOString().slice(0, 10);
-}
-
-function toNumericBars(bars: EtfDailyBar): NumericBar | null {
-  const values = [bars.open, bars.high, bars.low, bars.close, bars.vol, bars.amount].map(decimal);
-  if (values.some((value) => value === null)) return null;
-  const [open, high, low, close, vol, amount] = values as number[];
-  return { tradeDate: bars.trade_date, open, high, low, close, vol, amount };
-}
-
-function toNumericBarList(sourceBars: EtfDailyBar[]): NumericBar[] {
-  return sourceBars.map(toNumericBars).filter((bar): bar is NumericBar => bar !== null);
-}
-
-function matchAdjustmentFactors(
-  rawBars: NumericBar[],
-  factors: EtfAdjustmentFactor[]
-): MatchedAdjustmentBar[] | null {
-  // A valid cumulative factor is required for every plotted trading session.
-  // Falling back to an unadjusted price would silently mix price bases.
-  const factorByDate = new Map(factors.map((factor) => [factor.trade_date, decimal(factor.adj_factor)]));
-  const matched = rawBars.map((bar) => ({ bar, factor: factorByDate.get(bar.tradeDate) }));
-  if (matched.some(({ factor }) => factor === null || factor === undefined || factor <= 0)) return null;
-  return matched.map(({ bar, factor }) => ({ bar, factor: factor! }));
-}
-
-function adjustedBars(
-  sourceBars: EtfDailyBar[],
-  factors: EtfAdjustmentFactor[],
-  adjustment: AdjustmentMode
-): NumericBar[] | null {
-  const rawBars = toNumericBarList(sourceBars);
-  if (adjustment === "raw") return rawBars;
-
-  // Tushare factors are normalized against the selected range endpoint so that
-  // forward-adjusted prices end at the raw latest price and backward-adjusted
-  // prices start at the raw earliest price.
-  const matched = matchAdjustmentFactors(rawBars, factors);
-  if (matched === null) return null;
-
-  const anchor = adjustment === "forward" ? matched.at(-1)?.factor : matched[0]?.factor;
-  if (!anchor || anchor <= 0) return null;
-  return matched.map(({ bar, factor }) => {
-    const multiplier = factor! / anchor;
-    return {
-      ...bar,
-      open: bar.open * multiplier,
-      high: bar.high * multiplier,
-      low: bar.low * multiplier,
-      close: bar.close * multiplier
-    };
-  });
-}
-
-function summarizeAdjustmentFactors(
-  sourceBars: EtfDailyBar[],
-  factors: EtfAdjustmentFactor[]
-): AdjustmentFactorSummary | null {
-  const matched = matchAdjustmentFactors(toNumericBarList(sourceBars), factors);
-  if (matched === null || matched.length === 0) return null;
-
-  let changeCount = 0;
-  for (let index = 1; index < matched.length; index += 1) {
-    if (matched[index]!.factor !== matched[index - 1]!.factor) changeCount += 1;
-  }
-  return {
-    first: matched[0]!.factor,
-    last: matched.at(-1)!.factor,
-    changeCount
-  };
-}
-
-function aggregateBars(bars: NumericBar[], period: ChartPeriod): NumericBar[] {
-  // Aggregation happens after adjustment.  This preserves the selected price
-  // basis while applying the conventional OHLC and volume roll-up rules.
-  const buckets = new Map<string, NumericBar[]>();
-  for (const bar of bars) {
-    const key = dateKey(bar.tradeDate, period);
-    buckets.set(key, [...(buckets.get(key) ?? []), bar]);
-  }
-  return [...buckets.values()].map((bucket) => ({
-    tradeDate: bucket.at(-1)!.tradeDate,
-    open: bucket[0].open,
-    high: Math.max(...bucket.map((bar) => bar.high)),
-    low: Math.min(...bucket.map((bar) => bar.low)),
-    close: bucket.at(-1)!.close,
-    vol: bucket.reduce((sum, bar) => sum + bar.vol, 0),
-    amount: bucket.reduce((sum, bar) => sum + bar.amount, 0)
-  }));
-}
-
-function withinDateRange(value: string, startDate: string, endDate: string): boolean {
-  return (!startDate || value >= startDate) && (!endDate || value <= endDate);
-}
-
-function movingAverage(bars: NumericBar[], length: number): (number | null)[] {
-  return bars.map((_, index) => {
-    if (index + 1 < length) return null;
-    const closes = bars.slice(index + 1 - length, index + 1).map((bar) => bar.close);
-    return closes.reduce((sum, value) => sum + value, 0) / length;
-  });
-}
-
-function kLineTimestamp(tradeDate: string): number {
-  const timestamp = Date.parse(`${tradeDate}T00:00:00Z`);
-  return Number.isFinite(timestamp) ? timestamp : 0;
-}
-
-function chartNumber(value: number, fractionDigits = 4): string {
-  return value.toLocaleString("zh-CN", { maximumFractionDigits: fractionDigits });
-}
-
-function chartVolume(value: number): string {
-  const absolute = Math.abs(value);
-  if (absolute >= 100_000_000) return `${(value / 100_000_000).toFixed(2)} 亿`;
-  if (absolute >= 10_000) return `${(value / 10_000).toFixed(2)} 万`;
-  return value.toLocaleString("zh-CN", { maximumFractionDigits: 0 });
-}
-
-function adjustmentFactorText(value: number): string {
-  return value.toLocaleString("zh-CN", { maximumFractionDigits: 12 });
-}
-
-function adjustmentNotice(
-  adjustment: AdjustmentMode,
-  summary: AdjustmentFactorSummary | null
-): string | null {
-  if (adjustment === "raw" || summary === null) return null;
-  const label = ADJUSTMENT_LABELS[adjustment];
-  if (summary.changeCount === 0) {
-    return `${label}：当前日期筛选范围内复权因子未变化，K 线价格与不复权一致。`;
-  }
-  return `${label}：已按复权因子调整（${adjustmentFactorText(summary.first)} → ${adjustmentFactorText(summary.last)}，共 ${summary.changeCount} 次变动）。`;
-}
-
-const KLINE_PERIOD_TYPES: Record<ChartPeriod, KLineChartPeriod> = {
-  day: "day",
-  week: "week",
-  month: "month",
-  year: "year"
-};
-
-const KLINE_CHART_OPTIONS = {
-  locale: "zh-CN",
-  timezone: "Asia/Shanghai",
-  zoomAnchor: "cursor" as const,
-  layout: {
-    barSpaceLimit: { min: 1, max: 50 },
-    pane: { minHeight: 30, dragEnabled: false },
-    yAxis: {
-      position: "right" as const,
-      inside: false,
-      scrollZoomEnabled: false,
-      gap: { top: 0.16, bottom: 0.12 }
-    }
-  },
-  styles: {
-    grid: {
-      show: true,
-      horizontal: { show: true, style: "solid" as const, size: 1, color: "#343940" },
-      vertical: { show: true, style: "solid" as const, size: 1, color: "#2b3037" }
-    },
-    candle: {
-      type: "candle_solid" as const,
-      bar: {
-        compareRule: "current_open" as const,
-        upColor: KLINE_UP_COLOR,
-        downColor: KLINE_DOWN_COLOR,
-        noChangeColor: "#8c96a6",
-        upBorderColor: KLINE_UP_COLOR,
-        downBorderColor: KLINE_DOWN_COLOR,
-        noChangeBorderColor: "#8c96a6",
-        upWickColor: KLINE_UP_COLOR,
-        downWickColor: KLINE_DOWN_COLOR,
-        noChangeWickColor: "#8c96a6"
-      },
-      priceMark: {
-        show: true,
-        high: { show: false },
-        low: { show: false },
-        // The latest price is presented in the compact summary above the plot.
-        last: { show: false }
-      },
-      tooltip: { showRule: "follow_cross" as const, showType: "standard" as const }
-    },
-    indicator: {
-      bars: [{
-        style: "fill" as const,
-        borderSize: 0,
-        upColor: "rgba(243, 91, 105, 0.72)",
-        downColor: "rgba(69, 204, 145, 0.72)",
-        noChangeColor: "rgba(140, 150, 166, 0.72)"
-      }],
-      lines: MOVING_AVERAGE_LENGTHS.map((length) => ({ style: "solid" as const, smooth: false, size: 2, color: KLINE_MA_COLORS[length] })),
-      lastValueMark: { show: false },
-      tooltip: { showRule: "follow_cross" as const }
-    },
-    xAxis: {
-      show: true,
-      size: 28,
-      axisLine: { show: true, color: "#343940", size: 1 },
-      tickLine: { show: false },
-      tickText: { show: true, color: "#aab4c4", size: 11, marginStart: 4, marginEnd: 4 }
-    },
-    yAxis: {
-      show: true,
-      size: 64,
-      axisLine: { show: true, color: "#343940", size: 1 },
-      tickLine: { show: false },
-      tickText: { show: true, color: "#aab4c4", size: 11, marginStart: 4, marginEnd: 5 }
-    },
-    separator: { size: 1, color: "#343940", fill: true, activeBackgroundColor: "rgba(52, 57, 64, 0.2)" },
-    crosshair: {
-      show: true,
-      horizontal: {
-        show: true,
-        line: { show: true, style: "dashed" as const, dashedValue: [4, 2], size: 1, color: "#718096" },
-        text: { show: true, color: "#ffffff", size: 11, backgroundColor: "#343940", borderColor: "#343940", borderSize: 0, borderRadius: 3 }
-      },
-      vertical: {
-        show: true,
-        line: { show: true, style: "dashed" as const, dashedValue: [4, 2], size: 1, color: "#718096" },
-        text: { show: true, color: "#ffffff", size: 11, backgroundColor: "#343940", borderColor: "#343940", borderSize: 0, borderRadius: 3 }
-      }
-    }
-  }
-};
-
-function InteractiveKLineChart({
-  bars,
-  historyBars,
-  period,
-  visibleCount,
-  visibleAverages,
-  adjustment
-}: {
-  bars: NumericBar[];
-  historyBars: NumericBar[];
-  period: ChartPeriod;
-  visibleCount: number | null;
-  visibleAverages: Record<MovingAverageLength, boolean>;
-  adjustment: AdjustmentMode;
-}) {
-  const containerRef = useRef<HTMLDivElement>(null);
-  const orderedBars = useMemo(() => [...bars].sort((left, right) => left.tradeDate.localeCompare(right.tradeDate)), [bars]);
-  const orderedHistoryBars = useMemo(() => [...historyBars].sort((left, right) => left.tradeDate.localeCompare(right.tradeDate)), [historyBars]);
-  const latestBar = orderedBars.at(-1);
-
-  useEffect(() => {
-    const container = containerRef.current;
-    if (!container || orderedBars.length === 0) return;
-
-    const historyAverages = new Map<string, Record<string, number | null>>();
-    for (const length of MOVING_AVERAGE_LENGTHS) {
-      const values = movingAverage(orderedHistoryBars, length);
-      values.forEach((value, index) => {
-        const date = orderedHistoryBars[index]?.tradeDate;
-        if (!date) return;
-        historyAverages.set(date, { ...(historyAverages.get(date) ?? {}), [`ma${length}`]: value });
-      });
-    }
-    const chartData: KLineChartBar[] = orderedBars.map((bar) => ({
-      timestamp: kLineTimestamp(bar.tradeDate),
-      open: bar.open,
-      high: bar.high,
-      low: bar.low,
-      close: bar.close,
-      volume: bar.vol,
-      turnover: bar.amount,
-      ...(historyAverages.get(bar.tradeDate) ?? {})
-    }));
-
-    const chart = initKLineChart(container, KLINE_CHART_OPTIONS);
-    if (!chart) return;
-    // KLineChart otherwise keeps two bars visible at either edge, allowing a
-    // pan gesture to leave most of the viewport empty. Zero-distance limits
-    // keep every draggable position inside the available market data.
-    chart.setMaxOffsetLeftDistance(0);
-    chart.setMaxOffsetRightDistance(0);
-    chart.setOffsetRightDistance(0);
-    // KLineChart normally interprets a drag on the x-axis strip as a zoom
-    // gesture.  That makes a horizontal pan change behaviour near the chart
-    // boundary, so keep one predictable rule: dragging reviews history and
-    // the mouse wheel is the only direct zoom control.
-    chart.overrideXAxis({ scrollZoomEnabled: false });
-    chart.setSymbol({ ticker: "ETF", pricePrecision: 4, volumePrecision: 0 });
-    chart.setPeriod({ span: 1, type: KLINE_PERIOD_TYPES[period] });
-    chart.setDataLoader({
-      getBars: ({ callback }) => callback(chartData, false)
-    });
-
-    const activeAverages = MOVING_AVERAGE_LENGTHS.filter((length) => visibleAverages[length] && orderedHistoryBars.length >= length);
-    if (activeAverages.length > 0) {
-      chart.createIndicator({
-        name: KLINE_MA_INDICATOR_NAME,
-        paneId: "candle_pane",
-        calcParams: activeAverages,
-        styles: { lines: activeAverages.map((length) => ({ color: KLINE_MA_COLORS[length], size: 2 })) }
-      }, true);
-    }
-    const volumePaneId = chart.createIndicator({
-      name: "VOL",
-      calcParams: [],
-      styles: { lastValueMark: { show: false } }
-    }, false);
-    if (volumePaneId) chart.setPaneOptions({ id: volumePaneId, height: 92, minHeight: 76, dragEnabled: false });
-    // Apply the selected density after the first measurable layout, then align
-    // the newest bar to the data boundary without introducing blank space.
-    let viewportInitialized = false;
-    const initializeViewport = () => {
-      if (viewportInitialized || container.clientWidth <= 0) return;
-      const plotWidth = Math.max(container.clientWidth - 90, 1);
-      const targetBarCount = visibleCount === null ? orderedBars.length : Math.min(visibleCount, orderedBars.length);
-      const barSpace = Math.min(50, Math.max(1, plotWidth / Math.max(targetBarCount, 1)));
-      chart.setBarSpace(barSpace);
-      chart.setOffsetRightDistance(0);
-      chart.scrollToRealTime();
-      viewportInitialized = true;
-    };
-    const animationFrame = window.requestAnimationFrame(initializeViewport);
-    const observer = new ResizeObserver(() => {
-      initializeViewport();
-    });
-    observer.observe(container);
-    return () => {
-      window.cancelAnimationFrame(animationFrame);
-      observer.disconnect();
-      disposeKLineChart(chart);
-    };
-  }, [orderedBars, orderedHistoryBars, period, visibleAverages, visibleCount]);
-
-  if (!latestBar) return null;
-  const priceDirection = latestBar.close >= latestBar.open ? "up" : "down";
-  const closeLabel = adjustment === "raw" ? "收盘" : `${ADJUSTMENT_LABELS[adjustment]}收盘`;
-  return <div className="etf-kline-wrap">
-    <div className="etf-kline__summary" aria-label="最新行情">
-      <span className="etf-kline__summary-date">{formatDate(latestBar.tradeDate)}</span>
-      <span className="etf-kline__summary-item"><span>{closeLabel}</span><strong className={`etf-kline__summary-value etf-kline__summary-value--${priceDirection}`}>{chartNumber(latestBar.close)}</strong></span>
-      <span className="etf-kline__summary-item"><span>成交量</span><strong>{chartVolume(latestBar.vol)}</strong></span>
+function Kv({ label, children }: { label: string; children: React.ReactNode }) {
+  return (
+    <div className="qfe-cell">
+      <dt>{label}</dt>
+      <dd>{children}</dd>
     </div>
-    <div ref={containerRef} className="etf-kline" aria-label="可缩放、可在数据范围内横向拖拽回看的 ETF K 线图" />
-  </div>;
+  );
 }
 
 export function EtfDetailPage() {
-  const { tsCode = "" } = useParams();
-  const location = useLocation();
-  const { logout } = useAuth();
-  const navigate = useNavigate();
+  const { tsCode = "" } = useParams(),
+    navigate = useNavigate(),
+    location = useLocation(),
+    { logout } = useAuth();
   const [searchParams, setSearchParams] = useSearchParams();
-  const tab = (searchParams.get("tab") === "daily" || searchParams.get("tab") === "factors" ? searchParams.get("tab") : "basic") as DetailTab;
-  const [etf, setEtf] = useState<EtfCode | null>(null);
-  const [dailyBars, setDailyBars] = useState<EtfDailyBar[]>([]);
-  const [factors, setFactors] = useState<EtfAdjustmentFactor[]>([]);
-  const [startDate, setStartDate] = useState("");
-  const [endDate, setEndDate] = useState("");
-  const [period, setPeriod] = useState<ChartPeriod>("day");
-  const [adjustment, setAdjustment] = useState<AdjustmentMode>("raw");
-  const [visibleCount, setVisibleCount] = useState<number | null>(200);
-  const [visibleAverages, setVisibleAverages] = useState<Record<MovingAverageLength, boolean>>({ 5: true, 10: true, 20: true });
-  const [loading, setLoading] = useState(true);
-  const [seriesLoading, setSeriesLoading] = useState(false);
-  const [error, setError] = useState<string | null>(null);
-  const chartShellRef = useRef<HTMLElement>(null);
-  const [isChartFullscreen, setIsChartFullscreen] = useState(false);
-
-  const handleError = useCallback((caught: unknown, fallback: string) => {
-    if (caught instanceof DataCollectionApiError && caught.status === 401) {
-      logout(); navigate("/login", { replace: true }); return;
-    }
-    setError(caught instanceof Error ? caught.message : fallback);
-  }, [logout, navigate]);
-
-  useEffect(() => {
-    let active = true;
-    setLoading(true); setError(null);
-    void getEtf(tsCode).then((value) => { if (active) setEtf(value); }).catch((caught) => { if (active) handleError(caught, "ETF 详情加载失败。"); }).finally(() => { if (active) setLoading(false); });
-    return () => { active = false; };
-  }, [handleError, tsCode]);
-
-  const loadSeries = useCallback(async () => {
-    setSeriesLoading(true); setError(null);
-    try {
-      const [nextBars, nextFactors] = await Promise.all([
-        listEtfDailyBars(tsCode, {}),
-        listEtfAdjustmentFactors(tsCode, {})
-      ]);
-      setDailyBars(nextBars); setFactors(nextFactors);
-    } catch (caught) {
-      handleError(caught, "ETF 时序数据加载失败。");
-    } finally {
-      setSeriesLoading(false);
-    }
-  }, [handleError, tsCode]);
-
-  useEffect(() => { if (tab !== "basic") void loadSeries(); }, [loadSeries, tab]);
-
-  useEffect(() => {
-    const syncFullscreenState = () => setIsChartFullscreen(document.fullscreenElement === chartShellRef.current);
-    document.addEventListener("fullscreenchange", syncFullscreenState);
-    return () => document.removeEventListener("fullscreenchange", syncFullscreenState);
-  }, []);
-
-  const hasInvalidDateRange = Boolean(startDate && endDate && startDate > endDate);
-  const selectedDailyBars = useMemo(
-    () => hasInvalidDateRange ? [] : dailyBars.filter((bar) => withinDateRange(bar.trade_date, startDate, endDate)),
-    [dailyBars, endDate, hasInvalidDateRange, startDate]
-  );
-  const fullChartBars = useMemo(() => {
-    const adjusted = adjustedBars(dailyBars, factors, adjustment);
-    return adjusted === null ? null : aggregateBars(adjusted, period);
-  }, [adjustment, dailyBars, factors, period]);
-  const chartBars = useMemo(() => {
-    if (hasInvalidDateRange) return [];
-    return fullChartBars?.filter((bar) => withinDateRange(bar.tradeDate, startDate, endDate)) ?? null;
-  }, [endDate, fullChartBars, hasInvalidDateRange, startDate]);
-  const adjustmentSummary = useMemo(
-    () => adjustment === "raw" ? null : summarizeAdjustmentFactors(selectedDailyBars, factors),
-    [adjustment, factors, selectedDailyBars]
-  );
-  const currentAdjustmentNotice = adjustmentNotice(adjustment, adjustmentSummary);
-  const visibleFactors = useMemo(
-    () => factors.filter((factor) => withinDateRange(factor.trade_date, startDate, endDate)),
-    [endDate, factors, startDate]
-  );
-  const availableAverages: Record<MovingAverageLength, boolean> = {
-    5: (fullChartBars?.length ?? 0) >= 5,
-    10: (fullChartBars?.length ?? 0) >= 10,
-    20: (fullChartBars?.length ?? 0) >= 20
-  };
-  const displayName = etf?.csname ?? etf?.extname ?? etf?.ts_code ?? tsCode;
-  const toggleChartFullscreen = useCallback(async () => {
-    const chartShell = chartShellRef.current;
-    if (!chartShell) return;
-    try {
-      if (document.fullscreenElement === chartShell) {
-        await document.exitFullscreen();
-      } else {
-        await chartShell.requestFullscreen();
+  const tab =
+    searchParams.get("tab") === "factors"
+      ? "factors"
+      : searchParams.get("tab") === "overview"
+        ? "overview"
+        : "basic";
+  const [snapshot, setSnapshot] = useState<Snapshot | null>(null),
+    [loading, setLoading] = useState(true),
+    [error, setError] = useState(""),
+    [refresh, setRefresh] = useState(0);
+  const [period, setPeriod] = useState<Period>("day"),
+    [adjustment, setAdjustment] = useState<Adjustment>("raw"),
+    [indicators, setIndicators] =
+      useState<IndicatorSettings>(DEFAULT_INDICATORS);
+  const [range, setRange] = useState({ start: "", end: "" }),
+    [rangeDraft, setRangeDraft] = useState({ start: "", end: "" });
+  const [replay, setReplay] = useState<{ code: string; date: string } | null>(
+      null,
+    ),
+    [replayDate, setReplayDate] = useState(""),
+    [playing, setPlaying] = useState(false),
+    [speed, setSpeed] = useState(1);
+  const [anchor, setAnchor] = useState<PopoverAnchor | null>(null),
+    [params, setParams] = useState<number[]>([]),
+    [formError, setFormError] = useState("");
+  const [tool, setTool] = useState("cursor"),
+    [annotation, setAnnotation] = useState(""),
+    [selected, setSelected] = useState(false);
+  const [side, setSide] = useState(() => innerWidth > 1080),
+    [fullscreen, setFullscreen] = useState(false),
+    [notice, setNotice] = useState("");
+  const [inspected, setInspected] = useState<Bar | null>(null),
+    [visibleRange, setVisibleRange] = useState(""),
+    [factorPage, setFactorPage] = useState(0);
+  const root = useRef<HTMLElement>(null),
+    chart = useRef<ChartHandle>(null),
+    sideTrigger = useRef<HTMLButtonElement>(null);
+  const authError = useCallback(
+    (caught: unknown) => {
+      if (caught instanceof DataCollectionApiError && caught.status === 401) {
+        logout();
+        navigate("/login", { replace: true });
       }
-    } catch {
-      setError("无法切换 K 线图全屏显示，请检查浏览器权限后重试。");
-    }
+    },
+    [logout, navigate],
+  );
+  useEffect(() => {
+    const controller = new AbortController();
+    setLoading(true);
+    setError("");
+    void (async () => {
+      const results = await Promise.allSettled([
+        getEtf(tsCode, controller.signal),
+        listEtfDailyBars(tsCode, {}, controller.signal),
+        listEtfAdjustmentFactors(tsCode, {}, controller.signal),
+      ]);
+      if (controller.signal.aborted) return;
+      for (const result of results)
+        if (result.status === "rejected") authError(result.reason);
+      if (results[0].status === "rejected") throw results[0].reason;
+      if (results[1].status === "rejected") throw results[1].reason;
+      const etf = results[0].value,
+        daily = [...results[1].value].sort((a, b) =>
+          a.trade_date.localeCompare(b.trade_date),
+        );
+      const factorResult = results[2];
+      setSnapshot((prior) => ({
+        code: tsCode,
+        etf,
+        daily,
+        factors:
+          factorResult.status === "fulfilled"
+            ? factorResult.value
+            : prior?.code === tsCode
+              ? prior.factors
+              : [],
+        factorError:
+          factorResult.status === "fulfilled"
+            ? ""
+            : `复权因子刷新失败：${message(factorResult.reason)}`,
+      }));
+    })()
+      .catch((caught) => {
+        if (!controller.signal.aborted) setError(message(caught));
+      })
+      .finally(() => {
+        if (!controller.signal.aborted) setLoading(false);
+      });
+    return () => controller.abort();
+  }, [tsCode, refresh, authError]);
+  useEffect(() => {
+    setReplay(null);
+    setPlaying(false);
+    setInspected(null);
+    setRange({ start: "", end: "" });
+    setFactorPage(0);
+    setAnchor(null);
+    setTool("cursor");
+    setNotice("");
+  }, [tsCode]);
+  useEffect(() => {
+    const sync = () =>
+      setFullscreen(document.fullscreenElement === root.current);
+    document.addEventListener("fullscreenchange", sync);
+    return () => document.removeEventListener("fullscreenchange", sync);
   }, []);
-
-  if (loading) return <section className="collection-page"><div className="collection-empty-state">正在加载 ETF 详情…</div></section>;
-  if (!etf) return <section className="collection-page"><div className="collection-empty-state">{error ?? "ETF 不存在。"}</div></section>;
-
-  return <section className="collection-page etf-detail-page" aria-labelledby="etf-detail-title">
-    <button className="etf-detail__back" type="button" onClick={() => navigate(marketReturnTo(location.state?.marketReturnTo)) }><ChevronLeft aria-hidden="true" />返回 ETF 列表</button>
-    <div className="page-heading etf-detail__heading"><div><div className="etf-detail__title"><h2 id="etf-detail-title">{displayName}</h2><span>{etf.ts_code}</span></div><p>查看该 ETF 的基础资料、日线行情与复权因子</p></div></div>
-    {error && <div className="page-error" role="alert">{error}</div>}
-    {/* Tab URL changes must retain the originating market filters in history. */}
-    <div className="etf-detail__tabs" role="tablist" aria-label="ETF 详情页签">{TABS.map((item) => <button key={item.key} className={tab === item.key ? "active" : ""} type="button" role="tab" aria-selected={tab === item.key} onClick={() => setSearchParams(item.key === "basic" ? {} : { tab: item.key }, { state: location.state })}>{item.label}</button>)}</div>
-    {tab === "basic" && <section className="collection-table etf-detail__basic"><div className="collection-table__heading"><div><h3>基础资料</h3><span>ETF 基础信息的当前数据</span></div></div><dl><div><dt>交易所</dt><dd>{exchangeLabel(etf.exchange)}</dd></div><div><dt>上市状态</dt><dd>{statusLabel(etf.list_status)}</dd></div><div><dt>上市日期</dt><dd>{formatDate(etf.list_date)}</dd></div><div><dt>跟踪指数</dt><dd>{etf.index_name ?? "—"}</dd></div><div><dt>管理人</dt><dd>{etf.mgr_name ?? "—"}</dd></div><div><dt>管理费率</dt><dd>{etf.mgt_fee ? `${numberText(etf.mgt_fee)}%` : "—"}</dd></div></dl></section>}
-    {tab !== "basic" && <>
-      <div className="etf-detail__filters">
-        <label className="etf-detail__filter-field etf-detail__filter-field--start">
-          <span>开始日期</span>
-          <input type="date" value={startDate} aria-describedby="etf-detail-date-filter-help" aria-invalid={hasInvalidDateRange} onChange={(event) => setStartDate(event.target.value)} />
-        </label>
-        <label className="etf-detail__filter-field etf-detail__filter-field--end">
-          <span>结束日期</span>
-          <input type="date" value={endDate} aria-describedby="etf-detail-date-filter-help" aria-invalid={hasInvalidDateRange} onChange={(event) => setEndDate(event.target.value)} />
-        </label>
-        <button className="toolbar-button" type="button" title="重新请求完整历史数据；日期筛选会立即作用于当前视图。" disabled={seriesLoading || hasInvalidDateRange} onClick={() => void loadSeries()}><RefreshCw className={seriesLoading ? "spin" : ""} aria-hidden="true" />重新加载数据</button>
-        <div className="etf-detail__filter-feedback" id="etf-detail-date-filter-help">
-          <span>日期筛选即时生效；留空表示全部日线数据。</span>
-          {hasInvalidDateRange && <strong role="alert">开始日期不能晚于结束日期。</strong>}
+  useEffect(() => {
+    if (!notice) return;
+    const timer = setTimeout(() => setNotice(""), 6000);
+    return () => clearTimeout(timer);
+  }, [notice]);
+  useEffect(() => {
+    const escape = (event: KeyboardEvent) => {
+      if (event.key !== "Escape" || anchor) return;
+      chart.current?.cancel();
+      setTool("cursor");
+      if (innerWidth <= 1080 && side) {
+        setSide(false);
+        sideTrigger.current?.focus();
+      }
+    };
+    document.addEventListener("keydown", escape);
+    return () => document.removeEventListener("keydown", escape);
+  }, [anchor, side]);
+  const data = snapshot?.code === tsCode ? snapshot : null,
+    etf = data?.etf;
+  const daily = data?.daily ?? EMPTY_DAILY,
+    factors = data?.factors ?? EMPTY_FACTORS;
+  const cutoff = replay?.code === tsCode ? replay.date : undefined;
+  const replayIndex = cutoff
+    ? daily.findIndex((row) => row.trade_date === cutoff)
+    : -1;
+  useEffect(() => {
+    if (!playing || !cutoff || replayIndex < 0) return;
+    if (replayIndex >= daily.length - 1) {
+      setPlaying(false);
+      return;
+    }
+    const timer = setTimeout(
+      () =>
+        setReplay({ code: tsCode, date: daily[replayIndex + 1].trade_date }),
+      1000 / speed,
+    );
+    return () => clearTimeout(timer);
+  }, [playing, cutoff, daily, replayIndex, speed, tsCode]);
+  const series = useMemo(
+    () => buildSeries(daily, factors, adjustment, period, cutoff),
+    [daily, factors, adjustment, period, cutoff],
+  );
+  const dailyVisible = useMemo(
+    () => daily.filter((row) => !cutoff || row.trade_date <= cutoff),
+    [daily, cutoff],
+  );
+  const latest = dailyVisible.at(-1),
+    bar =
+      inspected &&
+      series.bars.some((item) => item.timestamp === inspected.timestamp)
+        ? inspected
+        : series.bars.at(-1);
+  const visibleFactors = useMemo(
+    () =>
+      factors
+        .filter(
+          (row) =>
+            (!cutoff || row.trade_date <= cutoff) &&
+            (!range.start || row.trade_date >= range.start) &&
+            (!range.end || row.trade_date <= range.end),
+        )
+        .sort((a, b) => b.trade_date.localeCompare(a.trade_date)),
+    [factors, cutoff, range],
+  );
+  useEffect(() => {
+    setFactorPage((page) =>
+      Math.min(page, Math.max(0, Math.ceil(visibleFactors.length / 20) - 1)),
+    );
+  }, [visibleFactors.length]);
+  const inRange =
+    Boolean(cutoff) ||
+    series.bars.some(
+      (row) =>
+        (!range.start || row.date >= range.start) &&
+        (!range.end || row.date <= range.end),
+    );
+  const open = (key: string, element: HTMLElement) => {
+    setFormError("");
+    setAnchor((prior) => (prior?.key === key ? null : { key, element }));
+  };
+  const close = () => setAnchor(null);
+  const chooseTool = (name: string, element: HTMLElement) => {
+    if (!series.bars.length) return;
+    setPlaying(false);
+    if (name === "simpleAnnotation") {
+      setAnnotation("");
+      open("annotation", element);
+      return;
+    }
+    chart.current?.cancel();
+    if (name !== "cursor" && name !== "zoom") chart.current?.draw(name);
+    setTool(name);
+  };
+  const toggleFullscreen = async () => {
+    try {
+      if (document.fullscreenElement === root.current)
+        await document.exitFullscreen();
+      else await root.current?.requestFullscreen();
+    } catch {
+      setNotice("无法切换全屏，请检查浏览器权限后重试。");
+    }
+  };
+  const selectCode = (code: string) => {
+    if (code !== tsCode)
+      navigate(`/admin/data/etf-basics/${encodeURIComponent(code)}`, {
+        state: {
+          marketReturnTo: marketReturnTo(location.state?.marketReturnTo),
+        },
+      });
+  };
+  const setInfoTab = (value: string) => {
+    const next = new URLSearchParams(searchParams);
+    if (value === "basic") next.delete("tab");
+    else next.set("tab", value);
+    setSearchParams(next, { state: location.state, replace: true });
+  };
+  const indicatorKey = anchor?.key.startsWith("params:")
+    ? anchor.key.slice(7)
+    : "";
+  return (
+    <section ref={root} className="qfe" aria-label="ETF 行情工作区">
+      <header className="qfe-topbar">
+        <div className="qfe-brand">
+          <span className="qfe-mark">QF</span>
+          <strong>Quant Foundry</strong>
         </div>
+        <div className="qfe-crumb">
+          <button
+            className="qfe-back"
+            title="返回 A 股市场"
+            onClick={() =>
+              navigate(marketReturnTo(location.state?.marketReturnTo))
+            }
+          >
+            <ArrowLeft />
+            <span>返回 A 股市场</span>
+          </button>
+          <span className="qfe-breadcrumb">
+            MARKET / A-SHARE / ETF WORKSPACE
+          </span>
+        </div>
+        <div className="qfe-quotes" title="未接入实时买卖盘">
+          <span>
+            卖 <strong>—</strong>
+          </span>
+          <span>
+            买 <strong>—</strong>
+          </span>
+        </div>
+        <div className="qfe-symbol">{tsCode}</div>
+        <div className="qfe-top-actions">
+          <button
+            ref={sideTrigger}
+            title="侧栏"
+            aria-label="切换资料侧栏"
+            aria-expanded={side}
+            onClick={() => setSide((v) => !v)}
+          >
+            <PanelRight />
+            <span>侧栏</span>
+          </button>
+          <button
+            className="qfe-top-alert"
+            title="警报未接入"
+            aria-label="警报未接入"
+            aria-disabled="true"
+            onClick={() =>
+              setNotice("价格警报尚未接入；本页用于历史行情研究。")
+            }
+          >
+            <Bell />
+          </button>
+          <button
+            className="qfe-primary"
+            title="刷新数据"
+            aria-label="刷新数据"
+            disabled={loading}
+            onClick={() => {
+              setPlaying(false);
+              setRefresh((v) => v + 1);
+            }}
+          >
+            <RefreshCw className={loading ? "spin" : ""} />
+            <span>{loading ? "刷新中…" : "刷新数据"}</span>
+          </button>
+        </div>
+      </header>
+      <div className={`qfe-workspace ${side ? "qfe-side-open" : ""}`}>
+        <aside className="qfe-tools" aria-label="绘图工具">
+          {[
+            ["cursor", MousePointer2],
+            ["segment", Slash],
+            ["parallelStraightLine", ChevronsUpDown],
+            ["fibonacciLine", ChartCandlestick],
+            ["simpleAnnotation", TextCursorInput],
+            ["qfRuler", Ruler],
+            ["zoom", ZoomIn],
+          ].map(([name, Icon]) => {
+            const key = name as string,
+              ToolIcon = Icon as typeof MousePointer2;
+            return (
+              <button
+                key={key}
+                className={tool === key ? "active" : ""}
+                aria-label={TOOL_LABELS[key]}
+                title={TOOL_LABELS[key]}
+                aria-pressed={tool === key}
+                disabled={!series.bars.length}
+                onClick={(e) => chooseTool(key, e.currentTarget)}
+              >
+                <ToolIcon />
+              </button>
+            );
+          })}
+          <button
+            aria-label="删除选中绘图"
+            title="删除选中绘图"
+            disabled={!selected}
+            onClick={() => chart.current?.removeSelected()}
+          >
+            <Trash2 />
+          </button>
+        </aside>
+        <div className="qfe-chart-top">
+          <span className="qfe-control-label">周期</span>
+          <button onClick={(e) => open("period", e.currentTarget)}>
+            1 {PERIODS[period]}
+            <ChevronDown />
+          </button>
+          <div className="qfe-button-group">
+            <button onClick={(e) => open("indicators", e.currentTarget)}>
+              指标
+            </button>
+            <button
+              aria-disabled="true"
+              onClick={() =>
+                setNotice("价格警报尚未接入；本页用于历史行情研究。")
+              }
+            >
+              警报
+            </button>
+            <button
+              className={cutoff ? "active" : ""}
+              disabled={!daily.length}
+              onClick={(e) => {
+                setPlaying(false);
+                setReplayDate(
+                  cutoff ??
+                    daily[Math.max(0, daily.length - 30)]?.trade_date ??
+                    "",
+                );
+                open("replay", e.currentTarget);
+              }}
+            >
+              回放
+            </button>
+          </div>
+          <div className="qfe-ma-buttons">
+            <span className="qfe-control-label">均线</span>
+            {indicators.ma.map((n, i) => (
+              <button
+                key={i}
+                aria-pressed={indicators.MA && indicators.maVisible[i]}
+                className={
+                  indicators.MA && indicators.maVisible[i] ? "" : "off"
+                }
+                onClick={() =>
+                  setIndicators((v) => ({
+                    ...v,
+                    MA: true,
+                    maVisible: v.maVisible.map((enabled, j) =>
+                      j === i ? !enabled : enabled,
+                    ),
+                  }))
+                }
+              >
+                <i style={{ background: MA_COLORS[i] }} />
+                MA{n}
+              </button>
+            ))}
+          </div>
+          <span className="qfe-spacer" />
+          <button
+            onClick={(e) => {
+              setRangeDraft(range);
+              open("range", e.currentTarget);
+            }}
+          >
+            范围
+          </button>
+          <button
+            aria-label={fullscreen ? "退出全屏" : "全屏"}
+            title={fullscreen ? "退出全屏" : "全屏"}
+            className="qfe-icon"
+            onClick={() => void toggleFullscreen()}
+          >
+            <Expand />
+          </button>
+          <button onClick={(e) => open("adjust", e.currentTarget)}>
+            {ADJUSTMENTS[adjustment]}
+            <ChevronDown />
+          </button>
+        </div>
+        <main className="qfe-stage" aria-busy={loading}>
+          <div className="qfe-chart-caption">
+            <strong>{tsCode}</strong>
+            <span>
+              {ADJUSTMENTS[adjustment]} · {PERIODS[period]}线
+              {cutoff ? ` · 回放至 ${dateText(cutoff)}` : ""}
+            </span>
+          </div>
+          <div className="qfe-ohlc" aria-label="当前查看的行情" aria-live="off">
+            <span>{dateText(bar?.date)}</span>
+            {(
+              [
+                ["开", bar?.open],
+                ["高", bar?.high],
+                ["低", bar?.low],
+                ["收", bar?.close],
+              ] as const
+            ).map(([label, value]) => (
+              <span key={label}>
+                {label} <strong>{numberText(value)}</strong>
+              </span>
+            ))}
+            <span>
+              量 <strong>{numberText(bar?.volume, 2)}</strong> 手
+            </span>
+            <span>
+              额 <strong>{numberText(bar?.turnover, 2)}</strong> 千元
+            </span>
+          </div>
+          <div className="qfe-plot">
+            <EtfChart
+              ref={chart}
+              bars={series.bars}
+              code={tsCode}
+              basis={adjustment}
+              period={period}
+              indicators={indicators}
+              volumeMissing={series.volumeMissing}
+              replay={Boolean(cutoff)}
+              range={range}
+              onInspect={setInspected}
+              onRange={setVisibleRange}
+              onDrawEnd={() => setTool("cursor")}
+              onSelection={setSelected}
+            />
+            <div className="qfe-watermark" aria-hidden="true">
+              Quant Foundry
+            </div>
+            {(!data || !series.bars.length || !inRange) && (
+              <div className="qfe-chart-empty" role="status">
+                {!data
+                  ? loading
+                    ? "正在加载 ETF 行情…"
+                    : error || "ETF 数据不可用。"
+                  : series.error ||
+                    (!series.bars.length
+                      ? "尚未采集日线行情。"
+                      : "所选范围内没有行情，请调整日期范围。")}
+              </div>
+            )}
+            {tool !== "cursor" && (
+              <div className="qfe-tool-status">
+                {tool === "zoom" ? (
+                  <>
+                    <span>缩放视口</span>
+                    <button
+                      aria-label="缩小图表"
+                      onClick={() => chart.current?.zoom(0.8)}
+                    >
+                      <Minus />
+                    </button>
+                    <button
+                      aria-label="放大图表"
+                      onClick={() => chart.current?.zoom(1.25)}
+                    >
+                      <ZoomIn />
+                    </button>
+                    <button onClick={() => chart.current?.reset()}>
+                      <Maximize />
+                      重置
+                    </button>
+                  </>
+                ) : (
+                  <span>{TOOL_HINTS[tool]} · Esc 取消</span>
+                )}
+                <button
+                  aria-label="退出绘图工具"
+                  onClick={() => {
+                    chart.current?.cancel();
+                    setTool("cursor");
+                  }}
+                >
+                  <X />
+                </button>
+              </div>
+            )}
+            {cutoff && (
+              <div className="qfe-replay" aria-label="历史回放控制">
+                <span className="qfe-replay-label">回放</span>
+                <strong>{dateText(cutoff)}</strong>
+                <button
+                  aria-label={playing ? "暂停回放" : "播放回放"}
+                  disabled={
+                    replayIndex < 0 ||
+                    replayIndex >= daily.length - 1 ||
+                    Boolean(series.error)
+                  }
+                  onClick={() => setPlaying((v) => !v)}
+                >
+                  {playing ? <Pause /> : <Play />}
+                </button>
+                <button
+                  aria-label="前进一根日线"
+                  disabled={
+                    replayIndex < 0 ||
+                    replayIndex >= daily.length - 1 ||
+                    Boolean(series.error)
+                  }
+                  onClick={() => {
+                    setPlaying(false);
+                    setReplay({
+                      code: tsCode,
+                      date: daily[replayIndex + 1].trade_date,
+                    });
+                  }}
+                >
+                  <SkipForward />
+                </button>
+                <select
+                  aria-label="回放速度"
+                  value={speed}
+                  onChange={(e) => setSpeed(Number(e.target.value))}
+                >
+                  {[1, 2, 4].map((v) => (
+                    <option key={v} value={v}>
+                      {v}×
+                    </option>
+                  ))}
+                </select>
+                <button
+                  onClick={() => {
+                    setPlaying(false);
+                    setReplay(null);
+                    setInspected(null);
+                  }}
+                >
+                  退出
+                </button>
+                {replayIndex === daily.length - 1 && (
+                  <small>已到最后一条</small>
+                )}
+              </div>
+            )}
+          </div>
+          {((error && data) ||
+            data?.factorError ||
+            series.volumeMissing ||
+            (loading && data)) && (
+            <div className="qfe-data-note" role={error ? "alert" : "status"}>
+              {error && data
+                ? `${error} 当前保留上次成功加载的数据。`
+                : loading
+                  ? "正在刷新，当前显示上次成功加载的数据。"
+                  : data?.factorError ||
+                    "部分成交量缺失，成交量副图暂不显示；价格图仍可查看。"}
+            </div>
+          )}
+        </main>
+        {side && (
+          <>
+            <button
+              className="qfe-side-scrim"
+              aria-label="关闭资料侧栏"
+              onClick={() => {
+                setSide(false);
+                sideTrigger.current?.focus();
+              }}
+            />
+            <aside className="qfe-right" aria-label="ETF 资料与自选">
+              <EtfWatchlist
+                code={tsCode}
+                replay={Boolean(cutoff)}
+                refresh={refresh}
+                onSelect={selectCode}
+                onClose={() => {
+                  setSide(false);
+                  sideTrigger.current?.focus();
+                }}
+                onError={authError}
+              />
+              <div className="qfe-info">
+                <div className="qfe-summary">
+                  <div className="qfe-summary-top">
+                    <span className="qfe-token">ETF</span>
+                    <div>
+                      <h1>{tsCode}</h1>
+                      <p>
+                        {exchangeName(etf?.exchange)} ·{" "}
+                        {etf?.csname ?? etf?.extname ?? "ETF"}
+                      </p>
+                    </div>
+                  </div>
+                  <div className="qfe-summary-price">
+                    <strong>{numberText(latest?.close)}</strong>
+                    <span className={direction(latest?.change)}>
+                      {signed(latest?.change)}
+                    </span>
+                    <span className={direction(latest?.pct_chg)}>
+                      {numeric(latest?.pct_chg) === null
+                        ? "—"
+                        : `${signed(latest?.pct_chg, 2)}%`}
+                    </span>
+                  </div>
+                  <p className="qfe-price-basis">
+                    {dateText(latest?.trade_date)} · 不复权日收盘
+                    {cutoff ? " · 回放" : ""}
+                  </p>
+                  {latest && numeric(latest.pct_chg) === null && (
+                    <p className="qfe-price-basis">历史涨跌字段未采集</p>
+                  )}
+                  <dl className="qfe-summary-grid">
+                    <Kv label="跟踪指数">{etf?.index_name ?? "—"}</Kv>
+                    <Kv label="基金管理人">{etf?.mgr_name ?? "—"}</Kv>
+                    <Kv label="上市日期">{dateText(etf?.list_date)}</Kv>
+                    <Kv label="管理费率">
+                      {numeric(etf?.mgt_fee) === null
+                        ? "—"
+                        : `${numberText(etf?.mgt_fee, 2)}%`}
+                    </Kv>
+                  </dl>
+                </div>
+                <div
+                  className="qfe-info-tabs"
+                  role="tablist"
+                  aria-label="ETF 资料页签"
+                >
+                  {(
+                    [
+                      ["basic", "基础资料"],
+                      ["overview", "概览"],
+                      ["factors", "复权因子"],
+                    ] as const
+                  ).map(([key, label]) => (
+                    <button
+                      key={key}
+                      role="tab"
+                      id={`qfe-tab-${key}`}
+                      aria-selected={tab === key}
+                      aria-controls="qfe-info-panel"
+                      onClick={() => setInfoTab(key)}
+                    >
+                      {label}
+                    </button>
+                  ))}
+                </div>
+                <div
+                  className="qfe-info-panel"
+                  id="qfe-info-panel"
+                  role="tabpanel"
+                  aria-labelledby={`qfe-tab-${tab}`}
+                >
+                  {tab === "basic" && (
+                    <dl className="qfe-kv">
+                      <Kv label="基金代码">{tsCode}</Kv>
+                      <Kv label="基金名称">
+                        {etf?.cname ?? etf?.extname ?? etf?.csname ?? "—"}
+                      </Kv>
+                      <Kv label="交易所">{exchangeName(etf?.exchange)}</Kv>
+                      <Kv label="指数代码">{etf?.index_code ?? "—"}</Kv>
+                      <Kv label="上市状态">
+                        {({ L: "上市", D: "退市", P: "发行" }[
+                          etf?.list_status ?? ""
+                        ] ??
+                          etf?.list_status) ||
+                          "—"}
+                      </Kv>
+                      <Kv label="ETF 类型">{etf?.etf_type ?? "—"}</Kv>
+                    </dl>
+                  )}
+                  {tab === "overview" && (
+                    <>
+                      <p className="qfe-note">
+                        加载全部已采集历史，默认显示最近 200 根 K
+                        线。滚轮缩放，横向拖拽回看；日期范围只调整视口。盘口与价格警报尚未接入。
+                      </p>
+                      <dl className="qfe-kv">
+                        <Kv label="日线记录">{dailyVisible.length} 条</Kv>
+                        <Kv label="复权因子">
+                          {
+                            factors.filter(
+                              (row) => !cutoff || row.trade_date <= cutoff,
+                            ).length
+                          }{" "}
+                          条
+                        </Kv>
+                        <Kv label="日线覆盖">
+                          {dateText(dailyVisible[0]?.trade_date)} —{" "}
+                          {dateText(latest?.trade_date)}
+                        </Kv>
+                        <Kv label="数据来源">{latest?.source ?? "—"}</Kv>
+                        <Kv label="最近同步">{timeText(latest?.updated_at)}</Kv>
+                        <Kv label="量额单位">成交量：手 · 成交额：千元</Kv>
+                      </dl>
+                    </>
+                  )}
+                  {tab === "factors" && (
+                    <>
+                      {data?.factorError && (
+                        <p className="qfe-error">{data.factorError}</p>
+                      )}
+                      <p className="qfe-price-basis">
+                        按日期倒序 · {visibleFactors.length} 条
+                        {cutoff ? " · 已隐藏未来日期" : ""}
+                      </p>
+                      <table className="qfe-factor-table">
+                        <thead>
+                          <tr>
+                            <th>交易日期</th>
+                            <th>复权因子</th>
+                            <th>更新时间</th>
+                          </tr>
+                        </thead>
+                        <tbody>
+                          {visibleFactors
+                            .slice(factorPage * 20, factorPage * 20 + 20)
+                            .map((row) => (
+                              <tr key={row.trade_date}>
+                                <td>{dateText(row.trade_date)}</td>
+                                <td title={`${row.adj_factor} · ${row.source}`}>
+                                  {numberText(row.adj_factor, 6)}
+                                </td>
+                                <td>{timeText(row.updated_at)}</td>
+                              </tr>
+                            ))}
+                        </tbody>
+                      </table>
+                      {!visibleFactors.length && (
+                        <p className="qfe-note">该范围内没有复权因子。</p>
+                      )}
+                      {visibleFactors.length > 20 && (
+                        <div className="qfe-actions">
+                          <button
+                            disabled={!factorPage}
+                            onClick={() => setFactorPage((v) => v - 1)}
+                          >
+                            上一页
+                          </button>
+                          <span>
+                            {factorPage + 1} /{" "}
+                            {Math.ceil(visibleFactors.length / 20)}
+                          </span>
+                          <button
+                            disabled={
+                              (factorPage + 1) * 20 >= visibleFactors.length
+                            }
+                            onClick={() => setFactorPage((v) => v + 1)}
+                          >
+                            下一页
+                          </button>
+                        </div>
+                      )}
+                    </>
+                  )}
+                </div>
+              </div>
+            </aside>
+          </>
+        )}
+        <footer className="qfe-timeline">
+          <span>
+            {series.bars.length && inRange ? visibleRange : "暂无可见行情"}
+          </span>
+          <span>历史行情 · UTC+8</span>
+        </footer>
       </div>
-      {tab === "daily" && <section ref={chartShellRef} className="etf-detail__chart-shell">
-        <div className="etf-detail__chart-heading">
-          <h3>K 线</h3>
-          <button className="etf-detail__expand" type="button" aria-label={isChartFullscreen ? "退出 K 线图全屏" : "全屏显示 K 线图"} onClick={() => void toggleChartFullscreen()}><Expand aria-hidden="true" />{isChartFullscreen ? "退出全屏" : "全屏"}</button>
+      {notice && (
+        <div className="qfe-toast" role="status">
+          {notice}
         </div>
-        <div className="etf-detail__chart-controls">
-          <div>{(["day", "week", "month", "year"] as ChartPeriod[]).map((item) => <button key={item} className={period === item ? "active" : ""} type="button" onClick={() => setPeriod(item)}>{PERIOD_LABELS[item]}</button>)}</div>
-          <div className="etf-detail__ma-toggles">{MOVING_AVERAGE_LENGTHS.map((length) => <button key={length} type="button" aria-pressed={availableAverages[length] && visibleAverages[length]} disabled={!availableAverages[length]} title={availableAverages[length] ? `显示或隐藏 MA${length}` : `至少需要 ${length} 根${PERIOD_KLINE_LABELS[period]}数据`} onClick={() => setVisibleAverages((current) => ({ ...current, [length]: !current[length] }))}><i className={`ma${length}`} aria-hidden="true" />MA{length}</button>)}</div>
-          <div>{(["raw", "forward", "backward"] as AdjustmentMode[]).map((item) => <button key={item} className={adjustment === item ? "active" : ""} type="button" onClick={() => setAdjustment(item)}>{ADJUSTMENT_LABELS[item]}</button>)}</div>
-        </div>
-        <div className="etf-detail__range-controls">{([30, 60, 90, 200, null] as (number | null)[]).map((count) => <button key={count ?? "all"} className={visibleCount === count ? "active" : ""} type="button" onClick={() => setVisibleCount(count)}>{count === null ? "全部" : `${count} ${PERIOD_LABELS[period]}`}</button>)}<span>滚轮缩放；图内横向拖拽回看</span></div>
-        {currentAdjustmentNotice && <p className="etf-detail__adjustment-note" role="status" aria-live="polite">{currentAdjustmentNotice}</p>}
-        {hasInvalidDateRange ? <div className="etf-detail__chart-empty">开始日期不能晚于结束日期。</div> : seriesLoading ? <div className="etf-detail__chart-empty">正在加载日线数据…</div> : chartBars === null || fullChartBars === null ? <div className="etf-detail__chart-empty">所选区间的复权因子不完整，无法生成复权 K 线。</div> : chartBars.length === 0 ? <div className="etf-detail__chart-empty">该日期范围内没有日线数据。</div> : <InteractiveKLineChart bars={chartBars} historyBars={fullChartBars} period={period} visibleCount={visibleCount} visibleAverages={visibleAverages} adjustment={adjustment} />}
-      </section>}
-      {tab === "factors" && <section className="collection-table etf-detail__factor-table"><div className="collection-table__heading"><div><h3>复权因子</h3><span>按交易日期升序展示</span></div><strong>{seriesLoading ? "正在加载…" : `${visibleFactors.length.toLocaleString("zh-CN")} 条`}</strong></div><div className="collection-table__scroll"><table><thead><tr><th>交易日期</th><th>复权因子</th><th>数据来源</th><th>更新时间</th></tr></thead><tbody>{seriesLoading ? <tr><td colSpan={4} className="collection-table__empty">正在加载复权因子…</td></tr> : visibleFactors.length === 0 ? <tr><td colSpan={4} className="collection-table__empty">该日期范围内没有复权因子数据</td></tr> : visibleFactors.map((factor) => <tr key={factor.trade_date}><td>{formatDate(factor.trade_date)}</td><td>{numberText(factor.adj_factor, 12)}</td><td>{factor.source}</td><td>{formatTimestamp(factor.updated_at)}</td></tr>)}</tbody></table></div></section>}
-    </>}
-  </section>;
+      )}
+      {anchor && (
+        <EtfPopover
+          anchor={anchor}
+          title={
+            indicatorKey
+              ? `${indicatorKey} 参数`
+              : ({
+                  period: "周期",
+                  adjust: "复权",
+                  indicators: "指标",
+                  range: "日期范围",
+                  replay: "历史回放",
+                  annotation: "标注",
+                }[anchor.key] ?? "设置")
+          }
+          close={close}
+        >
+          {anchor.key === "period" &&
+            (Object.keys(PERIODS) as Period[]).map((key) => (
+              <button
+                className="qfe-menu-item"
+                aria-pressed={period === key}
+                key={key}
+                onClick={() => {
+                  setPeriod(key);
+                  setInspected(null);
+                  close();
+                }}
+              >
+                1 {PERIODS[key]} {period === key ? "✓" : ""}
+              </button>
+            ))}
+          {anchor.key === "adjust" &&
+            (Object.keys(ADJUSTMENTS) as Adjustment[]).map((key) => (
+              <button
+                className="qfe-menu-item"
+                aria-pressed={adjustment === key}
+                key={key}
+                onClick={() => {
+                  setAdjustment(key);
+                  setInspected(null);
+                  close();
+                }}
+              >
+                {ADJUSTMENTS[key]} {adjustment === key ? "✓" : ""}
+              </button>
+            ))}
+          {anchor.key === "indicators" && (
+            <>
+              <p>主图均线与副图分别管理；关闭不会清除参数。</p>
+              {(["MA", "VOL", "MACD", "RSI"] as const).map((key) => (
+                <div className="qfe-field" key={key}>
+                  <label>
+                    <input
+                      type="checkbox"
+                      checked={indicators[key]}
+                      onChange={(e) =>
+                        setIndicators((v) => ({
+                          ...v,
+                          [key]: e.target.checked,
+                        }))
+                      }
+                    />
+                    {
+                      {
+                        MA: "均线 MA",
+                        VOL: "成交量 VOL",
+                        MACD: "MACD",
+                        RSI: "RSI",
+                      }[key]
+                    }
+                  </label>
+                  <button
+                    onClick={() => {
+                      setParams(
+                        key === "MA"
+                          ? [...indicators.ma]
+                          : key === "VOL"
+                            ? [indicators.vol]
+                            : key === "MACD"
+                              ? [...indicators.macd]
+                              : [indicators.rsi],
+                      );
+                      setAnchor({ ...anchor, key: `params:${key}` });
+                    }}
+                  >
+                    {"参数"}
+                  </button>
+                </div>
+              ))}
+            </>
+          )}
+          {indicatorKey && (
+            <>
+              <p>
+                周期为 1–250 的整数
+                {indicatorKey === "MACD" ? "，慢线周期需大于快线" : ""}。
+              </p>
+              {params.map((value, i) => (
+                <div className="qfe-field" key={i}>
+                  <label htmlFor={`qfe-param-${i}`}>
+                    {indicatorKey === "MA"
+                      ? `均线 ${i + 1}`
+                      : indicatorKey === "MACD"
+                        ? ["快线", "慢线", "信号"][i]
+                        : "周期"}
+                  </label>
+                  <input
+                    id={`qfe-param-${i}`}
+                    type="number"
+                    min="1"
+                    max="250"
+                    step="1"
+                    value={Number.isNaN(value) ? "" : value}
+                    onChange={(e) =>
+                      setParams((v) =>
+                        v.map((n, j) => (i === j ? e.target.valueAsNumber : n)),
+                      )
+                    }
+                  />
+                </div>
+              ))}
+              <div className="qfe-actions">
+                <button
+                  onClick={() => {
+                    setFormError("");
+                    setAnchor({ ...anchor, key: "indicators" });
+                  }}
+                >
+                  取消
+                </button>
+                <button
+                  className="qfe-primary"
+                  onClick={() => {
+                    if (!validParams(indicatorKey, params)) {
+                      setFormError("请填写有效周期；MACD 慢线必须大于快线。");
+                      return;
+                    }
+                    setIndicators((v) => ({
+                      ...v,
+                      ...(indicatorKey === "MA"
+                        ? { ma: [...params] }
+                        : indicatorKey === "MACD"
+                          ? { macd: [...params] }
+                          : indicatorKey === "RSI"
+                            ? { rsi: params[0] }
+                            : { vol: params[0] }),
+                    }));
+                    setFormError("");
+                    setAnchor({ ...anchor, key: "indicators" });
+                  }}
+                >
+                  应用
+                </button>
+              </div>
+            </>
+          )}
+          {anchor.key === "range" && (
+            <>
+              <label className="qfe-field-stack">
+                开始日期
+                <input
+                  type="date"
+                  value={rangeDraft.start}
+                  onChange={(e) =>
+                    setRangeDraft((v) => ({ ...v, start: e.target.value }))
+                  }
+                />
+              </label>
+              <label className="qfe-field-stack">
+                结束日期
+                <input
+                  type="date"
+                  value={rangeDraft.end}
+                  onChange={(e) =>
+                    setRangeDraft((v) => ({ ...v, end: e.target.value }))
+                  }
+                />
+              </label>
+              <p>留空表示全部历史。仅改变视口，指标保留历史预热。</p>
+              <div className="qfe-actions">
+                <button
+                  onClick={() => {
+                    setRange({ start: "", end: "" });
+                    setFactorPage(0);
+                    chart.current?.reset();
+                    close();
+                  }}
+                >
+                  重置
+                </button>
+                <button
+                  className="qfe-primary"
+                  onClick={() => {
+                    if (
+                      rangeDraft.start &&
+                      rangeDraft.end &&
+                      rangeDraft.start > rangeDraft.end
+                    ) {
+                      setFormError("开始日期不能晚于结束日期。");
+                      return;
+                    }
+                    setRange(rangeDraft);
+                    setFactorPage(0);
+                    close();
+                  }}
+                >
+                  应用
+                </button>
+              </div>
+            </>
+          )}
+          {anchor.key === "replay" && (
+            <>
+              <label className="qfe-field-stack">
+                开始回放日期
+                <input
+                  type="date"
+                  min={daily[0]?.trade_date}
+                  max={daily.at(-1)?.trade_date}
+                  value={replayDate}
+                  onChange={(e) => setReplayDate(e.target.value)}
+                />
+              </label>
+              <p>
+                从所选日期起的首个已采集交易日开始。每一步前进一条真实日线，周/月/年线随之更新。
+              </p>
+              <div className="qfe-actions">
+                <button onClick={close}>取消</button>
+                <button
+                  className="qfe-primary"
+                  onClick={() => {
+                    const first = daily.find(
+                      (row) => row.trade_date >= replayDate,
+                    );
+                    if (
+                      !replayDate ||
+                      !first ||
+                      replayDate < daily[0].trade_date
+                    ) {
+                      setFormError("请选择已采集历史覆盖内的日期。");
+                      return;
+                    }
+                    setPlaying(false);
+                    setReplay({ code: tsCode, date: first.trade_date });
+                    setFactorPage(0);
+                    setInspected(null);
+                    close();
+                  }}
+                >
+                  开始回放
+                </button>
+              </div>
+            </>
+          )}
+          {anchor.key === "annotation" && (
+            <>
+              <label className="qfe-field-stack">
+                标注文字
+                <input
+                  maxLength={80}
+                  value={annotation}
+                  onChange={(e) => setAnnotation(e.target.value)}
+                />
+              </label>
+              <div className="qfe-actions">
+                <button onClick={close}>取消</button>
+                <button
+                  className="qfe-primary"
+                  onClick={() => {
+                    if (!annotation.trim()) {
+                      setFormError("请输入标注文字。");
+                      return;
+                    }
+                    chart.current?.draw("simpleAnnotation", annotation.trim());
+                    setTool("simpleAnnotation");
+                    close();
+                  }}
+                >
+                  放置标注
+                </button>
+              </div>
+            </>
+          )}
+          {formError && (
+            <p className="qfe-error" role="alert">
+              {formError}
+            </p>
+          )}
+        </EtfPopover>
+      )}
+    </section>
+  );
 }

--- a/frontend/src/pages/etf/EtfChart.tsx
+++ b/frontend/src/pages/etf/EtfChart.tsx
@@ -1,0 +1,510 @@
+import {
+  forwardRef,
+  useEffect,
+  useImperativeHandle,
+  useLayoutEffect,
+  useRef,
+  useState,
+} from "react";
+import {
+  init,
+  dispose,
+  registerOverlay,
+  type Chart,
+  type Options,
+  type OverlayCreate,
+  type Crosshair,
+} from "klinecharts";
+import { EtfDrawingInput, type DrawingInput } from "./EtfDrawingInput";
+import {
+  MA_COLORS,
+  numberText,
+  type Bar,
+  type IndicatorSettings,
+  type Period,
+} from "./etfData";
+
+registerOverlay({
+  name: "qfRuler",
+  totalStep: 3,
+  needDefaultPointFigure: true,
+  createPointFigures: ({ coordinates, overlay }) => {
+    if (coordinates.length < 2) return [];
+    const a = overlay.points[0],
+      b = overlay.points[1];
+    const difference = (b.value ?? 0) - (a.value ?? 0);
+    const pct = a.value ? (difference / a.value) * 100 : null;
+    const days =
+      a.timestamp && b.timestamp
+        ? Math.round(Math.abs(b.timestamp - a.timestamp) / 86400000)
+        : 0;
+    return [
+      {
+        type: "line",
+        attrs: { coordinates },
+        styles: { color: "#E85F32", size: 1 },
+      },
+      {
+        type: "text",
+        attrs: {
+          x: coordinates[1].x,
+          y: coordinates[1].y - 12,
+          text: `${difference > 0 ? "+" : ""}${numberText(difference)} (${numberText(pct, 2)}%) · ${days} 自然日`,
+          align: "center",
+          baseline: "bottom",
+        },
+        styles: {
+          color: "#e8edf3",
+          backgroundColor: "#141922",
+          size: 12,
+          paddingLeft: 6,
+          paddingRight: 6,
+          paddingTop: 4,
+          paddingBottom: 4,
+        },
+      },
+    ];
+  },
+});
+const options: Options = {
+  locale: "zh-CN",
+  timezone: "Asia/Shanghai",
+  zoomAnchor: "cursor",
+  hotkey: { enabled: false },
+  decimalFold: { threshold: 100 },
+  layout: {
+    barSpaceLimit: { min: 1, max: 50 },
+    yAxis: { position: "right", gap: { top: 0.2, bottom: 0.1 } },
+  },
+  styles: {
+    grid: {
+      horizontal: { color: "#202734", style: "dashed", dashedValue: [1, 5] },
+      vertical: { color: "#202734", style: "dashed", dashedValue: [1, 5] },
+    },
+    candle: {
+      bar: {
+        compareRule: "current_open",
+        upColor: "#D64E4E",
+        downColor: "#2E9D68",
+        noChangeColor: "#8a94a3",
+        upBorderColor: "#D64E4E",
+        downBorderColor: "#2E9D68",
+        noChangeBorderColor: "#8a94a3",
+        upWickColor: "#D64E4E",
+        downWickColor: "#2E9D68",
+        noChangeWickColor: "#8a94a3",
+      },
+      priceMark: {
+        high: { show: false },
+        low: { show: false },
+        last: {
+          show: true,
+          upColor: "#D64E4E",
+          downColor: "#2E9D68",
+          noChangeColor: "#8a94a3",
+        },
+      },
+      tooltip: { showRule: "none" },
+    },
+    indicator: {
+      bars: [
+        {
+          upColor: "#D64E4E99",
+          downColor: "#2E9D6899",
+          noChangeColor: "#8a94a3",
+        },
+      ],
+      lines: MA_COLORS.map((color) => ({ color, size: 1.5 })),
+      lastValueMark: { show: false },
+      tooltip: {
+        showRule: "always",
+        title: { size: 12, color: "#b8c0cc" },
+        legend: { size: 12, color: "#b8c0cc", defaultValue: "—" },
+      },
+    },
+    xAxis: {
+      axisLine: { color: "#232833" },
+      tickLine: { show: false },
+      tickText: { color: "#aab4c4", size: 12 },
+    },
+    yAxis: {
+      size: 76,
+      axisLine: { color: "#232833" },
+      tickLine: { show: false },
+      tickText: { color: "#aab4c4", size: 12 },
+    },
+    separator: { color: "#232833", size: 1 },
+    crosshair: {
+      horizontal: {
+        line: { color: "#798394" },
+        text: { size: 12, backgroundColor: "#313846" },
+      },
+      vertical: {
+        line: { color: "#798394" },
+        text: { size: 12, backgroundColor: "#313846" },
+      },
+    },
+    overlay: {
+      line: { color: "#E85F32", size: 1 },
+      text: { color: "#e8edf3", size: 12 },
+    },
+  },
+};
+interface View {
+  space: number;
+  timestamp?: number;
+}
+export interface ChartHandle {
+  draw: (name: string, text?: string) => void;
+  cancel: () => void;
+  removeSelected: () => boolean;
+  zoom: (scale: number) => void;
+  reset: () => void;
+}
+interface Props {
+  bars: Bar[];
+  code: string;
+  basis: string;
+  period: Period;
+  indicators: IndicatorSettings;
+  volumeMissing: boolean;
+  replay: boolean;
+  range: { start: string; end: string };
+  onInspect: (bar: Bar | null) => void;
+  onRange: (value: string) => void;
+  onDrawEnd: () => void;
+  onSelection: (value: boolean) => void;
+}
+export const EtfChart = forwardRef<ChartHandle, Props>(
+  function EtfChart(props, ref) {
+    const element = useRef<HTMLDivElement>(null),
+      chartRef = useRef<Chart | null>(null),
+      current = useRef(props);
+    current.current = props;
+    const drawings = useRef(new Map<string, OverlayCreate[]>()),
+      selected = useRef<string | null>(null);
+    const [drawingInput, setDrawingInput] = useState<DrawingInput | null>(null);
+    const previous = useRef({ code: "", basis: "", period: "", replay: false });
+    const beforeReplay = useRef<View | null>(null);
+    const lastValidView = useRef<View | null>(null);
+    const view = (chart: Chart): View => ({
+      space: chart.getBarSpace().bar,
+      timestamp:
+        chart.getDataList()[
+          Math.min(
+            chart.getDataList().length - 1,
+            Math.max(0, Math.ceil(chart.getVisibleRange().to) - 1),
+          )
+        ]?.timestamp,
+    });
+    const cancel = () => {
+      setDrawingInput(null);
+      current.current.onDrawEnd();
+    };
+    const callbacks = () => ({
+      onDrawEnd: () => {
+        setDrawingInput(null);
+        current.current.onDrawEnd();
+      },
+      onSelected: ({ overlay }: { overlay: { id: string } }) => {
+        selected.current = overlay.id;
+        current.current.onSelection(true);
+      },
+      onDeselected: () => {
+        selected.current = null;
+        current.current.onSelection(false);
+      },
+    });
+    useImperativeHandle(ref, () => ({
+      cancel,
+      draw(name, text) {
+        cancel();
+        setDrawingInput({ name, text });
+      },
+      removeSelected() {
+        if (!selected.current) return false;
+        chartRef.current?.removeOverlay({ id: selected.current });
+        selected.current = null;
+        current.current.onSelection(false);
+        return true;
+      },
+      zoom(scale) {
+        chartRef.current?.zoomAtCoordinate(scale);
+      },
+      reset() {
+        const c = chartRef.current;
+        if (c) {
+          c.setBarSpace(
+            Math.min(
+              50,
+              Math.max(
+                1,
+                ((element.current?.clientWidth ?? 800) - 76) /
+                  Math.min(200, Math.max(1, c.getDataList().length)),
+              ),
+            ),
+          );
+          c.scrollToRealTime();
+        }
+      },
+    }));
+    useLayoutEffect(() => {
+      const c = init(element.current!, options);
+      if (!c) return;
+      chartRef.current = c;
+      c.setMaxOffsetLeftDistance(0);
+      c.setMaxOffsetRightDistance(0);
+      c.setOffsetRightDistance(0);
+      c.overrideXAxis({ scrollZoomEnabled: false });
+      c.setSymbol({
+        ticker: current.current.code,
+        pricePrecision: 3,
+        volumePrecision: 2,
+      });
+      c.setPeriod({ type: "day", span: 1 });
+      const inspect = (value: unknown) => {
+        const index = (value as Partial<Crosshair>).dataIndex;
+        current.current.onInspect(
+          index === undefined ? null : (current.current.bars[index] ?? null),
+        );
+      };
+      const range = () => {
+        const r = c.getVisibleRange(),
+          data = current.current.bars;
+        const a = Math.max(0, Math.floor(r.from)),
+          b = Math.min(data.length - 1, Math.ceil(r.to) - 1);
+        current.current.onRange(
+          data[a] && data[b]
+            ? `${data[a].date.replaceAll("-", "/")} — ${data[b].date.replaceAll("-", "/")} · ${b - a + 1} 根 K 线`
+            : "暂无可见行情",
+        );
+      };
+      c.subscribeAction("onCrosshairChange", inspect);
+      c.subscribeAction("onVisibleRangeChange", range);
+      const observer = new ResizeObserver(() => c.resize());
+      observer.observe(element.current!);
+      return () => {
+        observer.disconnect();
+        dispose(c);
+        chartRef.current = null;
+        previous.current = { code: "", basis: "", period: "", replay: false };
+      };
+    }, []);
+    useEffect(() => {
+      const c = chartRef.current;
+      if (!c) return;
+      cancel();
+      const old = previous.current,
+        saved = c.getDataList().length
+          ? view(c)
+          : (lastValidView.current ?? view(c)),
+        key = `${props.code}:${props.basis}`;
+      if (c.getDataList().length) lastValidView.current = saved;
+      if (old.code !== props.code || old.basis !== props.basis) {
+        if (old.code)
+          drawings.current.set(
+            `${old.code}:${old.basis}`,
+            c.getOverlays().map((o) => ({
+              name: o.name,
+              points: o.points.map((p) => ({ ...p })),
+              extendData: o.extendData,
+            })),
+          );
+        c.removeOverlay();
+        selected.current = null;
+        current.current.onSelection(false);
+        for (const o of drawings.current.get(key) ?? [])
+          c.createOverlay({ ...o, ...callbacks() });
+        if (old.code !== props.code) {
+          beforeReplay.current = null;
+          lastValidView.current = null;
+        }
+      }
+      if (props.replay && !old.replay) beforeReplay.current = saved;
+      if (old.code !== props.code)
+        c.setSymbol({
+          ticker: props.code,
+          pricePrecision: 3,
+          volumePrecision: 2,
+        });
+      if (old.period !== props.period)
+        c.setPeriod({ type: props.period, span: 1 });
+      c.setDataLoader({
+        getBars: ({ callback }) =>
+          callback(
+            props.bars.map((bar) => ({ ...bar })),
+            false,
+          ),
+      });
+      // Drawings with anchors beyond the cutoff would expose future prices.
+      for (const o of c.getOverlays())
+        c.overrideOverlay({
+          id: o.id,
+          visible:
+            !props.replay ||
+            o.points.every(
+              (p) =>
+                !p.timestamp ||
+                p.timestamp <= (props.bars.at(-1)?.timestamp ?? 0),
+            ),
+        });
+      const frame = requestAnimationFrame(() => {
+        // The chart library cannot binary-search an empty series. Preserve the
+        // last valid view while a missing-factor state has no chart data.
+        if (!c.getDataList().length) return;
+        const restore =
+          old.replay && !props.replay ? beforeReplay.current : saved;
+        if (old.code !== props.code || !restore?.timestamp) {
+          c.setBarSpace(
+            Math.min(
+              50,
+              Math.max(
+                1,
+                ((element.current?.clientWidth ?? 800) - 76) /
+                  Math.min(200, Math.max(props.bars.length, 1)),
+              ),
+            ),
+          );
+          c.scrollToRealTime();
+        } else {
+          c.setBarSpace(restore.space);
+          if (props.replay) c.scrollToRealTime();
+          else c.scrollToTimestamp(restore.timestamp);
+        }
+      });
+      previous.current = {
+        code: props.code,
+        basis: props.basis,
+        period: props.period,
+        replay: props.replay,
+      };
+      return () => cancelAnimationFrame(frame);
+    }, [props.bars, props.code, props.basis, props.period, props.replay]);
+    useEffect(() => {
+      const c = chartRef.current;
+      if (!c) return;
+      const settings = props.indicators;
+      for (const name of ["MA", "VOL", "MACD", "RSI"] as const) {
+        const enabled =
+          settings[name] && (name !== "VOL" || !props.volumeMissing);
+        const ma = settings.ma.filter((_, i) => settings.maVisible[i]);
+        const config = {
+          name,
+          precision:
+            name === "RSI" ? 2 : name === "VOL" ? 2 : name === "MACD" ? 4 : 3,
+          ...(name === "RSI" ? { minValue: 0, maxValue: 100 } : {}),
+          ...(name === "VOL" ? { shortName: "VOL · 手" } : {}),
+          calcParams:
+            name === "MA"
+              ? ma
+              : name === "VOL"
+                ? [settings.vol]
+                : name === "MACD"
+                  ? settings.macd
+                  : [settings.rsi],
+          ...(name === "MA"
+            ? {
+                paneId: "candle_pane",
+                styles: {
+                  lines: MA_COLORS.filter((_, i) => settings.maVisible[i]).map(
+                    (color) => ({ color, size: 1.5 }),
+                  ),
+                },
+              }
+            : {}),
+        };
+        if (!enabled || (name === "MA" && !ma.length))
+          c.removeIndicator({ name });
+        else if (c.getIndicators({ name }).length) c.overrideIndicator(config);
+        else {
+          const pane = c.createIndicator(config, name === "MA");
+          if (pane && name !== "MA") {
+            c.setPaneOptions({
+              id: pane,
+              height: 110,
+              minHeight: 90,
+              dragEnabled: true,
+            });
+            c.overrideYAxis({ paneId: pane, gap: { top: 0.6, bottom: 0.05 } });
+          }
+        }
+      }
+    }, [props.indicators, props.volumeMissing]);
+    useEffect(() => {
+      const c = chartRef.current;
+      if (!c || (!props.range.start && !props.range.end)) return;
+      const subset = props.bars.filter(
+        (b) =>
+          (!props.range.start || b.date >= props.range.start) &&
+          (!props.range.end || b.date <= props.range.end),
+      );
+      if (!subset.length) return;
+      const frame = requestAnimationFrame(() => {
+        if (!c.getDataList().length) return;
+        c.setBarSpace(
+          Math.min(
+            50,
+            Math.max(
+              1,
+              ((element.current?.clientWidth ?? 800) - 76) / subset.length,
+            ),
+          ),
+        );
+        c.scrollToTimestamp(subset.at(-1)!.timestamp);
+      });
+      return () => cancelAnimationFrame(frame);
+    }, [props.range, props.period, props.code]);
+    return (
+      <>
+        <div
+          ref={element}
+          className="qfe-chart"
+          tabIndex={0}
+          role="img"
+          aria-label="ETF K线与指标图。滚轮缩放，拖拽回看。聚焦后按左右方向键查看各根行情。"
+          onMouseLeave={() => props.onInspect(null)}
+          onKeyDown={(event) => {
+            if (event.key === "Escape") {
+              cancel();
+              return;
+            }
+            if (event.key !== "ArrowLeft" && event.key !== "ArrowRight") return;
+            event.preventDefault();
+            const c = chartRef.current;
+            if (!c || !props.bars.length) return;
+            const index = Math.max(
+              0,
+              Math.min(
+                props.bars.length - 1,
+                Number(element.current?.dataset.index ?? props.bars.length) +
+                  (event.key === "ArrowLeft" ? -1 : 1),
+              ),
+            );
+            element.current!.dataset.index = String(index);
+            const bar = props.bars[index];
+            props.onInspect(bar);
+            c.scrollToDataIndex(index);
+          }}
+        />
+        {drawingInput && (
+          <EtfDrawingInput
+            key={drawingInput.name}
+            chartRef={chartRef}
+            mode={drawingInput}
+            complete={(points) => {
+              chartRef.current?.createOverlay({
+                name: drawingInput.name,
+                points,
+                extendData: drawingInput.text,
+                needDefaultPointFigure: true,
+                ...callbacks(),
+              });
+              setDrawingInput(null);
+              current.current.onDrawEnd();
+            }}
+          />
+        )}
+      </>
+    );
+  },
+);

--- a/frontend/src/pages/etf/EtfDrawingInput.tsx
+++ b/frontend/src/pages/etf/EtfDrawingInput.tsx
@@ -1,0 +1,108 @@
+import { useRef, useState, type RefObject } from "react";
+import type { Chart, Point } from "klinecharts";
+
+export interface DrawingInput {
+  name: string;
+  text?: string;
+}
+// Collect anchors with native pointer events. KLineCharts treats two fast,
+// separated clicks as a double click and drops the second anchor; this layer
+// accepts both mouse and touch anchors without altering the library internals.
+export function EtfDrawingInput({
+  chartRef,
+  mode,
+  complete,
+}: {
+  chartRef: RefObject<Chart | null>;
+  mode: DrawingInput;
+  complete: (points: Partial<Point>[]) => void;
+}) {
+  const [points, setPoints] = useState<Partial<Point>[]>([]);
+  const [hover, setHover] = useState<{ x: number; y: number } | null>(null);
+  const down = useRef<{ x: number; y: number } | null>(null);
+  const c = chartRef.current;
+  const pixels = (c?.convertToPixel(points, { paneId: "candle_pane" }) ??
+    []) as { x: number; y: number }[];
+  const preview = [...pixels, ...(hover ? [hover] : [])];
+  return (
+    <svg
+      className="qfe-drawing-input"
+      aria-label="点击图表放置绘图锚点，Esc 取消"
+      onPointerDown={(event) => {
+        event.preventDefault();
+        down.current = { x: event.clientX, y: event.clientY };
+        event.currentTarget.setPointerCapture(event.pointerId);
+      }}
+      onPointerMove={(event) => {
+        const box = event.currentTarget.getBoundingClientRect();
+        setHover({ x: event.clientX - box.left, y: event.clientY - box.top });
+      }}
+      onPointerUp={(event) => {
+        const start = down.current;
+        down.current = null;
+        if (
+          !start ||
+          Math.hypot(event.clientX - start.x, event.clientY - start.y) > 6 ||
+          !c
+        )
+          return;
+        const box = event.currentTarget.getBoundingClientRect(),
+          x = event.clientX - box.left,
+          y = event.clientY - box.top;
+        const size = c.getSize("candle_pane", "main");
+        if (!size || x < 0 || y < 0 || x > size.width || y > size.height)
+          return;
+        const converted = c.convertFromPixel([{ x, y }], {
+          paneId: "candle_pane",
+        });
+        const point = Array.isArray(converted) ? converted[0] : converted;
+        if (
+          !point ||
+          point.value === undefined ||
+          !Number.isFinite(point.value)
+        )
+          return;
+        const data = c.getDataList(),
+          index = Math.max(
+            0,
+            Math.min(data.length - 1, Math.round(point.dataIndex ?? 0)),
+          );
+        if (!data[index]) return;
+        const next = [
+          ...points,
+          { timestamp: data[index].timestamp, value: point.value },
+        ];
+        const count =
+          mode.name === "simpleAnnotation"
+            ? 1
+            : mode.name === "parallelStraightLine"
+              ? 3
+              : 2;
+        if (next.length === count) complete(next);
+        else setPoints(next);
+      }}
+      onPointerCancel={() => {
+        down.current = null;
+      }}
+    >
+      <polyline
+        points={preview.map((p) => `${p.x},${p.y}`).join(" ")}
+        fill="none"
+        stroke="#E85F32"
+        strokeWidth="1.5"
+        strokeDasharray="4 3"
+      />
+      {pixels.map((p, i) => (
+        <circle
+          key={i}
+          cx={p.x}
+          cy={p.y}
+          r="4"
+          fill="#141922"
+          stroke="#E85F32"
+          strokeWidth="1.5"
+        />
+      ))}
+    </svg>
+  );
+}

--- a/frontend/src/pages/etf/EtfPopover.tsx
+++ b/frontend/src/pages/etf/EtfPopover.tsx
@@ -1,0 +1,75 @@
+import { useLayoutEffect, useRef, type ReactNode } from "react";
+
+export interface PopoverAnchor {
+  element: HTMLElement;
+  key: string;
+}
+export function EtfPopover({
+  anchor,
+  title,
+  close,
+  children,
+  boundary,
+}: {
+  anchor: PopoverAnchor;
+  title: string;
+  close: () => void;
+  children: ReactNode;
+  boundary?: HTMLElement | null;
+}) {
+  const ref = useRef<HTMLElement>(null);
+  const closeRef = useRef(close);
+  closeRef.current = close;
+  useLayoutEffect(() => {
+    const panel = ref.current!;
+    const position = () => {
+      const rect = anchor.element.getBoundingClientRect();
+      // Sidebar menus must fit their own surface, not just the viewport.
+      const bounds = boundary?.getBoundingClientRect();
+      const left = Math.max(8, bounds ? bounds.left + 8 : 8);
+      const right = Math.min(
+        innerWidth - 8,
+        bounds ? bounds.left + boundary!.clientWidth - 8 : innerWidth - 8,
+      );
+      panel.style.width = `${Math.max(0, Math.min(320, right - left))}px`;
+      panel.style.left = `${Math.max(left, Math.min(rect.left, right - panel.offsetWidth))}px`;
+      panel.style.top = `${Math.max(8, Math.min(rect.bottom + 8, innerHeight - panel.offsetHeight - 8))}px`;
+    };
+    position();
+    const observer = new ResizeObserver(position);
+    observer.observe(panel);
+    if (boundary) observer.observe(boundary);
+    const outside = (e: PointerEvent) => {
+      if (
+        !panel.contains(e.target as Node) &&
+        !anchor.element.contains(e.target as Node)
+      )
+        closeRef.current();
+    };
+    const key = (e: KeyboardEvent) => {
+      if (e.key === "Escape") {
+        e.stopPropagation();
+        closeRef.current();
+      }
+    };
+    document.addEventListener("pointerdown", outside);
+    document.addEventListener("keydown", key, true);
+    window.addEventListener("resize", position);
+    panel
+      .querySelector<HTMLElement>('input,button,select,[tabindex="0"]')
+      ?.focus();
+    return () => {
+      observer.disconnect();
+      document.removeEventListener("pointerdown", outside);
+      document.removeEventListener("keydown", key, true);
+      window.removeEventListener("resize", position);
+      if (anchor.element.isConnected) anchor.element.focus();
+    };
+  }, [anchor.element, anchor.key, boundary]);
+  return (
+    <section ref={ref} className="qfe-popover" role="dialog" aria-label={title}>
+      <h2>{title}</h2>
+      {children}
+    </section>
+  );
+}

--- a/frontend/src/pages/etf/EtfWatchlist.tsx
+++ b/frontend/src/pages/etf/EtfWatchlist.tsx
@@ -1,0 +1,323 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import { MoreHorizontal, Plus, X } from "lucide-react";
+import { listEtfs, type EtfCode } from "../../api/dataCollections";
+import {
+  listWatchlist,
+  setWatched,
+  type WatchItem,
+} from "../../api/etfWatchlist";
+import { direction, numberText, numeric, signed } from "./etfData";
+import { EtfPopover, type PopoverAnchor } from "./EtfPopover";
+
+export function EtfWatchlist({
+  code,
+  replay,
+  refresh,
+  onSelect,
+  onClose,
+  onError,
+}: {
+  code: string;
+  replay: boolean;
+  refresh: number;
+  onSelect: (code: string) => void;
+  onClose: () => void;
+  onError: (error: unknown) => void;
+}) {
+  const [rows, setRows] = useState<WatchItem[]>([]),
+    [loading, setLoading] = useState(true),
+    [error, setError] = useState("");
+  const [anchor, setAnchor] = useState<PopoverAnchor | null>(null),
+    [keyword, setKeyword] = useState(""),
+    [matches, setMatches] = useState<EtfCode[]>([]);
+  const [searching, setSearching] = useState(false),
+    [searchError, setSearchError] = useState(""),
+    [searchOffset, setSearchOffset] = useState(0),
+    [total, setTotal] = useState(0);
+  const [pending, setPending] = useState(""),
+    [revision, setRevision] = useState(0);
+  const generation = useRef(0),
+    mounted = useRef(true);
+  useEffect(() => {
+    mounted.current = true;
+    return () => {
+      mounted.current = false;
+    };
+  }, []);
+  useEffect(() => {
+    const controller = new AbortController();
+    const version = ++generation.current;
+    setLoading(true);
+    setError("");
+    void (async () => {
+      const next: WatchItem[] = [];
+      let offset = 0,
+        more = true;
+      while (more) {
+        const page = await listWatchlist(offset, controller.signal);
+        next.push(...page.items);
+        more = page.has_more;
+        offset += page.items.length;
+        if (more && !page.items.length)
+          throw new Error("自选分页返回异常，请重试。");
+      }
+      if (version === generation.current) setRows(next);
+    })()
+      .catch((e) => {
+        if (!controller.signal.aborted) {
+          setError(e instanceof Error ? e.message : "自选加载失败。");
+          onError(e);
+        }
+      })
+      .finally(() => {
+        if (!controller.signal.aborted) setLoading(false);
+      });
+    return () => controller.abort();
+  }, [refresh, revision, onError]);
+  useEffect(() => {
+    if (anchor?.key !== "add" || !keyword.trim()) {
+      setMatches([]);
+      setTotal(0);
+      setSearching(false);
+      return;
+    }
+    const controller = new AbortController();
+    setSearching(true);
+    setSearchError("");
+    setMatches([]);
+    const timer = setTimeout(() => {
+      void listEtfs(
+        { keyword: keyword.trim(), limit: 20, offset: searchOffset },
+        controller.signal,
+      )
+        .then((result) => {
+          setMatches(result.items);
+          setTotal(result.total);
+        })
+        .catch((e) => {
+          if (!controller.signal.aborted) {
+            setSearchError(e instanceof Error ? e.message : "搜索失败。");
+            onError(e);
+          }
+        })
+        .finally(() => {
+          if (!controller.signal.aborted) setSearching(false);
+        });
+    }, 250);
+    return () => {
+      clearTimeout(timer);
+      controller.abort();
+    };
+  }, [keyword, searchOffset, anchor?.key, onError]);
+  const mutate = useCallback(
+    async (target: string, watched: boolean) => {
+      if (pending) return;
+      setPending(target);
+      setError("");
+      try {
+        await setWatched(target, watched);
+        if (!mounted.current) return;
+        if (!watched)
+          setRows((prior) => prior.filter((item) => item.ts_code !== target));
+        // Reload the server snapshot after success; don't invent quote facts.
+        setRevision((v) => v + 1);
+      } catch (e) {
+        if (mounted.current) {
+          setError(e instanceof Error ? e.message : "自选操作失败，请重试。");
+          onError(e);
+        }
+      } finally {
+        if (mounted.current) setPending("");
+      }
+    },
+    [pending, onError],
+  );
+  const open = (key: string, element: HTMLElement) =>
+    setAnchor((prior) => (prior?.key === key ? null : { key, element }));
+  return (
+    <section className="qfe-watch" aria-label="自选 ETF">
+      <div className="qfe-right-head">
+        <strong>自选 ETF</strong>
+        <span className="qfe-spacer" />
+        <button
+          className="qfe-icon"
+          aria-label="添加自选"
+          title="添加自选"
+          onClick={(e) => open("add", e.currentTarget)}
+        >
+          <Plus />
+        </button>
+        <button
+          className="qfe-icon"
+          aria-label="管理自选"
+          title="管理自选"
+          onClick={(e) => open("manage", e.currentTarget)}
+        >
+          <MoreHorizontal />
+        </button>
+        <button
+          className="qfe-icon qfe-narrow-close"
+          aria-label="关闭资料侧栏"
+          onClick={onClose}
+        >
+          <X />
+        </button>
+      </div>
+      <div className="qfe-watch-scroll" aria-busy={loading}>
+        <div className="qfe-watch-columns">
+          <span>标的</span>
+          <span>收盘</span>
+          <span>涨跌</span>
+          <span>涨跌幅</span>
+        </div>
+        {error && (
+          <div className="qfe-note qfe-error" role="alert">
+            {error}
+            <button
+              onClick={() => setRevision((v) => v + 1)}
+              disabled={loading}
+            >
+              重试
+            </button>
+          </div>
+        )}
+        {loading && !rows.length ? (
+          <p className="qfe-note">正在加载自选…</p>
+        ) : !rows.length ? (
+          <p className="qfe-note">还没有自选 ETF。点击 ＋ 添加。</p>
+        ) : (
+          rows.map((item) => (
+            <button
+              key={item.ts_code}
+              className={`qfe-watch-row ${code === item.ts_code ? "active" : ""}`}
+              onClick={() => onSelect(item.ts_code)}
+              title={`${item.name ?? item.ts_code} · ${replay ? "回放中隐藏最新行情" : `${item.trade_date ?? "无日线"} · 不复权收盘 · ${item.message}`}`}
+            >
+              <span className="qfe-watch-code">{item.ts_code}</span>
+              <span>{replay ? "—" : numberText(item.close)}</span>
+              <span className={replay ? "neutral" : direction(item.change)}>
+                {replay ? "—" : signed(item.change)}
+              </span>
+              <span className={replay ? "neutral" : direction(item.pct_chg)}>
+                {replay || numeric(item.pct_chg) === null
+                  ? "—"
+                  : `${signed(item.pct_chg, 2)}%`}
+              </span>
+            </button>
+          ))
+        )}
+        {replay && <p className="qfe-note">回放中隐藏自选最新行情。</p>}
+      </div>
+      {anchor && (
+        <EtfPopover
+          anchor={anchor}
+          boundary={anchor.element.closest<HTMLElement>(".qfe-right")}
+          title={anchor.key === "add" ? "添加自选" : "管理自选"}
+          close={() => setAnchor(null)}
+        >
+          {anchor.key === "add" ? (
+            <>
+              <label htmlFor="qfe-watch-search">代码、名称或跟踪指数</label>
+              <input
+                id="qfe-watch-search"
+                type="search"
+                value={keyword}
+                placeholder="例如 510300 或沪深300"
+                onChange={(e) => {
+                  setKeyword(e.target.value);
+                  setSearchOffset(0);
+                }}
+              />
+              <div className="qfe-results" aria-live="polite">
+                {searching ? (
+                  <p>正在搜索…</p>
+                ) : searchError ? (
+                  <p role="alert">{searchError}</p>
+                ) : !keyword.trim() ? (
+                  <p>输入关键词搜索 ETF。</p>
+                ) : !matches.length ? (
+                  <p>没有匹配的 ETF，请调整关键词。</p>
+                ) : (
+                  matches.map((item) => (
+                    <div className="qfe-search-row" key={item.ts_code}>
+                      <div>
+                        <strong>
+                          {item.csname ?? item.extname ?? item.ts_code}
+                        </strong>
+                        <small>{item.ts_code}</small>
+                      </div>
+                      <button
+                        disabled={
+                          Boolean(pending) ||
+                          loading ||
+                          rows.some((row) => row.ts_code === item.ts_code)
+                        }
+                        onClick={() => void mutate(item.ts_code, true)}
+                      >
+                        {pending === item.ts_code
+                          ? "添加中…"
+                          : rows.some((row) => row.ts_code === item.ts_code)
+                            ? "已添加"
+                            : "添加"}
+                      </button>
+                    </div>
+                  ))
+                )}
+              </div>
+              {total > 20 && (
+                <div className="qfe-actions">
+                  <button
+                    disabled={searchOffset === 0 || searching}
+                    onClick={() => setSearchOffset((v) => v - 20)}
+                  >
+                    上一页
+                  </button>
+                  <span>
+                    {searchOffset + 1}–{Math.min(searchOffset + 20, total)} /{" "}
+                    {total}
+                  </span>
+                  <button
+                    disabled={searchOffset + 20 >= total || searching}
+                    onClick={() => setSearchOffset((v) => v + 20)}
+                  >
+                    下一页
+                  </button>
+                </div>
+              )}
+              <p>选择后加入自选，当前研究标的不变。</p>
+            </>
+          ) : (
+            <>
+              <p>移除只影响自选列表，保留当前图表与行情数据。</p>
+              <div className="qfe-results">
+                {rows.length ? (
+                  rows.map((item) => (
+                    <div className="qfe-search-row" key={item.ts_code}>
+                      <div>
+                        <strong>{item.ts_code}</strong>
+                        <small>{item.name}</small>
+                      </div>
+                      <button
+                        disabled={Boolean(pending) || loading}
+                        onClick={() => void mutate(item.ts_code, false)}
+                      >
+                        {pending === item.ts_code ? "移除中…" : "移除"}
+                      </button>
+                    </div>
+                  ))
+                ) : (
+                  <p>还没有自选 ETF。点击 ＋ 添加。</p>
+                )}
+              </div>
+            </>
+          )}
+          {error && (
+            <p className="qfe-error" role="alert">
+              {error}
+            </p>
+          )}
+        </EtfPopover>
+      )}
+    </section>
+  );
+}

--- a/frontend/src/pages/etf/EtfWorkspace.css
+++ b/frontend/src/pages/etf/EtfWorkspace.css
@@ -1,0 +1,981 @@
+/* ETF-only surface, following the approved designer baseline. */
+.qfe {
+  --qfe-line: #232833;
+  --qfe-line2: #313846;
+  --qfe-muted: #8a94a3;
+  --qfe-sub: #b8c0cc;
+  --qfe-text: #e8edf3;
+  --qfe-panel: #141922;
+  --qfe-orange: #e85f32;
+  background: #0b0d12;
+  color: var(--qfe-text);
+  height: 100dvh;
+  min-height: 420px;
+  display: grid;
+  grid-template-rows: 50px minmax(0, 1fr);
+  font:
+    14px/1.5 "MiSans",
+    "PingFang SC",
+    "Microsoft YaHei",
+    system-ui,
+    sans-serif;
+  overflow: hidden;
+}
+.qfe * {
+  box-sizing: border-box;
+}
+.qfe button,
+.qfe input,
+.qfe select {
+  font: inherit;
+  color: inherit;
+}
+.qfe button {
+  cursor: pointer;
+  min-height: 32px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+  padding: 0 10px;
+  background: var(--qfe-panel);
+  border: 1px solid var(--qfe-line2);
+  border-radius: 8px;
+  font-size: 12px;
+  white-space: nowrap;
+}
+.qfe button:hover:not(:disabled) {
+  background: #1a212c;
+  border-color: #465168;
+}
+.qfe button:disabled {
+  opacity: 0.45;
+  cursor: not-allowed;
+}
+.qfe button[aria-disabled="true"] {
+  opacity: 0.65;
+  cursor: help;
+}
+.qfe button:focus-visible,
+.qfe input:focus-visible,
+.qfe select:focus-visible,
+.qfe [tabindex]:focus-visible {
+  outline: 2px solid #ff9a73;
+  outline-offset: 2px;
+}
+.qfe svg {
+  width: 16px;
+  height: 16px;
+  flex: none;
+  stroke-width: 1.7;
+}
+.qfe button.active,
+.qfe button[aria-pressed="true"],
+.qfe button[aria-selected="true"] {
+  background: #171d26;
+  border-color: #465168;
+  color: #fff;
+}
+.qfe .qfe-primary {
+  background: var(--qfe-orange);
+  border-color: var(--qfe-orange);
+  color: #fff;
+}
+.qfe .qfe-primary:hover:not(:disabled) {
+  background: #d54e25;
+  border-color: #d54e25;
+}
+.qfe .qfe-icon {
+  width: 32px;
+  padding: 0;
+  flex-shrink: 0;
+}
+.qfe .qfe-spacer {
+  flex: 1;
+  min-width: 0;
+}
+.qfe .up {
+  color: #d64e4e;
+}
+.qfe .down {
+  color: #2e9d68;
+}
+.qfe .neutral {
+  color: var(--qfe-sub);
+}
+.qfe-topbar {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 0 14px;
+  background: #f6f3ee;
+  border-bottom: 1px solid #d9d5ce;
+  color: #17212f;
+  min-width: 0;
+}
+.qfe-brand {
+  display: flex;
+  gap: 10px;
+  align-items: center;
+  flex-shrink: 0;
+}
+.qfe-brand strong {
+  font-size: 13px;
+  white-space: nowrap;
+}
+.qfe-mark {
+  display: grid;
+  place-items: center;
+  width: 28px;
+  height: 28px;
+  border: 1px solid #e85f32;
+  border-radius: 8px;
+  color: #e85f32;
+  background: #fffdfc;
+  font: 800 10px/1 monospace;
+}
+.qfe-crumb {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex: 1;
+  min-width: 0;
+}
+.qfe-breadcrumb {
+  font-size: 12px;
+  color: #727d87;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.qfe-topbar button {
+  background: #fffdfc;
+  border-color: #d9d5ce;
+  color: #354250;
+}
+.qfe-topbar button:hover:not(:disabled) {
+  background: #fff;
+  border-color: #c7c1b8;
+  color: #17212f;
+}
+.qfe .qfe-back {
+  border-radius: 999px;
+  flex-shrink: 0;
+}
+.qfe-top-actions {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-shrink: 0;
+}
+.qfe-symbol {
+  white-space: nowrap;
+  font:
+    700 12px/30px "Geist Mono",
+    monospace;
+  border: 1px solid #d9d5ce;
+  background: #fffdfc;
+  border-radius: 999px;
+  padding: 0 12px;
+}
+.qfe-symbol:before {
+  content: "";
+  display: inline-block;
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: #4f8b62;
+  margin-right: 8px;
+}
+.qfe-quotes {
+  display: flex;
+  gap: 8px;
+  font-size: 12px;
+}
+.qfe-quotes span {
+  display: flex;
+  gap: 18px;
+  align-items: center;
+  border-radius: 9px;
+  padding: 4px 10px;
+  background: #fbecea;
+  border: 1px solid #e7c2be;
+  color: #b95a52;
+}
+.qfe-quotes span + span {
+  background: #eef3fc;
+  border-color: #c8d7f4;
+  color: #476dae;
+}
+.qfe-quotes strong {
+  font: 700 14px monospace;
+}
+.qfe-workspace {
+  color-scheme: dark;
+  min-height: 0;
+  display: grid;
+  grid-template-columns: 46px minmax(0, 1fr);
+  grid-template-rows: 48px minmax(0, 1fr) 32px;
+  position: relative;
+}
+.qfe-workspace.qfe-side-open {
+  grid-template-columns: 46px minmax(0, 1fr) 320px;
+}
+.qfe-tools {
+  grid-column: 1;
+  grid-row: 1 / 4;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 10px;
+  padding-top: 10px;
+  background: #0b0e13;
+  border-right: 1px solid var(--qfe-line);
+}
+.qfe-tools button {
+  height: 32px;
+  width: 32px;
+  border: 0;
+  padding: 0;
+  background: transparent;
+  color: var(--qfe-sub);
+}
+.qfe-tools svg {
+  width: 18px;
+  height: 18px;
+}
+.qfe-tools button:nth-child(6) {
+  margin-top: 10px;
+}
+.qfe-tools button:last-child {
+  margin-top: 6px;
+}
+.qfe-chart-top {
+  grid-column: 2;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 0 12px;
+  border-bottom: 1px solid var(--qfe-line);
+  background: #0d1016;
+  min-width: 0;
+  overflow: auto;
+  scrollbar-width: thin;
+}
+.qfe-chart-top > button,
+.qfe-button-group {
+  flex-shrink: 0;
+}
+.qfe-button-group,
+.qfe-ma-buttons {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+.qfe-control-label {
+  font: 700 12px/1.2 monospace;
+  color: var(--qfe-muted);
+  white-space: nowrap;
+}
+.qfe-ma-buttons {
+  margin-left: 4px;
+  flex-shrink: 0;
+}
+.qfe-ma-buttons i {
+  width: 12px;
+  height: 2px;
+  border-radius: 2px;
+}
+.qfe button.off {
+  opacity: 0.5;
+}
+.qfe-stage {
+  grid-column: 2;
+  grid-row: 2;
+  min-width: 0;
+  min-height: 0;
+  display: flex;
+  flex-direction: column;
+  background: #090b10;
+  overflow: hidden;
+}
+.qfe-chart-caption {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+  align-items: baseline;
+  padding: 12px 16px 0;
+  font:
+    12px/18px "Geist Mono",
+    monospace;
+  min-height: 30px;
+  color: var(--qfe-sub);
+}
+.qfe-chart-caption strong {
+  letter-spacing: 0.08em;
+  color: #d6dde6;
+}
+.qfe-ohlc {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px 12px;
+  padding: 3px 16px 6px;
+  color: var(--qfe-muted);
+  font:
+    12px/18px "Geist Mono",
+    monospace;
+}
+.qfe-ohlc span {
+  white-space: nowrap;
+}
+.qfe-ohlc strong {
+  font-weight: 500;
+  color: var(--qfe-sub);
+}
+.qfe-plot {
+  position: relative;
+  flex: 1;
+  min-height: 0;
+}
+.qfe-chart {
+  position: absolute;
+  inset: 0;
+  touch-action: none;
+}
+.qfe-chart-empty {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  text-align: center;
+  padding: 30px;
+  z-index: 8;
+  background: #090b10;
+  color: var(--qfe-sub);
+  font-size: 14px;
+  line-height: 24px;
+}
+.qfe-watermark {
+  position: absolute;
+  left: 18px;
+  bottom: 145px;
+  color: #ffffff20;
+  font-size: 24px;
+  font-weight: 800;
+  pointer-events: none;
+  z-index: 2;
+}
+.qfe-tool-status {
+  position: absolute;
+  z-index: 10;
+  left: 12px;
+  top: 40px;
+  max-width: calc(100% - 24px);
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  align-items: center;
+  padding: 8px 12px;
+  background: #141922;
+  border: 1px solid #465168;
+  font-size: 13px;
+  border-radius: 6px;
+}
+.qfe-replay {
+  position: absolute;
+  left: 50%;
+  bottom: 135px;
+  transform: translateX(-50%);
+  z-index: 15;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 10px 12px;
+  background: #141922;
+  border: 1px solid #465168;
+  border-radius: 8px;
+  white-space: nowrap;
+  font-size: 13px;
+  max-width: calc(100% - 24px);
+}
+.qfe-replay strong {
+  font: 500 12px monospace;
+}
+.qfe-replay-label {
+  color: #ff936a;
+  font-size: 12px;
+}
+.qfe-replay select {
+  height: 32px;
+  background: #1a212c;
+  border: 1px solid #465168;
+  border-radius: 6px;
+  padding: 0 6px;
+  font-size: 13px;
+}
+.qfe-replay button {
+  padding: 0 8px;
+}
+.qfe-data-note {
+  padding: 6px 14px;
+  background: #141922;
+  border-top: 1px solid var(--qfe-line);
+  color: var(--qfe-sub);
+  font-size: 13px;
+  flex-shrink: 0;
+}
+.qfe-timeline {
+  grid-column: 2;
+  grid-row: 3;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  padding: 0 12px;
+  border-top: 1px solid var(--qfe-line);
+  font:
+    12px/18px "Geist Mono",
+    monospace;
+  color: var(--qfe-muted);
+  min-width: 0;
+}
+.qfe-timeline span {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.qfe-right {
+  grid-column: 3;
+  grid-row: 1 / 4;
+  min-height: 0;
+  overflow: auto;
+  border-left: 1px solid var(--qfe-line);
+  background: #090b10;
+  scrollbar-width: thin;
+}
+.qfe-right-head {
+  height: 44px;
+  padding: 0 10px;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  border-bottom: 1px solid var(--qfe-line);
+  background: #0b0e13;
+}
+.qfe-right-head strong {
+  font-size: 14px;
+}
+.qfe-right-head button {
+  border: 0;
+  background: transparent;
+  color: var(--qfe-sub);
+}
+.qfe-watch-scroll {
+  min-height: 140px;
+  max-height: 30vh;
+  overflow: auto;
+  scrollbar-width: thin;
+}
+.qfe-watch-columns,
+.qfe .qfe-watch-row {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) 57px 50px 61px;
+  gap: 4px;
+  padding: 9px 10px;
+  width: 100%;
+  font:
+    12px/18px "Geist Mono",
+    monospace;
+  text-align: right;
+  border: 0;
+  border-radius: 0;
+  min-height: 36px;
+}
+.qfe-watch-columns {
+  color: var(--qfe-muted);
+  border-bottom: 1px solid var(--qfe-line);
+  position: sticky;
+  top: 0;
+  background: #090b10;
+  z-index: 1;
+}
+.qfe-watch-columns span:first-child,
+.qfe-watch-code {
+  text-align: left;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.qfe .qfe-watch-row {
+  background: transparent;
+  border-top: 1px solid #ffffff08;
+  color: var(--qfe-sub);
+}
+.qfe .qfe-watch-row.active {
+  background: #141b25;
+}
+.qfe .qfe-watch-row:hover {
+  background: #11161f;
+}
+.qfe-info {
+  border-top: 1px solid var(--qfe-line);
+  background: #0c1016;
+}
+.qfe-summary {
+  padding: 14px 14px 12px;
+}
+.qfe-summary-top {
+  display: flex;
+  align-items: flex-start;
+  gap: 8px;
+}
+.qfe-token {
+  display: grid;
+  place-items: center;
+  flex-shrink: 0;
+  width: 28px;
+  height: 28px;
+  background: #d7a741;
+  color: #111;
+  border-radius: 50%;
+  font-size: 10px;
+  font-weight: 800;
+}
+.qfe-summary h1 {
+  font-size: 18px;
+  line-height: 1.2;
+  margin: 0;
+  font-weight: 800;
+}
+.qfe-summary-top p {
+  margin: 4px 0 0;
+  font-size: 13px;
+  line-height: 20px;
+  color: var(--qfe-sub);
+}
+.qfe-summary-price {
+  display: flex;
+  align-items: baseline;
+  gap: 8px;
+  margin: 10px 0 2px;
+  font:
+    700 13px/1.5 "Geist Mono",
+    monospace;
+}
+.qfe-summary-price strong {
+  font-size: 22px;
+}
+.qfe-price-basis {
+  font-size: 12px;
+  color: var(--qfe-muted);
+  margin: 2px 0 8px;
+  line-height: 18px;
+}
+.qfe-summary-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 8px;
+  margin: 10px 0 0;
+}
+.qfe-cell {
+  padding: 9px 10px;
+  border-radius: 10px;
+  background: #121821;
+  border: 1px solid var(--qfe-line);
+  min-width: 0;
+}
+.qfe-cell dt {
+  display: block;
+  color: var(--qfe-muted);
+  font-size: 12px;
+  margin-bottom: 5px;
+}
+.qfe-cell dd {
+  display: block;
+  font-size: 14px;
+  font-weight: 650;
+  line-height: 1.4;
+  margin: 0;
+  overflow-wrap: anywhere;
+}
+.qfe-info-tabs {
+  display: flex;
+  gap: 3px;
+  padding: 0 10px 10px;
+}
+.qfe-info-tabs button {
+  flex: 1;
+  min-width: 0;
+  padding: 0 7px;
+  background: #121821;
+  color: var(--qfe-sub);
+}
+.qfe-info-panel {
+  padding: 0 14px 14px;
+}
+.qfe-kv {
+  display: grid;
+  gap: 8px;
+  margin: 0;
+}
+.qfe-note {
+  padding: 12px;
+  color: var(--qfe-sub);
+  font-size: 13px;
+  line-height: 21px;
+  margin: 0;
+}
+.qfe-info-panel > .qfe-note {
+  background: #121821;
+  border: 1px solid var(--qfe-line);
+  border-radius: 10px;
+  margin-bottom: 10px;
+}
+.qfe-factor-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 12px;
+  font-variant-numeric: tabular-nums;
+}
+.qfe-factor-table th {
+  padding: 8px 2px;
+  color: var(--qfe-muted);
+  font-weight: 600;
+  text-align: left;
+  border-bottom: 1px solid var(--qfe-line);
+}
+.qfe-factor-table td {
+  padding: 9px 2px;
+  border-bottom: 1px solid #ffffff0d;
+  color: var(--qfe-sub);
+}
+.qfe-factor-table td:first-child {
+  white-space: nowrap;
+}
+.qfe-factor-table td:last-child {
+  font-size: 12px;
+}
+.qfe .qfe-side-scrim,
+.qfe .qfe-narrow-close {
+  display: none;
+}
+.qfe-popover {
+  position: fixed;
+  z-index: 80;
+  width: min(320px, calc(100vw - 16px));
+  max-height: calc(100dvh - 16px);
+  overflow: auto;
+  background: #141922;
+  border: 1px solid #465168;
+  border-radius: 10px;
+  box-shadow: 0 12px 32px #0005;
+  padding: 16px;
+  color: var(--qfe-text);
+  font-size: 14px;
+  scrollbar-width: thin;
+}
+.qfe-popover h2 {
+  font-size: 16px;
+  margin: 0 0 12px;
+  line-height: 24px;
+}
+.qfe-popover p {
+  font-size: 13px;
+  line-height: 20px;
+  color: var(--qfe-sub);
+  margin: 8px 0;
+}
+.qfe-popover label {
+  font-size: 13px;
+}
+.qfe-popover input,
+.qfe-popover select {
+  height: 36px;
+  border: 1px solid #465168;
+  border-radius: 6px;
+  background: #0f1319;
+  padding: 0 8px;
+  min-width: 0;
+  color-scheme: dark;
+}
+.qfe-popover input[type="search"] {
+  width: 100%;
+  margin-top: 6px;
+}
+.qfe-field {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 8px 0;
+}
+.qfe-field label {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+.qfe-field input[type="number"] {
+  width: 78px;
+}
+.qfe-field input[type="checkbox"] {
+  height: 18px;
+  width: 18px;
+  accent-color: #e85f32;
+}
+.qfe-field-stack {
+  display: grid;
+  gap: 6px;
+  margin: 12px 0;
+}
+.qfe-field-stack input {
+  width: 100%;
+}
+.qfe-actions {
+  display: flex;
+  gap: 8px;
+  align-items: center;
+  justify-content: flex-end;
+  margin-top: 12px;
+  font-size: 12px;
+}
+.qfe-actions button {
+  font-size: 13px;
+}
+.qfe .qfe-menu-item {
+  display: flex;
+  width: 100%;
+  justify-content: space-between;
+  background: transparent;
+  border: 0;
+  padding: 0 10px;
+  margin: 3px 0;
+  height: 32px;
+  font-size: 13px;
+}
+.qfe .qfe-menu-item[aria-pressed="true"] {
+  background: #e85f3224;
+}
+.qfe-results {
+  max-height: 40vh;
+  overflow: auto;
+  scrollbar-width: thin;
+}
+.qfe-search-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 12px 0;
+  border-bottom: 1px solid var(--qfe-line2);
+}
+.qfe-search-row > div {
+  flex: 1;
+  min-width: 0;
+}
+.qfe-search-row strong {
+  display: block;
+  font-size: 13px;
+  overflow-wrap: anywhere;
+}
+.qfe-search-row small {
+  display: block;
+  font-size: 12px;
+  color: var(--qfe-muted);
+  margin-top: 4px;
+}
+.qfe-search-row button {
+  flex-shrink: 0;
+}
+.qfe .qfe-error {
+  color: #f29387;
+}
+.qfe-error button {
+  margin: 4px 8px;
+}
+.qfe-toast {
+  position: fixed;
+  left: 50%;
+  bottom: 24px;
+  transform: translateX(-50%);
+  z-index: 100;
+  padding: 10px 16px;
+  background: #141922;
+  border: 1px solid #465168;
+  border-radius: 8px;
+  box-shadow: 0 12px 32px #0005;
+  color: var(--qfe-text);
+  max-width: calc(100vw - 32px);
+  font-size: 13px;
+}
+@media (max-width: 1320px) {
+  .qfe-ma-buttons {
+    display: none;
+  }
+}
+@media (max-width: 1320px) {
+  .qfe-workspace.qfe-side-open {
+    grid-template-columns: 46px minmax(0, 1fr) 300px;
+  }
+  .qfe-breadcrumb {
+    display: none;
+  }
+  .qfe-chart-top {
+    padding: 0 10px;
+  }
+  .qfe-chart-top > button {
+    padding: 0 8px;
+  }
+}
+@media (max-width: 1080px) {
+  .qfe-workspace.qfe-side-open {
+    grid-template-columns: 46px minmax(0, 1fr);
+  }
+  .qfe-right {
+    grid-column: auto;
+    grid-row: auto;
+    position: absolute;
+    right: 0;
+    top: 0;
+    bottom: 0;
+    width: min(360px, 100%);
+    z-index: 65;
+    box-shadow: -12px 0 30px #0004;
+  }
+  .qfe .qfe-side-scrim {
+    display: block;
+    position: absolute;
+    inset: 0;
+    z-index: 60;
+    border: 0;
+    border-radius: 0;
+    background: #0006;
+    min-height: 0;
+    padding: 0;
+  }
+  .qfe .qfe-side-scrim:hover {
+    background: #0006;
+  }
+  .qfe .qfe-narrow-close {
+    display: inline-flex;
+  }
+  .qfe-quotes {
+    display: none;
+  }
+  .qfe-replay {
+    left: 12px;
+    right: 12px;
+    transform: none;
+    flex-wrap: wrap;
+    white-space: normal;
+    max-width: none;
+    width: fit-content;
+  }
+}
+@media (max-width: 700px) {
+  .qfe {
+    grid-template-rows: 46px minmax(0, 1fr);
+  }
+  .qfe-topbar {
+    padding: 0 8px;
+    gap: 6px;
+  }
+  .qfe-brand strong,
+  .qfe .qfe-top-alert {
+    display: none;
+  }
+  .qfe-brand {
+    gap: 0;
+  }
+  .qfe-top-actions {
+    gap: 4px;
+  }
+  .qfe-top-actions button {
+    width: 32px;
+    padding: 0;
+    gap: 0;
+  }
+  .qfe-top-actions button span {
+    display: none;
+  }
+  .qfe .qfe-back {
+    padding: 0 8px;
+    gap: 4px;
+    font-size: 0;
+  }
+  .qfe-back span {
+    display: none;
+  }
+  .qfe-back:after {
+    content: "返回";
+    font-size: 12px;
+  }
+  .qfe-symbol {
+    padding: 0 7px;
+    font-size: 12px;
+  }
+  .qfe-symbol:before {
+    display: none;
+  }
+  .qfe-workspace,
+  .qfe-workspace.qfe-side-open {
+    grid-template-columns: 42px minmax(0, 1fr);
+    grid-template-rows: 46px minmax(0, 1fr) 30px;
+  }
+  .qfe-tools {
+    gap: 8px;
+  }
+  .qfe-chart-top {
+    padding: 0 8px;
+    gap: 5px;
+  }
+  .qfe-control-label {
+    display: none;
+  }
+  .qfe-chart-caption {
+    padding: 10px 10px 0;
+    gap: 4px 8px;
+  }
+  .qfe-ohlc {
+    padding: 3px 10px 6px;
+    gap: 2px 8px;
+    font-size: 12px;
+  }
+  .qfe-ohlc span:nth-last-child(-n + 2) {
+    display: none;
+  }
+  .qfe-timeline {
+    padding: 0 8px;
+    font-size: 12px;
+  }
+  .qfe-timeline > span:last-child {
+    display: none;
+  }
+  .qfe-watermark {
+    font-size: 20px;
+    left: 10px;
+  }
+  .qfe-replay {
+    padding: 8px;
+    gap: 6px;
+  }
+  .qfe-tool-status {
+    padding: 6px;
+    left: 8px;
+    max-width: calc(100% - 16px);
+  }
+}
+@media (prefers-reduced-motion: reduce) {
+  .qfe * {
+    animation: none !important;
+    transition: none !important;
+  }
+}
+
+.qfe .qfe-drawing-input {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  z-index: 9;
+  touch-action: none;
+  cursor: crosshair;
+}

--- a/frontend/src/pages/etf/etfData.ts
+++ b/frontend/src/pages/etf/etfData.ts
@@ -1,0 +1,216 @@
+import type {
+  EtfAdjustmentFactor,
+  EtfDailyBar,
+} from "../../api/dataCollections";
+
+export type Period = "day" | "week" | "month" | "year";
+export type Adjustment = "raw" | "forward" | "backward";
+export const PERIODS: Record<Period, string> = {
+  day: "日",
+  week: "周",
+  month: "月",
+  year: "年",
+};
+export const ADJUSTMENTS: Record<Adjustment, string> = {
+  raw: "不复权",
+  forward: "前复权",
+  backward: "后复权",
+};
+export const MA_COLORS = ["#B68B3D", "#4F8F8B", "#4E7C9C", "#8B6596"];
+export interface Bar {
+  timestamp: number;
+  date: string;
+  open: number;
+  high: number;
+  low: number;
+  close: number;
+  volume?: number;
+  turnover?: number;
+}
+export interface IndicatorSettings {
+  MA: boolean;
+  VOL: boolean;
+  MACD: boolean;
+  RSI: boolean;
+  ma: number[];
+  maVisible: boolean[];
+  macd: number[];
+  rsi: number;
+  vol: number;
+}
+export const DEFAULT_INDICATORS: IndicatorSettings = {
+  MA: true,
+  VOL: true,
+  MACD: false,
+  RSI: false,
+  ma: [5, 10, 20, 60],
+  maVisible: [true, true, true, true],
+  macd: [12, 26, 9],
+  rsi: 14,
+  vol: 5,
+};
+
+export function numeric(value: unknown): number | null {
+  if (
+    value === null ||
+    value === undefined ||
+    (typeof value !== "number" && typeof value !== "string") ||
+    String(value).trim() === ""
+  )
+    return null;
+  const result = Number(value);
+  return Number.isFinite(result) ? result : null;
+}
+export function numberText(value: unknown, digits = 3): string {
+  const n = numeric(value);
+  return n === null
+    ? "—"
+    : n.toLocaleString("zh-CN", {
+        minimumFractionDigits: digits,
+        maximumFractionDigits: digits,
+      });
+}
+export function signed(value: unknown, digits = 3): string {
+  const n = numeric(value);
+  return n === null ? "—" : `${n > 0 ? "+" : ""}${numberText(n, digits)}`;
+}
+export function direction(value: unknown): string {
+  const n = numeric(value);
+  return n === null || n === 0 ? "neutral" : n > 0 ? "up" : "down";
+}
+export const exchangeName = (value: string | null | undefined) =>
+  ({ SH: "上交所", SSE: "上交所", SZ: "深交所", SZSE: "深交所" })[
+    value ?? ""
+  ] ??
+  value ??
+  "—";
+export const dateText = (value: string | null | undefined) =>
+  value?.replaceAll("-", "/") ?? "—";
+export const timeText = (value: string | null | undefined) =>
+  value
+    ? new Intl.DateTimeFormat("zh-CN", {
+        timeZone: "Asia/Shanghai",
+        month: "2-digit",
+        day: "2-digit",
+        hour: "2-digit",
+        minute: "2-digit",
+        hour12: false,
+      }).format(new Date(value))
+    : "—";
+
+function bucket(date: string, period: Period): string {
+  if (period === "day") return date;
+  if (period === "month") return date.slice(0, 7);
+  if (period === "year") return date.slice(0, 4);
+  const d = new Date(`${date}T00:00:00Z`);
+  d.setUTCDate(d.getUTCDate() - ((d.getUTCDay() + 6) % 7));
+  return d.toISOString().slice(0, 10);
+}
+
+export function buildSeries(
+  source: EtfDailyBar[],
+  factors: EtfAdjustmentFactor[],
+  adjustment: Adjustment,
+  period: Period,
+  cutoff?: string,
+): { bars: Bar[]; error: string; volumeMissing: boolean } {
+  // Truncate before adjustment and aggregation: replay must not use a future
+  // factor as its anchor or include future sessions in a weekly/monthly bar.
+  const rows = [...source]
+    .filter((r) => !cutoff || r.trade_date <= cutoff)
+    .sort((a, b) => a.trade_date.localeCompare(b.trade_date));
+  const factorMap = new Map(
+    factors.map((f) => [f.trade_date, numeric(f.adj_factor)]),
+  );
+  if (!rows.length) return { bars: [], error: "", volumeMissing: false };
+  const invalid = rows.filter((r) => {
+    const o = numeric(r.open),
+      h = numeric(r.high),
+      l = numeric(r.low),
+      c = numeric(r.close);
+    return (
+      o === null ||
+      h === null ||
+      l === null ||
+      c === null ||
+      Math.min(o, h, l, c) <= 0 ||
+      h < Math.max(o, c, l) ||
+      l > Math.min(o, c)
+    );
+  });
+  // Block an invalid price series rather than dropping dates and bridging a
+  // gap with a plausible-looking moving average. Raw facts remain inspectable.
+  if (invalid.length)
+    return {
+      bars: [],
+      error: `${invalid.length} 条日线价格缺失或无效（首条 ${invalid[0].trade_date}），请核查采集数据后重试。`,
+      volumeMissing: false,
+    };
+  const missing =
+    adjustment === "raw"
+      ? []
+      : rows.filter(
+          (r) =>
+            !factorMap.get(r.trade_date) || factorMap.get(r.trade_date)! <= 0,
+        );
+  if (missing.length)
+    return {
+      bars: [],
+      error: `${ADJUSTMENTS[adjustment]}缺少 ${missing.length} 个交易日的有效复权因子（${missing[0].trade_date} 至 ${missing.at(-1)!.trade_date}）。请补采，或切回不复权。`,
+      volumeMissing: false,
+    };
+  const anchor =
+    adjustment === "raw"
+      ? 1
+      : factorMap.get(
+          (adjustment === "forward" ? rows.at(-1)! : rows[0]).trade_date,
+        )!;
+  const result: Bar[] = [];
+  let lastBucket = "",
+    volumeMissing = false;
+  for (const row of rows) {
+    const scale =
+      adjustment === "raw" ? 1 : factorMap.get(row.trade_date)! / anchor;
+    const volume = numeric(row.vol),
+      turnover = numeric(row.amount);
+    if (volume === null || volume < 0) volumeMissing = true;
+    const bar: Bar = {
+      timestamp: Date.parse(`${row.trade_date}T00:00:00Z`),
+      date: row.trade_date,
+      open: numeric(row.open)! * scale,
+      high: numeric(row.high)! * scale,
+      low: numeric(row.low)! * scale,
+      close: numeric(row.close)! * scale,
+      volume: volume === null || volume < 0 ? undefined : volume,
+      turnover: turnover === null || turnover < 0 ? undefined : turnover,
+    };
+    const key = bucket(row.trade_date, period),
+      prior = result.at(-1);
+    if (prior && key === lastBucket) {
+      prior.timestamp = bar.timestamp;
+      prior.date = bar.date;
+      prior.high = Math.max(prior.high, bar.high);
+      prior.low = Math.min(prior.low, bar.low);
+      prior.close = bar.close;
+      prior.volume =
+        prior.volume === undefined || bar.volume === undefined
+          ? undefined
+          : prior.volume + bar.volume;
+      prior.turnover =
+        prior.turnover === undefined || bar.turnover === undefined
+          ? undefined
+          : prior.turnover + bar.turnover;
+    } else result.push(bar);
+    lastBucket = key;
+  }
+  return { bars: result, error: "", volumeMissing };
+}
+
+export function validParams(key: string, values: number[]): boolean {
+  return (
+    values.length === ({ MA: 4, MACD: 3, RSI: 1, VOL: 1 }[key] ?? 0) &&
+    values.length > 0 &&
+    values.every((v) => Number.isInteger(v) && v >= 1 && v <= 250) &&
+    (key !== "MACD" || values[0] < values[1])
+  );
+}

--- a/frontend/tests/etf-workspace.test.cjs
+++ b/frontend/tests/etf-workspace.test.cjs
@@ -1,0 +1,214 @@
+// Fixtures are calculation/contract tests only; the workspace loads real APIs.
+const { test } = require("node:test");
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const ts = require("typescript");
+require.extensions[".ts"] = (module, filename) =>
+  module._compile(
+    ts.transpileModule(fs.readFileSync(filename, "utf8"), {
+      compilerOptions: {
+        module: ts.ModuleKind.CommonJS,
+        target: ts.ScriptTarget.ES2022,
+      },
+      fileName: filename,
+    }).outputText,
+    filename,
+  );
+const {
+  buildSeries,
+  numeric,
+  numberText,
+  signed,
+  validParams,
+} = require("../src/pages/etf/etfData.ts");
+const daily = (date, price = 10, extra = {}) => ({
+  ts_code: "TEST.SH",
+  trade_date: date,
+  open: String(price),
+  high: String(price + 2),
+  low: String(price - 1),
+  close: String(price + 1),
+  vol: "100",
+  amount: "1000",
+  source: "fixture",
+  updated_at: "2026-09-01T00:00:00Z",
+  ...extra,
+});
+const factor = (date, value) => ({
+  ts_code: "TEST.SH",
+  trade_date: date,
+  adj_factor: String(value),
+  source: "fixture",
+  updated_at: "2026-09-01T00:00:00Z",
+});
+
+test("missing quote facts never render as zero or fabricate a sign", () => {
+  for (const value of [
+    null,
+    undefined,
+    "",
+    " ",
+    "bad",
+    NaN,
+    Infinity,
+    {},
+    false,
+  ]) {
+    assert.equal(numeric(value), null);
+    assert.equal(numberText(value), "—");
+    assert.equal(signed(value), "—");
+  }
+  assert.equal(numberText("0"), "0.000");
+  assert.equal(signed("0"), "0.000");
+  assert.equal(signed("1"), "+1.000");
+  assert.equal(signed("-1"), "-1.000");
+});
+test("daily series sorts without mutating API records and retains real volume units", () => {
+  const source = [daily("2026-08-04", 20), daily("2026-08-03", 10)];
+  const copy = structuredClone(source);
+  const result = buildSeries(source, [], "raw", "day");
+  assert.equal(result.error, "");
+  assert.deepEqual(source, copy);
+  assert.deepEqual(
+    result.bars.map((x) => x.date),
+    ["2026-08-03", "2026-08-04"],
+  );
+  assert.equal(result.bars[0].volume, 100);
+  assert.equal(result.bars[0].turnover, 1000);
+});
+test("weekly and monthly aggregation uses first open, extrema, last close and summed original volume", () => {
+  const rows = [
+    daily("2026-07-31", 10),
+    daily("2026-08-03", 20),
+    daily("2026-08-04", 30),
+  ];
+  for (const period of ["week", "month"]) {
+    const { bars } = buildSeries(rows, [], "raw", period);
+    assert.equal(bars.length, 2);
+    assert.deepEqual(bars[1], {
+      timestamp: Date.parse("2026-08-04T00:00:00Z"),
+      date: "2026-08-04",
+      open: 20,
+      high: 32,
+      low: 19,
+      close: 31,
+      volume: 200,
+      turnover: 2000,
+    });
+  }
+  const { bars } = buildSeries(rows, [], "raw", "year");
+  assert.equal(bars.length, 1);
+  assert.equal(bars[0].open, 10);
+  assert.equal(bars[0].close, 31);
+});
+test("replay excludes future OHLC, future factor anchors and future partial-period records", () => {
+  const rows = [
+    daily("2026-08-03", 10),
+    daily("2026-08-04", 20),
+    daily("2026-08-05", 100),
+  ];
+  const factors = [
+    factor("2026-08-03", 1),
+    factor("2026-08-04", 2),
+    factor("2026-08-05", 10),
+  ];
+  const replay = buildSeries(rows, factors, "forward", "week", "2026-08-04");
+  assert.equal(replay.bars.length, 1);
+  assert.equal(replay.bars[0].open, 5);
+  assert.equal(replay.bars[0].close, 21);
+  assert.equal(replay.bars[0].high, 22);
+  assert.equal(replay.bars[0].volume, 200);
+  assert.deepEqual(
+    replay,
+    buildSeries(rows.slice(0, 2), factors.slice(0, 2), "forward", "week"),
+  );
+});
+test("forward/backward factors adjust price only, without changing underlying records", () => {
+  const rows = [daily("2026-08-03"), daily("2026-08-04")],
+    factors = [factor("2026-08-03", 1), factor("2026-08-04", 2)];
+  const forward = buildSeries(rows, factors, "forward", "day").bars,
+    backward = buildSeries(rows, factors, "backward", "day").bars;
+  assert.equal(forward[0].close, 5.5);
+  assert.equal(forward[1].close, 11);
+  assert.equal(backward[0].close, 11);
+  assert.equal(backward[1].close, 22);
+  assert.equal(backward[1].volume, 100);
+  assert.equal(rows[0].close, "11");
+});
+test("incomplete factors block adjusted chart but raw chart remains usable", () => {
+  const rows = [daily("2026-08-03"), daily("2026-08-04")];
+  for (const value of [0, -1, "bad"]) {
+    const result = buildSeries(
+      rows,
+      [factor("2026-08-03", 1), factor("2026-08-04", value)],
+      "forward",
+      "day",
+    );
+    assert.equal(result.bars.length, 0);
+    assert.match(result.error, /2026-08-04/);
+  }
+  assert.equal(buildSeries(rows, [], "raw", "day").bars.length, 2);
+  assert.equal(
+    buildSeries(rows, [factor("2026-08-03", 1)], "forward", "day", "2026-08-03")
+      .error,
+    "",
+  );
+});
+test("invalid prices block instead of silently skipping a trading day and bridging MA", () => {
+  for (const extra of [
+    { open: null },
+    { close: "" },
+    { high: "3" },
+    { low: "15" },
+    { close: "0" },
+    { high: "Infinity" },
+  ]) {
+    const result = buildSeries(
+      [
+        daily("2026-08-03"),
+        daily("2026-08-04", 10, extra),
+        daily("2026-08-05"),
+      ],
+      [],
+      "raw",
+      "day",
+    );
+    assert.equal(result.bars.length, 0);
+    assert.match(result.error, /2026-08-04/);
+  }
+});
+test("missing volume propagates across aggregates without pretending to be zero", () => {
+  const result = buildSeries(
+    [daily("2026-08-03"), daily("2026-08-04", 10, { vol: null, amount: null })],
+    [],
+    "raw",
+    "week",
+  );
+  assert.equal(result.volumeMissing, true);
+  assert.equal(result.error, "");
+  assert.equal(result.bars[0].volume, undefined);
+  assert.equal(result.bars[0].turnover, undefined);
+  const zero = buildSeries(
+    [daily("2026-08-03", 10, { vol: "0", amount: "0" })],
+    [],
+    "raw",
+    "day",
+  );
+  assert.equal(zero.volumeMissing, false);
+  assert.equal(zero.bars[0].volume, 0);
+});
+test("indicator periods reject empty, fractional, invalid and inverted MACD settings", () => {
+  assert.equal(validParams("MACD", [12, 26, 9]), true);
+  assert.equal(validParams("MA", [5, 10, 20, 60]), true);
+  for (const params of [
+    [0, 10, 20, 60],
+    [-1, 10, 20, 60],
+    [251, 10, 20, 60],
+    [1.5, 10, 20, 60],
+    [NaN, 10, 20, 60],
+    [],
+  ])
+    assert.equal(validParams("MA", params), false);
+  assert.equal(validParams("MACD", [26, 12, 9]), false);
+  assert.equal(validParams("MACD", [12, 12, 9]), false);
+});


### PR DESCRIPTION
将 ETF 详情页升级为已验收的行情研究工作区：浅色顶栏、局部深色图表、绘图工具与自选/资料侧栏，沿用既有鉴权及返回市场的筛选上下文。

- 接入 PR #36 已部署的真实持久自选接口，支持搜索、添加、移除及收盘摘要。自选弹层限制在侧栏内；管理自选与指标弹层均无需“完成”按钮。
- 提供日/周/月/年线、前后复权、日期视口、MA/VOL/MACD/RSI 参数、全屏、绘图和历史回放。日期视口保留完整指标预热；回放先截断数据，再复权、聚合和计算，退出恢复此前视口。
- 保留真实缺失状态：涨跌未采集显示“—”，复权因子不全说明缺失日期，成交量缺失不伪造为零。盘口及警报明确尚未接入。
- 绘图按标的和复权基准隔离；修复快速点击丢锚点、空图日期定位及窄屏侧栏遮罩问题。样式仅作用于 ETF 工作区。

验证：

- 用户已完成本页验收。
- 前端测试 49 项通过，TypeScript/Vite 构建及版本一致性检查通过。
- 真实测试后端验证 561250.SH 的缺因子/涨跌缺失、自选持久化与清理、回放、因子分页；510300.SH 的 3466 条历史、MA60 预热、周线量额与截止日回放核对一致。
- 隔离浏览器验证五类绘图、多指标、回放视口恢复、缩放与全屏；1440/1280/390px 弹层边界及窄屏侧栏检查通过，最终无 pageerror。

本 PR 仅变更前端，不新增后端迁移或触发采集；原稿和本地计划文档不提交。
