### PR TITLE
Fix PostgreSQL strategy-scoped backtest queries

### DIFF
--- a/backend/app/backtesting/run_repository.py
+++ b/backend/app/backtesting/run_repository.py
@@ -729,7 +729,9 @@ class DatabaseRunRepository:
         if strategy_id is not None:
             statement = statement.join(
                 StrategyRevision,
-                StrategyRevision.id == BacktestRunRecord.strategy_revision_id,
+                # Legacy run bindings are text; cast the trusted UUID side so
+                # malformed historical text never causes a PostgreSQL UUID error.
+                cast(StrategyRevision.id, String) == BacktestRunRecord.strategy_revision_id,
             ).where(StrategyRevision.strategy_id == strategy_id)
         statement = (
             statement.order_by(BacktestRunRecord.created_at, BacktestRunRecord.id)
@@ -791,7 +793,9 @@ class DatabaseRunRepository:
         if strategy_id is not None:
             statement = statement.join(
                 StrategyRevision,
-                StrategyRevision.id == BacktestRunRecord.strategy_revision_id,
+                # Legacy run bindings are text; cast the trusted UUID side so
+                # malformed historical text never causes a PostgreSQL UUID error.
+                cast(StrategyRevision.id, String) == BacktestRunRecord.strategy_revision_id,
             ).where(StrategyRevision.strategy_id == strategy_id)
 
         query_payload = {

--- a/backend/tests/test_strategy_run_queries_postgresql.py
+++ b/backend/tests/test_strategy_run_queries_postgresql.py
@@ -1,0 +1,62 @@
+"""Regression coverage for UUID strategy revisions joined to textual run bindings."""
+import os
+from uuid import uuid4
+
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import Session
+
+from app.core.config import get_settings
+from app.strategies.service import StrategyStorageService
+from app.backtesting.models import BacktestRunRecord
+from app.backtesting.run_repository import DatabaseRunRepository
+
+pytestmark = pytest.mark.skipif(
+    os.getenv("POSTGRES_TEST_ENABLED") != "1", reason="requires disposable PostgreSQL"
+)
+
+
+def test_strategy_run_queries_preserve_scope_and_cursor_with_text_bindings():
+    engine = create_engine(get_settings().database_url)
+    try:
+        with Session(engine) as session:
+            # All fixture writes roll back, including immutable revision records.
+            service = StrategyStorageService(session)
+            strategy = service.create_strategy(
+                name="UUID query regression", source_code="def run(context, parameters):\n    return {'mode': 'hold'}\n"
+            )
+            revision = service.publish_revision(strategy.id, expected_draft_version=1)
+            other = service.create_strategy(
+                name="Other strategy", source_code="def run(context, parameters):\n    return {'mode': 'hold'}\n"
+            )
+            other_revision = service.publish_revision(other.id, expected_draft_version=1)
+            owner = "test:" + uuid4().hex
+            matching = []
+            for binding, scope in [
+                (str(revision.id), owner), (str(revision.id), owner),
+                (str(other_revision.id), owner), (str(revision.id), owner + ":other"),
+                ("legacy-not-a-uuid", owner), (None, owner),
+            ]:
+                run_id = uuid4()
+                session.execute(BacktestRunRecord.__table__.insert().values(
+                    id=run_id, run_kind="backtest_run", profile="formal@1",
+                    status="queued", idempotency_key=str(run_id), config_hash="a" * 64,
+                    tenant_id=scope, idempotency_scope=scope, strategy_revision_id=binding,
+                ))
+                if binding == str(revision.id) and scope == owner:
+                    matching.append(run_id)
+            session.flush()
+            repo = DatabaseRunRepository(session)
+            assert {r.id for r in repo.list(strategy_id=str(strategy.id), owner_scope=owner)} == set(matching)
+            assert len(repo.list(strategy_id=str(strategy.id), owner_scope=owner, limit=1, offset=1)) == 1
+            args = dict(strategy_id=str(strategy.id), owner_scope=owner, limit=1, signing_key="test-cursor-key-at-least-thirty-two-characters")
+            first = repo.list_page(**args)
+            assert first.has_more and first.next_cursor
+            second = repo.list_page(**args, cursor=first.next_cursor)
+            assert not second.has_more
+            assert {first.items[0].id, second.items[0].id} == set(matching)
+            assert repo.list(strategy_id=str(uuid4()), owner_scope=owner) == []
+            assert not repo.list_page(**{**args, "strategy_id": str(uuid4())}).items
+            session.rollback()
+    finally:
+        engine.dispose()


### PR DESCRIPTION
策略工作台读取回测历史时，PostgreSQL 因 `strategy_revisions.id`（UUID）与 `backtest_runs.strategy_revision_id`（字符串）直接关联而返回 HTTP 500，空列表同样失败。将可信 UUID 一侧转换为字符串，使普通列表和游标分页都能按策略查询，同时避免历史非 UUID 文本触发转换异常。

新增真实 PostgreSQL 回归测试，覆盖策略隔离、所有者隔离、非 UUID/空历史引用、空结果、offset 与游标连续翻页。本地相关测试 30 通过；PostgreSQL 用例由 CI 的临时数据库执行。本 PR 仅包含后端修复与测试，前端工作台仍在本地等待逐页验收。

合并后需手动部署测试环境后端；无数据库迁移。
