### PR TITLE
Fix strategy workspace response serialization

### DIFF
--- a/backend/app/backtesting/component_config.py
+++ b/backend/app/backtesting/component_config.py
@@ -56,10 +56,11 @@ def resolve_components(slippage=None, selections=None, analyzers=()):
             validate_v1_analyzer_spec(constructed)
             if selected.key == "sharpe_config_rf":
                 resolve_config_rf_daily(constructed)
+        descriptor = entry.describe()
         return {"key": entry.key, "version": entry.version, "kind": kind,
                 "name_zh": entry.name_zh, "name_en": entry.name_en, "display_name": entry.display_name,
-                "parameters": parameters, "parameter_schema": dict(entry.parameter_schema),
-                "capabilities": dict(entry.capabilities)}
+                "parameters": parameters, "parameter_schema": descriptor["parameter_schema"],
+                "capabilities": descriptor["capabilities"]}
 
     result = {kind: resolve(kind, selected) for kind, selected in requested.items()}
     identities = [(item.key, item.version) for item in analyzers]

--- a/backend/tests/test_component_response_serialization.py
+++ b/backend/tests/test_component_response_serialization.py
@@ -1,0 +1,17 @@
+"""API configuration projections must contain JSON-serializable nested values."""
+from app.backtesting.component_config import resolve_components
+from app.strategies.schemas import StrategyBacktestWorkspaceResponse
+
+
+def test_workspace_serializes_real_component_descriptors():
+    components = resolve_components()
+    response = StrategyBacktestWorkspaceResponse(
+        strategy={}, published_revisions=[], slippage_models=[], formal_gate={},
+        component_options={kind: [value] for kind, value in components.items() if kind not in ('analyzer', 'slippage_model')},
+        runs={'items': []},
+    )
+    encoded = response.model_dump_json()
+    assert 'properties' in encoded
+    # Editing an API projection must not mutate the registry's frozen schema.
+    components['execution_model']['parameter_schema']['properties'].clear()
+    assert resolve_components()['execution_model']['parameter_schema']['properties']

--- a/backend/tests/test_strategy_run_queries_postgresql.py
+++ b/backend/tests/test_strategy_run_queries_postgresql.py
@@ -57,6 +57,22 @@ def test_strategy_run_queries_preserve_scope_and_cursor_with_text_bindings():
             assert {first.items[0].id, second.items[0].id} == set(matching)
             assert repo.list(strategy_id=str(uuid4()), owner_scope=owner) == []
             assert not repo.list_page(**{**args, "strategy_id": str(uuid4())}).items
+            # Exercise the whole HTTP response, not only repository SQL.
+            from fastapi import FastAPI
+            from fastapi.testclient import TestClient
+            from app.strategies.router import router
+            from app.db.session import get_db_session
+            from app.backtesting.run_router import _cursor_signing_key
+            app = FastAPI()
+            app.include_router(router)
+            app.dependency_overrides[get_db_session] = lambda: session
+            app.dependency_overrides[_cursor_signing_key] = lambda: args["signing_key"]
+            with TestClient(app) as client:
+                response = client.get(f"/api/admin/strategies/{strategy.id}/backtests")
+                assert response.status_code == 200
+                payload = response.json()
+                assert payload["published_revisions"][0]["id"] == str(revision.id)
+                assert payload["component_options"]["execution_model"][0]["parameter_schema"]["properties"]
             session.rollback()
     finally:
         engine.dispose()

--- a/backend/tests/test_strategy_run_queries_postgresql.py
+++ b/backend/tests/test_strategy_run_queries_postgresql.py
@@ -63,11 +63,9 @@ def test_strategy_run_queries_preserve_scope_and_cursor_with_text_bindings():
             import json
             from app.strategies.router import router
             from app.db.session import get_db_session
-            from app.backtesting.run_router import _cursor_signing_key
             app = FastAPI()
             app.include_router(router)
             app.dependency_overrides[get_db_session] = lambda: session
-            app.dependency_overrides[_cursor_signing_key] = lambda: args["signing_key"]
             async def request_workspace():
                 messages = []
                 async def receive():

--- a/backend/tests/test_strategy_run_queries_postgresql.py
+++ b/backend/tests/test_strategy_run_queries_postgresql.py
@@ -59,7 +59,8 @@ def test_strategy_run_queries_preserve_scope_and_cursor_with_text_bindings():
             assert not repo.list_page(**{**args, "strategy_id": str(uuid4())}).items
             # Exercise the whole HTTP response, not only repository SQL.
             from fastapi import FastAPI
-            from fastapi.testclient import TestClient
+            import asyncio
+            import json
             from app.strategies.router import router
             from app.db.session import get_db_session
             from app.backtesting.run_router import _cursor_signing_key
@@ -67,12 +68,24 @@ def test_strategy_run_queries_preserve_scope_and_cursor_with_text_bindings():
             app.include_router(router)
             app.dependency_overrides[get_db_session] = lambda: session
             app.dependency_overrides[_cursor_signing_key] = lambda: args["signing_key"]
-            with TestClient(app) as client:
-                response = client.get(f"/api/admin/strategies/{strategy.id}/backtests")
-                assert response.status_code == 200
-                payload = response.json()
-                assert payload["published_revisions"][0]["id"] == str(revision.id)
-                assert payload["component_options"]["execution_model"][0]["parameter_schema"]["properties"]
+            async def request_workspace():
+                messages = []
+                async def receive():
+                    return {"type": "http.request", "body": b"", "more_body": False}
+                async def send(message):
+                    messages.append(message)
+                await app({
+                    "type": "http", "asgi": {"version": "3.0"},
+                    "http_version": "1.1", "method": "GET", "scheme": "http",
+                    "path": f"/api/admin/strategies/{strategy.id}/backtests",
+                    "root_path": "", "query_string": b"", "headers": [],
+                    "server": ("test", 80), "client": ("127.0.0.1", 1234),
+                }, receive, send)
+                assert next(m for m in messages if m["type"] == "http.response.start")["status"] == 200
+                return json.loads(b"".join(m.get("body", b"") for m in messages if m["type"] == "http.response.body"))
+            payload = asyncio.run(request_workspace())
+            assert payload["published_revisions"][0]["id"] == str(revision.id)
+            assert payload["component_options"]["execution_model"][0]["parameter_schema"]["properties"]
             session.rollback()
     finally:
         engine.dispose()

--- a/backend/tests/test_strategy_run_queries_postgresql.py
+++ b/backend/tests/test_strategy_run_queries_postgresql.py
@@ -65,6 +65,8 @@ def test_strategy_run_queries_preserve_scope_and_cursor_with_text_bindings():
             from app.db.session import get_db_session
             app = FastAPI()
             app.include_router(router)
+            from app.core.config import Settings
+            app.state.settings = Settings(cursor_signing_key=args["signing_key"], api_token="test-api-token-at-least-thirty-two-characters")
             app.dependency_overrides[get_db_session] = lambda: session
             async def request_workspace():
                 messages = []


### PR DESCRIPTION
策略工作台的回测上下文接口在测试环境中完成 UUID 关联修复后，继续暴露组件配置中的 mappingproxy 无法被 Pydantic JSON 序列化，导致接口仍返回 HTTP 500。

本 PR 将组件描述的参数 Schema 和 capabilities 显式转换为普通 JSON dict，并补充 API 响应序列化回归测试；同时扩展 PostgreSQL 策略回测查询测试覆盖完整 workspace 响应。无数据库迁移。

验证：组件序列化测试通过；相关 PostgreSQL 测试在本地无测试数据库时按既有标记跳过，CI 将在临时 PostgreSQL 中执行完整套件。
