### PR TITLE
Build strategy workspace frontend

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -87,7 +87,7 @@ export function App() {
       />
       <Route
         path="/admin/strategies"
-        element={<RequireAuth><AdminPage><StrategiesPage /></AdminPage></RequireAuth>}
+        element={<RequireAuth><StrategiesPage /></RequireAuth>}
       />
       <Route
         path="/admin/backtest-accounts"
@@ -100,7 +100,7 @@ export function App() {
       <Route path="/admin/backtest-runs" element={<RequireAuth><AdminPage><BacktestRunsPage /></AdminPage></RequireAuth>} />
       <Route
         path="/admin/strategies/:strategyId"
-        element={<RequireAuth><AdminPage><StrategiesPage /></AdminPage></RequireAuth>}
+        element={<RequireAuth><StrategiesPage /></RequireAuth>}
       />
       <Route path="/admin/strategies/:strategyId/backtests" element={<RequireAuth><AdminPage><StrategyBacktestsPage /></AdminPage></RequireAuth>} />
       <Route path="*" element={<Navigate to="/admin" replace />} />

--- a/frontend/src/api/strategies.ts
+++ b/frontend/src/api/strategies.ts
@@ -82,7 +82,7 @@ export class StrategyApiError extends Error {
   constructor(
     message: string,
     readonly status: number,
-    readonly issues: StrategyValidationIssue[] = []
+    readonly issues: StrategyValidationIssue[] = [],
   ) {
     super(message);
     this.name = "StrategyApiError";
@@ -94,7 +94,7 @@ function headers(): HeadersInit {
   return token
     ? {
         Authorization: `Bearer ${token}`,
-        "Content-Type": "application/json"
+        "Content-Type": "application/json",
       }
     : { "Content-Type": "application/json" };
 }
@@ -105,27 +105,35 @@ function isValidationIssue(value: unknown): value is StrategyValidationIssue {
   return typeof issue.code === "string" && typeof issue.message === "string";
 }
 
-function parseErrorDetail(detail: unknown): { message: string; issues: StrategyValidationIssue[] } {
+function parseErrorDetail(detail: unknown): {
+  message: string;
+  issues: StrategyValidationIssue[];
+} {
   if (typeof detail === "string") return { message: detail, issues: [] };
-  if (!detail || typeof detail !== "object") return { message: "策略请求失败。", issues: [] };
+  if (!detail || typeof detail !== "object")
+    return { message: "策略请求失败。", issues: [] };
 
   const body = detail as Record<string, unknown>;
-  const issues = Array.isArray(body.issues) ? body.issues.filter(isValidationIssue) : [];
-  if (typeof body.message === "string") return { message: body.message, issues };
+  const issues = Array.isArray(body.issues)
+    ? body.issues.filter(isValidationIssue)
+    : [];
+  if (typeof body.message === "string")
+    return { message: body.message, issues };
   return { message: "策略请求校验失败。", issues };
 }
 
 async function request<T>(path: string, init?: RequestInit): Promise<T> {
   const response = await fetch(path, {
+    cache: "no-store",
     ...init,
-    headers: { ...headers(), ...init?.headers }
+    headers: { ...headers(), ...init?.headers },
   });
 
   if (!response.ok) {
     let message = `请求失败（HTTP ${response.status}）。`;
     let issues: StrategyValidationIssue[] = [];
     try {
-      const body = await response.json() as { detail?: unknown };
+      const body = (await response.json()) as { detail?: unknown };
       ({ message, issues } = parseErrorDetail(body.detail));
     } catch {
       // Keep the HTTP fallback when the response is not JSON.
@@ -137,77 +145,102 @@ async function request<T>(path: string, init?: RequestInit): Promise<T> {
   return response.json() as Promise<T>;
 }
 
-export function listStrategies(includeArchived = false): Promise<StrategySummary[]> {
-  const params = new URLSearchParams({ include_archived: String(includeArchived) });
+export function listStrategies(
+  includeArchived = false,
+  offset = 0,
+  limit = 100,
+): Promise<StrategySummary[]> {
+  const params = new URLSearchParams({
+    include_archived: String(includeArchived),
+    offset: String(offset),
+    limit: String(limit),
+  });
   return request<StrategySummary[]>(`/api/admin/strategies?${params}`);
 }
 
 export function getStrategy(strategyId: string): Promise<StrategyDetail> {
-  return request<StrategyDetail>(`/api/admin/strategies/${encodeURIComponent(strategyId)}`);
+  return request<StrategyDetail>(
+    `/api/admin/strategies/${encodeURIComponent(strategyId)}`,
+  );
 }
 
-export function createStrategy(payload: StrategyCreatePayload): Promise<StrategyDetail> {
+export function createStrategy(
+  payload: StrategyCreatePayload,
+): Promise<StrategyDetail> {
   return request<StrategyDetail>("/api/admin/strategies", {
     method: "POST",
-    body: JSON.stringify(payload)
+    body: JSON.stringify(payload),
   });
 }
 
 export function updateStrategyMetadata(
   strategyId: string,
-  payload: StrategyMetadataPayload
+  payload: StrategyMetadataPayload,
 ): Promise<StrategySummary> {
-  return request<StrategySummary>(`/api/admin/strategies/${encodeURIComponent(strategyId)}`, {
-    method: "PATCH",
-    body: JSON.stringify(payload)
-  });
+  return request<StrategySummary>(
+    `/api/admin/strategies/${encodeURIComponent(strategyId)}`,
+    {
+      method: "PATCH",
+      body: JSON.stringify(payload),
+    },
+  );
 }
 
 export function saveStrategyDraft(
   strategyId: string,
-  payload: StrategyDraftPayload
+  payload: StrategyDraftPayload,
 ): Promise<StrategyDraft> {
-  return request<StrategyDraft>(`/api/admin/strategies/${encodeURIComponent(strategyId)}/draft`, {
-    method: "PATCH",
-    body: JSON.stringify(payload)
-  });
+  return request<StrategyDraft>(
+    `/api/admin/strategies/${encodeURIComponent(strategyId)}/draft`,
+    {
+      method: "PATCH",
+      body: JSON.stringify(payload),
+    },
+  );
 }
 
-export function validateStrategy(strategyId: string): Promise<StrategyValidationResult> {
+export function validateStrategy(
+  strategyId: string,
+): Promise<StrategyValidationResult> {
   return request<StrategyValidationResult>(
     `/api/admin/strategies/${encodeURIComponent(strategyId)}/validate`,
-    { method: "POST" }
+    { method: "POST" },
   );
 }
 
 export function publishStrategy(
   strategyId: string,
-  draftVersion: number
+  draftVersion: number,
 ): Promise<StrategyRevision> {
-  return request<StrategyRevision>(`/api/admin/strategies/${encodeURIComponent(strategyId)}/publish`, {
-    method: "POST",
-    body: JSON.stringify({ draft_version: draftVersion })
-  });
+  return request<StrategyRevision>(
+    `/api/admin/strategies/${encodeURIComponent(strategyId)}/publish`,
+    {
+      method: "POST",
+      body: JSON.stringify({ draft_version: draftVersion }),
+    },
+  );
 }
 
-export function listStrategyRevisions(strategyId: string): Promise<StrategyRevisionSummary[]> {
+export function listStrategyRevisions(
+  strategyId: string,
+): Promise<StrategyRevisionSummary[]> {
   return request<StrategyRevisionSummary[]>(
-    `/api/admin/strategies/${encodeURIComponent(strategyId)}/revisions`
+    `/api/admin/strategies/${encodeURIComponent(strategyId)}/revisions`,
   );
 }
 
 export function getStrategyRevision(
   strategyId: string,
-  revisionNumber: number
+  revisionNumber: number,
 ): Promise<StrategyRevision> {
   return request<StrategyRevision>(
-    `/api/admin/strategies/${encodeURIComponent(strategyId)}/revisions/${revisionNumber}`
+    `/api/admin/strategies/${encodeURIComponent(strategyId)}/revisions/${revisionNumber}`,
   );
 }
 
 export function archiveStrategy(strategy: StrategySummary): Promise<void> {
   return request<void>(
     `/api/admin/strategies/${encodeURIComponent(strategy.id)}?version=${strategy.version}`,
-    { method: "DELETE" }
+    { method: "DELETE" },
   );
 }

--- a/frontend/src/components/OverviewShell.tsx
+++ b/frontend/src/components/OverviewShell.tsx
@@ -34,11 +34,11 @@ const destinations = [
 
 /** Reviewed overview, source and collection-task pages share this shell. Legacy routes retain their
  * existing theme setting until each page is reviewed and accepted separately. */
-export function OverviewShell({ children, title = "数据运营总览", section = "WORKBENCH", className = "" }: { children: React.ReactNode; title?: string; section?: string; className?: string }) {
+export function OverviewShell({ children, title = "数据运营总览", section = "WORKBENCH", className = "", workspace = false, beforeNavigate }: { children: React.ReactNode; title?: string; section?: string; className?: string; workspace?: boolean; beforeNavigate?: () => boolean }) {
   const { logout } = useAuth();
   const navigate = useNavigate();
   const location = useLocation();
-  const [collapsed, setCollapsed] = useState(() => window.innerWidth <= 1240);
+  const [collapsed, setCollapsed] = useState(() => { if (workspace) { try { return localStorage.getItem("qfs-sidebar") !== "expanded"; } catch { return true; } } return window.innerWidth <= 1240; });
   const [open, setOpen] = useState(false);
   const [query, setQuery] = useState("");
   const [selected, setSelected] = useState(0);
@@ -71,6 +71,7 @@ export function OverviewShell({ children, title = "数据运营总览", section 
     if (open) resultRef.current?.children[selected]?.scrollIntoView({ block: "nearest" });
   }, [selected, open]);
   function go(to: string) {
+    if (to === "logout" && beforeNavigate && !beforeNavigate()) return;
     close();
     if (to === "logout") { logout(); navigate("/login", { replace: true }); }
     else if (to === "/docs") window.open("/docs", "_blank", "noopener,noreferrer");
@@ -78,13 +79,14 @@ export function OverviewShell({ children, title = "数据运营总览", section 
   }
   function navItem(item: typeof toolItems[number], tool = false) {
     const Icon = item.icon;
-    const className = `qfo-nav-item${tool ? " qfo-tool-link" : ""}${item.to === location.pathname ? " qfo-active" : ""}${!item.to ? " qfo-nav-disabled" : ""}`;
+    const active=item.to === location.pathname || (workspace && item.to === "/admin/strategies" && location.pathname.startsWith("/admin/strategies/"));
+    const className = `qfo-nav-item${tool ? " qfo-tool-link" : ""}${active ? " qfo-active" : ""}${!item.to ? " qfo-nav-disabled" : ""}`;
     const label = item.to ? item.label : `${item.label}（尚未开放）`;
     const content = <><Icon aria-hidden="true" /><span>{item.label}</span></>;
     if (!item.to) return <button key={item.label} type="button" className={className} aria-disabled="true" aria-label={label} title={label}>{content}</button>;
     if (item.to === "logout") return <button key={item.label} type="button" className={className} aria-label={label} title={label} onClick={() => go(item.to)}>{content}</button>;
     if (item.to === "/docs") return <a key={item.label} className={className} aria-label={label} title={label} href="/docs" target="_blank" rel="noreferrer">{content}</a>;
-    return <Link key={item.label} className={className} aria-label={label} title={label} to={item.to} aria-current={item.to === location.pathname ? "page" : undefined}>{content}</Link>;
+    return <Link key={item.label} className={className} aria-label={label} title={label} to={item.to} aria-current={active ? "page" : undefined}>{content}</Link>;
   }
   return <div className={`qfo-root ${className}`}>
     <div className={`qfo-app${collapsed ? " qfo-sidebar-collapsed" : ""}`} inert={open}>
@@ -95,7 +97,7 @@ export function OverviewShell({ children, title = "数据运营总览", section 
       </aside>
       <section className="qfo-shell">
         <header className="qfo-topbar">
-          <button className="qfo-icon-btn qfo-sidebar-toggle" type="button" aria-label={collapsed ? "展开侧栏" : "收起侧栏"} title={collapsed ? "展开侧栏" : "收起侧栏"} aria-expanded={!collapsed} aria-controls="overview-navigation" onClick={() => setCollapsed(value => !value)}><Menu aria-hidden="true" /></button>
+          <button className="qfo-icon-btn qfo-sidebar-toggle" type="button" aria-label={collapsed ? "展开侧栏" : "收起侧栏"} title={collapsed ? "展开侧栏" : "收起侧栏"} aria-expanded={!collapsed} aria-controls="overview-navigation" onClick={() => setCollapsed(value => { if (workspace) { try { localStorage.setItem("qfs-sidebar", value ? "expanded" : "collapsed"); } catch { /* Storage is optional. */ } } return !value; })}><Menu aria-hidden="true" /></button>
           <div className="qfo-crumb"><span className="qfo-crumb-index">{section}</span><span className="qfo-crumb-sep">/</span><span className="qfo-crumb-title">{title}</span></div>
           <div className="qfo-top-actions"><button className="qfo-quick" type="button" aria-label="快速跳转" aria-haspopup="dialog" onClick={show}><Search aria-hidden="true" /><span>快速跳转</span><span className="qfo-kbd">⌘ K</span></button></div>
         </header>

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -1,17 +1,24 @@
 import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
-import { BrowserRouter } from "react-router-dom";
+import { createBrowserRouter, RouterProvider } from "react-router-dom";
 
 import { App } from "./App";
 import { AuthProvider } from "./auth/AuthContext";
 import "./styles.css";
 
-createRoot(document.getElementById("root")!).render(
-  <StrictMode>
-    <BrowserRouter>
+const router = createBrowserRouter([
+  {
+    path: "*",
+    element: (
       <AuthProvider>
         <App />
       </AuthProvider>
-    </BrowserRouter>
-  </StrictMode>
+    ),
+  },
+]);
+
+createRoot(document.getElementById("root")!).render(
+  <StrictMode>
+    <RouterProvider router={router} />
+  </StrictMode>,
 );

--- a/frontend/src/pages/StrategiesPage.tsx
+++ b/frontend/src/pages/StrategiesPage.tsx
@@ -1,25 +1,17 @@
 import {
   Archive,
-  CircleAlert,
-  CircleCheck,
-  Clock3,
   Code2,
-  Copy,
   ExternalLink,
-  FileCode2,
-  GitBranch,
-  History,
-  LoaderCircle,
   Plus,
   RefreshCw,
   Rocket,
   Save,
   ShieldCheck,
-  X
+  X,
 } from "lucide-react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import type { FormEvent, KeyboardEvent } from "react";
-import { Link, useNavigate, useParams } from "react-router-dom";
+import type { FormEvent } from "react";
+import { useBlocker, useNavigate, useParams } from "react-router-dom";
 
 import {
   archiveStrategy,
@@ -32,36 +24,19 @@ import {
   saveStrategyDraft,
   StrategyApiError,
   StrategyDetail,
-  StrategyDraft,
   StrategyRevision,
   StrategyRevisionSummary,
   StrategySummary,
   StrategyValidationIssue,
   StrategyValidationResult,
   updateStrategyMetadata,
-  validateStrategy
+  validateStrategy,
 } from "../api/strategies";
+import { OverviewShell } from "../components/OverviewShell";
+import { TEMPLATES, type TemplateKey } from "./strategies/templates";
+import { Drawer, ResizeHandle, RecentRuns } from "./strategies/WorkspaceParts";
+import "./strategies/StrategyWorkspace.css";
 import { useAuth } from "../auth/AuthContext";
-
-const SOURCE_TEMPLATE = `"""Private strategy entry point."""
-
-
-def run(context, parameters):
-    """Return one decision for the current step.
-
-    Two modes are supported in the first version:
-    - target_weights: submit the full target portfolio as
-      {"mode": "target_weights", "targets": {"<instrument_id>": "0.60"}}
-    - hold: submit no new trading intent with {"mode": "hold"}
-    """
-    return {"mode": "hold"}
-`;
-
-const EMPTY_PARAMETER_SCHEMA = {
-  type: "object",
-  properties: {},
-  additionalProperties: false
-};
 
 type EditorDraft = {
   name: string;
@@ -74,13 +49,13 @@ type EditorDraft = {
 type CreateDraft = {
   name: string;
   description: string;
-  sourceCode: string;
+  template: TemplateKey;
 };
 
 const EMPTY_CREATE_DRAFT: CreateDraft = {
   name: "",
   description: "",
-  sourceCode: SOURCE_TEMPLATE
+  template: "hold",
 };
 
 function prettyJson(value: Record<string, unknown>): string {
@@ -93,11 +68,14 @@ function editorDraftFromDetail(detail: StrategyDetail): EditorDraft {
     description: detail.description ?? "",
     sourceCode: detail.draft.source_code,
     parameterSchema: prettyJson(detail.draft.parameter_schema),
-    defaultParameters: prettyJson(detail.draft.default_parameters)
+    defaultParameters: prettyJson(detail.draft.default_parameters),
   };
 }
 
-function parseJsonObject(value: string, label: string): Record<string, unknown> {
+function parseJsonObject(
+  value: string,
+  label: string,
+): Record<string, unknown> {
   let parsed: unknown;
   try {
     parsed = JSON.parse(value);
@@ -114,7 +92,10 @@ function canonicalJson(value: unknown): string {
   if (Array.isArray(value)) return `[${value.map(canonicalJson).join(",")}]`;
   if (value && typeof value === "object") {
     const object = value as Record<string, unknown>;
-    return `{${Object.keys(object).sort().map((key) => `${JSON.stringify(key)}:${canonicalJson(object[key])}`).join(",")}}`;
+    return `{${Object.keys(object)
+      .sort()
+      .map((key) => `${JSON.stringify(key)}:${canonicalJson(object[key])}`)
+      .join(",")}}`;
   }
   return JSON.stringify(value) ?? "undefined";
 }
@@ -129,7 +110,7 @@ function formatTimestamp(value: string | null | undefined): string {
     day: "2-digit",
     hour: "2-digit",
     minute: "2-digit",
-    hour12: false
+    hour12: false,
   }).format(date);
 }
 
@@ -143,33 +124,52 @@ function issueLocation(issue: StrategyValidationIssue): string {
   return `第 ${issue.line} 行${issue.column ? `，第 ${issue.column} 列` : ""}`;
 }
 
-function stateLabel(detail: StrategyDetail, validation: StrategyValidationResult | null, isDirty: boolean): string {
+function stateLabel(
+  detail: StrategyDetail,
+  validation: StrategyValidationResult | null,
+  isDirty: boolean,
+): string {
   if (detail.state === "archived") return "已归档";
-  if (!isDirty && validation?.draft_version === detail.draft.version && !validation.valid) return "发布检查失败";
+  if (
+    !isDirty &&
+    validation?.draft_version === detail.draft.version &&
+    !validation.valid
+  )
+    return "发布检查失败";
   if (!detail.current_revision_id) return "从未发布";
   if (isDirty || detail.draft_changed_since_revision) return "草稿有未发布修改";
   return "已发布";
 }
 
-function isSameEditorDraft(detail: StrategyDetail, draft: EditorDraft): boolean {
-  return detail.name === draft.name
-    && (detail.description ?? "") === draft.description
-    && detail.draft.source_code === draft.sourceCode
-    && canonicalJson(detail.draft.parameter_schema) === canonicalJson(parseJsonObject(draft.parameterSchema, "参数 Schema"))
-    && canonicalJson(detail.draft.default_parameters) === canonicalJson(parseJsonObject(draft.defaultParameters, "默认参数"));
+function isSameEditorDraft(
+  detail: StrategyDetail,
+  draft: EditorDraft,
+): boolean {
+  return (
+    detail.name === draft.name &&
+    (detail.description ?? "") === draft.description &&
+    detail.draft.source_code === draft.sourceCode &&
+    canonicalJson(detail.draft.parameter_schema) ===
+      canonicalJson(parseJsonObject(draft.parameterSchema, "参数 Schema")) &&
+    canonicalJson(detail.draft.default_parameters) ===
+      canonicalJson(parseJsonObject(draft.defaultParameters, "默认参数"))
+  );
 }
 
 function sourceLineCount(source: string): number {
   return source.length === 0 ? 1 : source.split("\n").length;
 }
 
-function validationFromError(error: StrategyApiError, detail: StrategyDetail | null): StrategyValidationResult | null {
+function validationFromError(
+  error: StrategyApiError,
+  detail: StrategyDetail | null,
+): StrategyValidationResult | null {
   if (error.issues.length === 0 || !detail) return null;
   return {
     valid: false,
     draft_version: detail.draft.version,
     source_hash: detail.draft.source_hash,
-    issues: error.issues
+    issues: error.issues,
   };
 }
 
@@ -189,9 +189,13 @@ export function StrategiesPage() {
   const [detail, setDetail] = useState<StrategyDetail | null>(null);
   const [revisions, setRevisions] = useState<StrategyRevisionSummary[]>([]);
   const [draft, setDraft] = useState<EditorDraft | null>(null);
-  const [validation, setValidation] = useState<StrategyValidationResult | null>(null);
-  const [revisionPreview, setRevisionPreview] = useState<StrategyRevision | null>(null);
-  const [createDraft, setCreateDraft] = useState<CreateDraft>(EMPTY_CREATE_DRAFT);
+  const [validation, setValidation] = useState<StrategyValidationResult | null>(
+    null,
+  );
+  const [revisionPreview, setRevisionPreview] =
+    useState<StrategyRevision | null>(null);
+  const [createDraft, setCreateDraft] =
+    useState<CreateDraft>(EMPTY_CREATE_DRAFT);
   const [createOpen, setCreateOpen] = useState(false);
   const [revisionLoading, setRevisionLoading] = useState(false);
   const [loadingList, setLoadingList] = useState(true);
@@ -203,84 +207,230 @@ export function StrategiesPage() {
   const [archiving, setArchiving] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [notice, setNotice] = useState<string | null>(null);
-  const [search, setSearch] = useState("");
+  const [search, setSearch] = useState(() => sessionValue("search", ""));
   const detailRequestSequence = useRef(0);
   const revisionRequestSequence = useRef(0);
 
-  const selectedSummary = strategies.find((item) => item.id === strategyId) ?? null;
   const isArchived = detail?.state === "archived";
-  const isDirty = Boolean(detail && draft && !isSameEditorDraftSafe(detail, draft));
-  const publishedCount = strategies.filter((item) => item.current_revision_id !== null).length;
-  const draftCount = strategies.length - publishedCount;
+  const isDirty = Boolean(
+    detail && draft && !isSameEditorDraftSafe(detail, draft),
+  );
+  const busy = saving || validating || publishing || archiving || refreshing;
+  const [file, setFile] = useState<
+    "sourceCode" | "defaultParameters" | "description"
+  >("sourceCode");
+  const [panel, setPanel] = useState("parameters");
+  const [filter, setFilter] = useState(() => sessionValue("filter", "all"));
+  const [overlay, setOverlay] = useState("");
+  const [explorer, setExplorer] = useState(
+      () => sessionValue("explorer", "true") === "true",
+    ),
+    [contextOpen, setContextOpen] = useState(
+      () => sessionValue("context", "true") === "true",
+    );
+  const [diagnostics, setDiagnostics] = useState(false);
+  const [sizes, setSizes] = useState(() => {
+    try {
+      return {
+        ...{ left: 228, right: 320, bottom: 180 },
+        ...JSON.parse(sessionStorage.getItem("qfs-sizes") || "{}"),
+      };
+    } catch {
+      return { left: 228, right: 320, bottom: 180 };
+    }
+  });
+  const [narrow, setNarrow] = useState(window.innerWidth < 1200);
+  const [cursor, setCursor] = useState({ line: 1, column: 1 });
+  const editorRef = useRef<HTMLTextAreaElement>(null),
+    linesRef = useRef<HTMLPreElement>(null);
+  const lock = useRef(false);
+  const guardRef = useRef({ dirty: false, busy: false });
+  guardRef.current = {
+    dirty:
+      isDirty ||
+      Boolean(
+        createOpen &&
+          (createDraft.name ||
+            createDraft.description ||
+            createDraft.template !== "hold"),
+      ),
+    busy,
+  };
+  function canLeave() {
+    if (guardRef.current.busy) {
+      setNotice("操作进行中，请稍后再离开。");
+      return false;
+    }
+    return (
+      !guardRef.current.dirty ||
+      window.confirm("当前草稿尚未保存，确定放弃修改并离开吗？")
+    );
+  }
+  useEffect(() => {
+    try {
+      sessionStorage.setItem("qfs-sizes", JSON.stringify(sizes));
+    } catch {
+      /* Storage is optional. */
+    }
+  }, [sizes]);
+  useEffect(() => {
+    const resize = () => setNarrow(window.innerWidth < 1200);
+    window.addEventListener("resize", resize);
+    return () => window.removeEventListener("resize", resize);
+  }, []);
+  const workbenchRef = useRef<HTMLDivElement>(null);
+  useEffect(() => {
+    const el = workbenchRef.current;
+    if (!el) return;
+    const resize = new ResizeObserver(([entry]) =>
+      setNarrow(
+        entry.contentRect.width < 360 + sizes.left + sizes.right + 16 ||
+          window.innerWidth < 900,
+      ),
+    );
+    resize.observe(el);
+    return () => resize.disconnect();
+  }, [sizes.left, sizes.right]);
+  useEffect(() => {
+    try {
+      for (const [k, v] of Object.entries({
+        search,
+        filter,
+        explorer,
+        context: contextOpen,
+      }))
+        sessionStorage.setItem("qfs-" + k, String(v));
+    } catch {
+      /* Storage is optional. */
+    }
+  }, [search, filter, explorer, contextOpen]);
+  const explorerVisible = narrow ? overlay === "explorer" : explorer,
+    contextVisible = narrow ? overlay === "context" : contextOpen;
+  const blocker = useBlocker(() => !canLeave());
+  useEffect(() => {
+    if (blocker.state === "blocked") blocker.reset();
+  }, [blocker]);
+  useEffect(() => {
+    const unload = (event: BeforeUnloadEvent) => {
+      if (guardRef.current.dirty || guardRef.current.busy) {
+        event.preventDefault();
+        event.returnValue = "";
+      }
+    };
+    window.addEventListener("beforeunload", unload);
+    return () => window.removeEventListener("beforeunload", unload);
+  }, []);
+  useEffect(() => {
+    const key = (e: globalThis.KeyboardEvent) => {
+      if ((e.ctrlKey || e.metaKey) && e.key.toLowerCase() === "s") {
+        e.preventDefault();
+        if (!createOpen) void handleSave();
+      }
+      if (e.key === "Escape" && !document.querySelector("dialog[open]")) {
+        if (narrow) {
+          setOverlay("");
+        } else setDiagnostics(false);
+      }
+    };
+    window.addEventListener("keydown", key);
+    return () => window.removeEventListener("keydown", key);
+  });
 
   const visibleStrategies = useMemo(() => {
     const query = search.trim().toLocaleLowerCase();
-    if (!query) return strategies;
-    return strategies.filter((item) => `${item.name} ${item.description ?? ""}`.toLocaleLowerCase().includes(query));
-  }, [search, strategies]);
+    return strategies.filter(
+      (item) =>
+        (filter === "all" || item.state === filter) &&
+        `${item.name} ${item.description ?? ""} ${item.id}`
+          .toLocaleLowerCase()
+          .includes(query),
+    );
+  }, [search, strategies, filter]);
 
-  const handleApiError = useCallback((caught: unknown, fallback: string) => {
-    if (caught instanceof StrategyApiError && caught.status === 401) {
-      logout();
-      navigate("/login", { replace: true });
-      return;
-    }
-    setError(caught instanceof Error ? caught.message : fallback);
-  }, [logout, navigate]);
+  const handleApiError = useCallback(
+    (caught: unknown, fallback: string) => {
+      if (caught instanceof StrategyApiError && caught.status === 401) {
+        logout();
+        navigate("/login", { replace: true });
+        return;
+      }
+      setError(
+        caught instanceof StrategyApiError && caught.status === 409
+          ? `版本冲突：${caught.message}。本地输入已保留，请复制需要保留的内容后刷新核对服务端版本。`
+          : caught instanceof Error
+            ? caught.message
+            : fallback,
+      );
+    },
+    [logout, navigate],
+  );
 
-  const loadStrategies = useCallback(async (background = false) => {
-    if (background) setRefreshing(true); else setLoadingList(true);
-    setError(null);
-    try {
-      const next = await listStrategies();
-      setStrategies(next);
-      if (!strategyId && next.length > 0) {
-        navigate(`/admin/strategies/${next[0].id}`, { replace: true });
-      } else if (strategyId && next.length === 0) {
-        navigate("/admin/strategies", { replace: true });
+  const loadStrategies = useCallback(
+    async (background = false) => {
+      if (background) setRefreshing(true);
+      else setLoadingList(true);
+      setError(null);
+      try {
+        const next: StrategySummary[] = [];
+        for (let offset = 0; ; offset += 100) {
+          const batch = await listStrategies(true, offset, 100);
+          next.push(...batch);
+          if (batch.length < 100) break;
+        }
+        setStrategies(next);
+        if (!strategyId && next.length > 0) {
+          navigate(`/admin/strategies/${next[0].id}`, { replace: true });
+        } else if (strategyId && next.length === 0) {
+          navigate("/admin/strategies", { replace: true });
+        }
+      } catch (caught) {
+        handleApiError(caught, "策略列表加载失败。");
+      } finally {
+        setLoadingList(false);
+        setRefreshing(false);
       }
-    } catch (caught) {
-      handleApiError(caught, "策略列表加载失败。");
-    } finally {
-      setLoadingList(false);
-      setRefreshing(false);
-    }
-  }, [handleApiError, navigate, strategyId]);
+    },
+    [handleApiError, navigate, strategyId],
+  );
 
-  const loadDetail = useCallback(async (id: string, background = false) => {
-    const requestSequence = ++detailRequestSequence.current;
-    revisionRequestSequence.current += 1;
-    setRevisionPreview(null);
-    if (!background) {
-      setLoadingDetail(true);
-      // Do not render one strategy's private source while another route is
-      // loading, even briefly. The selected record owns the editor surface.
-      setDetail(null);
-      setDraft(null);
-      setRevisions([]);
-      setValidation(null);
-    }
-    setError(null);
-    try {
-      const [nextDetail, nextRevisions] = await Promise.all([
-        getStrategy(id),
-        listStrategyRevisions(id)
-      ]);
-      if (requestSequence !== detailRequestSequence.current) return;
-      setDetail(nextDetail);
-      setDraft(editorDraftFromDetail(nextDetail));
-      setRevisions(nextRevisions);
-      setValidation(null);
-    } catch (caught) {
-      if (requestSequence === detailRequestSequence.current) {
-        handleApiError(caught, "策略详情加载失败。");
+  const loadDetail = useCallback(
+    async (id: string, background = false) => {
+      const requestSequence = ++detailRequestSequence.current;
+      revisionRequestSequence.current += 1;
+      setRevisionPreview(null);
+      setFile("sourceCode");
+      if (!background) {
+        setLoadingDetail(true);
+        // Do not render one strategy's private source while another route is
+        // loading, even briefly. The selected record owns the editor surface.
+        setDetail(null);
+        setDraft(null);
+        setRevisions([]);
+        setValidation(null);
       }
-    } finally {
-      if (requestSequence === detailRequestSequence.current) {
-        setLoadingDetail(false);
+      setError(null);
+      try {
+        const [nextDetail, nextRevisions] = await Promise.all([
+          getStrategy(id),
+          listStrategyRevisions(id),
+        ]);
+        if (requestSequence !== detailRequestSequence.current) return;
+        setDetail(nextDetail);
+        setDraft(editorDraftFromDetail(nextDetail));
+        setRevisions(nextRevisions);
+        setValidation(null);
+      } catch (caught) {
+        if (requestSequence === detailRequestSequence.current) {
+          handleApiError(caught, "策略详情加载失败。");
+        }
+      } finally {
+        if (requestSequence === detailRequestSequence.current) {
+          setLoadingDetail(false);
+        }
       }
-    }
-  }, [handleApiError]);
+    },
+    [handleApiError],
+  );
 
   useEffect(() => {
     void loadStrategies();
@@ -304,71 +454,92 @@ export function StrategiesPage() {
 
   function selectStrategy(id: string) {
     if (id === strategyId) return;
-    if (isDirty && !window.confirm("当前草稿尚未保存，确定放弃修改并切换策略吗？")) return;
     navigate(`/admin/strategies/${id}`);
   }
 
-  function updateDraftField<K extends keyof EditorDraft>(field: K, value: EditorDraft[K]) {
-    setDraft((current) => current ? { ...current, [field]: value } : current);
-    setValidation(null);
+  function updateDraftField<K extends keyof EditorDraft>(
+    field: K,
+    value: EditorDraft[K],
+  ) {
+    setDraft((current) => (current ? { ...current, [field]: value } : current));
     setNotice(null);
   }
 
   async function persistEditor(): Promise<StrategyDetail> {
     if (!detail || !draft) throw new Error("请先选择一个策略。");
-    const parameterSchema = parseJsonObject(draft.parameterSchema, "参数 Schema");
-    const defaultParameters = parseJsonObject(draft.defaultParameters, "默认参数");
+    const parameterSchema = parseJsonObject(
+      draft.parameterSchema,
+      "参数 Schema",
+    );
+    const defaultParameters = parseJsonObject(
+      draft.defaultParameters,
+      "默认参数",
+    );
     let nextDetail = detail;
 
     // Metadata and source use independent optimistic-lock versions in the API.
     // Persist them sequentially so a successful metadata save is never silently
     // discarded while the editor still reports the precise draft-save conflict.
-    const metadataChanged = detail.name !== draft.name || (detail.description ?? "") !== draft.description;
+    const metadataChanged =
+      detail.name !== draft.name ||
+      (detail.description ?? "") !== draft.description;
     if (metadataChanged) {
       const updated = await updateStrategyMetadata(detail.id, {
         version: nextDetail.version,
         name: draft.name.trim(),
-        description: draft.description.trim() || null
+        description: draft.description.trim() || null,
       });
       nextDetail = { ...nextDetail, ...updated };
-      setStrategies((current) => current.map((item) => item.id === updated.id ? updated : item));
+      setDetail(nextDetail);
+      setStrategies((current) =>
+        current.map((item) => (item.id === updated.id ? updated : item)),
+      );
     }
 
-    const draftChanged = detail.draft.source_code !== draft.sourceCode
-      || canonicalJson(detail.draft.parameter_schema) !== canonicalJson(parameterSchema)
-      || canonicalJson(detail.draft.default_parameters) !== canonicalJson(defaultParameters);
+    const draftChanged =
+      detail.draft.source_code !== draft.sourceCode ||
+      canonicalJson(detail.draft.parameter_schema) !==
+        canonicalJson(parameterSchema) ||
+      canonicalJson(detail.draft.default_parameters) !==
+        canonicalJson(defaultParameters);
     if (draftChanged) {
-      await saveStrategyDraft(detail.id, {
+      const saved = await saveStrategyDraft(detail.id, {
         version: nextDetail.draft.version,
         source_code: draft.sourceCode,
         parameter_schema: parameterSchema,
-        default_parameters: defaultParameters
+        default_parameters: defaultParameters,
       });
       // The server compares source and parameter contracts with the published
       // revision. Refresh that projection after a save, including a revert.
+      nextDetail = { ...nextDetail, draft: saved };
+      setDetail(nextDetail);
       nextDetail = await getStrategy(detail.id);
     }
 
     setDetail(nextDetail);
     setDraft(editorDraftFromDetail(nextDetail));
-    setStrategies((current) => current.map((item) => item.id === nextDetail.id
-      ? { ...item, ...nextDetail }
-      : item));
+    setStrategies((current) =>
+      current.map((item) =>
+        item.id === nextDetail.id ? { ...item, ...nextDetail } : item,
+      ),
+    );
     return nextDetail;
   }
 
   async function handleSave(event?: FormEvent) {
     event?.preventDefault();
-    if (!detail || !draft || saving || isArchived) return;
+    if (!detail || !draft || busy || lock.current || isArchived) return;
+    lock.current = true;
     setSaving(true);
     setError(null);
     setNotice(null);
     try {
       await persistEditor();
-      setNotice("草稿已保存到 PostgreSQL。");
+      setNotice("草稿已保存。");
     } catch (caught) {
       handleApiError(caught, "策略草稿保存失败。");
     } finally {
+      lock.current = false;
       setSaving(false);
     }
   }
@@ -384,7 +555,9 @@ export function StrategiesPage() {
   }
 
   async function handleValidate() {
-    if (!detail || validating || saving || isArchived) return;
+    if (!detail || busy || lock.current || isArchived) return;
+    lock.current = true;
+    setDiagnostics(true);
     setValidating(true);
     setError(null);
     setNotice(null);
@@ -394,12 +567,14 @@ export function StrategiesPage() {
     } catch (caught) {
       handleApiError(caught, "策略校验失败。");
     } finally {
+      lock.current = false;
       setValidating(false);
     }
   }
 
   async function handlePublish() {
-    if (!detail || publishing || saving || validating || isArchived) return;
+    if (!detail || busy || lock.current || isArchived) return;
+    lock.current = true;
     setPublishing(true);
     setError(null);
     setNotice(null);
@@ -408,6 +583,7 @@ export function StrategiesPage() {
       const result = await validateStrategy(current.id);
       setValidation(result);
       if (!result.valid) {
+        setDiagnostics(true);
         setError("当前草稿未通过校验，请先处理下方问题。");
         return;
       }
@@ -418,12 +594,15 @@ export function StrategiesPage() {
           revision_number: revision.revision_number,
           source_hash: revision.source_hash,
           runtime_manifest: revision.runtime_manifest,
-          published_at: revision.published_at
+          published_at: revision.published_at,
         },
-        ...currentRevisions
+        ...currentRevisions,
       ]);
       await loadDetail(current.id, true);
-      setNotice(`已发布策略版本 v${revision.revision_number}。发布版本不可修改。`);
+      setValidation(result);
+      setNotice(
+        `已发布策略版本 v${revision.revision_number}。发布版本不可修改。`,
+      );
     } catch (caught) {
       if (caught instanceof StrategyApiError) {
         const failedValidation = validationFromError(caught, detail);
@@ -431,53 +610,79 @@ export function StrategiesPage() {
       }
       handleApiError(caught, "策略发布失败。");
     } finally {
+      lock.current = false;
       setPublishing(false);
     }
   }
 
   async function handleCreate(event: FormEvent<HTMLFormElement>) {
     event.preventDefault();
+    if (lock.current || busy) return;
+    if (
+      isDirty &&
+      !window.confirm("创建后将离开当前策略，确定放弃当前未保存草稿吗？")
+    )
+      return;
     if (!createDraft.name.trim()) {
       setError("请填写策略名称。");
       return;
     }
+    lock.current = true;
     setSaving(true);
     setError(null);
     try {
       const created = await createStrategy({
         name: createDraft.name.trim(),
         description: createDraft.description.trim() || undefined,
-        source_code: createDraft.sourceCode,
-        parameter_schema: EMPTY_PARAMETER_SCHEMA,
-        default_parameters: {}
+        source_code: TEMPLATES[createDraft.template].source,
+        parameter_schema: TEMPLATES[createDraft.template].schema,
+        default_parameters: TEMPLATES[createDraft.template].parameters,
       });
       setCreateOpen(false);
       setCreateDraft(EMPTY_CREATE_DRAFT);
-      setStrategies((current) => [created, ...current.filter((item) => item.id !== created.id)]);
+      setStrategies((current) => [
+        created,
+        ...current.filter((item) => item.id !== created.id),
+      ]);
+      guardRef.current = { dirty: false, busy: false };
       navigate(`/admin/strategies/${created.id}`);
       setNotice("策略已创建，当前是未发布草稿。");
     } catch (caught) {
       handleApiError(caught, "策略创建失败。");
     } finally {
+      lock.current = false;
       setSaving(false);
     }
   }
 
   async function handleArchive() {
-    if (!detail || archiving || isArchived) return;
-    if (!window.confirm("归档后将不能继续编辑或发布，但版本历史会保留。确定归档吗？")) return;
+    if (!detail || busy || lock.current || isArchived) return;
+    if (isDirty) {
+      setError("请先保存草稿或刷新放弃修改，再归档策略。");
+      return;
+    }
+    if (
+      !window.confirm(
+        "归档后将不能继续编辑或发布，但版本历史会保留。确定归档吗？",
+      )
+    )
+      return;
+    lock.current = true;
     setArchiving(true);
     setError(null);
     try {
       await archiveStrategy(detail);
-      const next = strategies.filter((item) => item.id !== detail.id);
-      setStrategies(next);
-      if (next.length > 0) navigate(`/admin/strategies/${next[0].id}`, { replace: true });
-      else navigate("/admin/strategies", { replace: true });
+      setStrategies((current) =>
+        current.map((item) =>
+          item.id === detail.id ? { ...item, state: "archived" } : item,
+        ),
+      );
+      await loadDetail(detail.id, true);
       setNotice("策略已归档，源码和版本历史仍保留在数据库中。");
     } catch (caught) {
       handleApiError(caught, "策略归档失败。");
     } finally {
+      lock.current = false;
       setArchiving(false);
     }
   }
@@ -488,7 +693,10 @@ export function StrategiesPage() {
     setRevisionLoading(true);
     setError(null);
     try {
-      const nextRevision = await getStrategyRevision(detail.id, revision.revision_number);
+      const nextRevision = await getStrategyRevision(
+        detail.id,
+        revision.revision_number,
+      );
       if (requestSequence === revisionRequestSequence.current) {
         setRevisionPreview(nextRevision);
       }
@@ -504,6 +712,7 @@ export function StrategiesPage() {
   }
 
   async function refreshPage() {
+    if (!canLeave()) return;
     setRefreshing(true);
     try {
       await loadStrategies(true);
@@ -513,262 +722,771 @@ export function StrategiesPage() {
     }
   }
 
-  const currentRevisionNumber = detail?.current_revision?.revision_number ?? null;
+  const currentRevisionNumber =
+    detail?.current_revision?.revision_number ?? null;
 
+  const stale = Boolean(
+    validation &&
+      (isDirty || validation.draft_version !== detail?.draft.version),
+  );
+  const checkLabel = stale ? "检查已过期" : statusText(validation);
+  const editorValue = draft?.[file] || "";
+  function closeCreate() {
+    if (busy) return;
+    if (
+      (createDraft.name ||
+        createDraft.description ||
+        createDraft.template !== "hold") &&
+      !window.confirm("放弃尚未创建的策略信息吗？")
+    )
+      return;
+    setCreateOpen(false);
+    setCreateDraft(EMPTY_CREATE_DRAFT);
+  }
+  function showCreate() {
+    if (busy) return;
+    setCreateOpen(true);
+  }
+  function updateCursor() {
+    const e = editorRef.current;
+    if (!e) return;
+    const before = e.value.slice(0, e.selectionStart);
+    setCursor({
+      line: before.split("\n").length,
+      column: before.length - before.lastIndexOf("\n"),
+    });
+  }
+  function formatSchema() {
+    try {
+      updateDraftField(
+        "parameterSchema",
+        prettyJson(
+          parseJsonObject(draft?.parameterSchema || "", "参数 Schema"),
+        ),
+      );
+    } catch (e) {
+      setError((e as Error).message);
+    }
+  }
+  let parameters: Record<string, unknown> | null = null;
+  try {
+    parameters = parseJsonObject(draft?.defaultParameters || "", "默认参数");
+  } catch {
+    /* Keep malformed JSON in the editor. */
+  }
+  const controlsDisabled =
+    busy || Boolean(isArchived) || !draft || detail?.id !== strategyId;
   return (
-    <section className="strategies-page" aria-labelledby="strategies-title">
-      <div className="page-heading strategies-page__heading">
-        <div>
-          <span className="workbench-eyebrow">PRIVATE STRATEGY WORKBENCH</span>
-          <h2 id="strategies-title">策略工作台</h2>
-          <p>在 Web 中编辑私有策略，源码直接保存到 PostgreSQL，不进入项目目录。</p>
-        </div>
-        <div className="strategies-page__actions">
-          <button className="toolbar-button" type="button" disabled={refreshing} onClick={() => void refreshPage()}>
-            <RefreshCw className={refreshing ? "spin" : ""} aria-hidden="true" />刷新
-          </button>
-          <button className="task-create-button" type="button" onClick={() => { setCreateOpen(true); setError(null); }}>
-            <Plus aria-hidden="true" />新建策略
-          </button>
-        </div>
-      </div>
-
-      {error && <div className="page-error" role="alert"><CircleAlert aria-hidden="true" />{error}</div>}
-      {notice && <div className="strategy-message strategy-message--success" role="status"><CircleCheck aria-hidden="true" />{notice}</div>}
-
-      <div className="strategy-stats" aria-label="策略概览">
-        <article><span>策略总数</span><strong>{loadingList ? "—" : strategies.length}</strong><small>当前部署中的私有策略</small></article>
-        <article><span>已发布</span><strong>{loadingList ? "—" : publishedCount}</strong><small>至少存在一个不可变版本</small></article>
-        <article><span>仅草稿</span><strong>{loadingList ? "—" : draftCount}</strong><small>尚未发布可执行版本</small></article>
-        <article className="strategy-stat--focus"><span>当前版本</span><strong>{currentRevisionNumber ? `v${currentRevisionNumber}` : "—"}</strong><small>{selectedSummary?.name ?? "尚未选择策略"}</small></article>
-      </div>
-
-      <div className="strategies-layout">
-        <aside className="strategy-board" aria-label="策略列表">
-          <div className="strategy-board__heading">
-            <div><span className="workbench-eyebrow">STRATEGIES</span><h3>私有策略</h3></div>
-            <span>{strategies.length} 项</span>
+    <OverviewShell
+      title="策略工作台"
+      section="RESEARCH / 01"
+      className="qfs-root"
+      workspace
+      beforeNavigate={() => {
+        const ok = canLeave();
+        if (ok) guardRef.current = { dirty: false, busy: false };
+        return ok;
+      }}
+    >
+      <section className="qfs-page" aria-labelledby="strategies-title">
+        <header className="qfs-heading">
+          <div>
+            <small>PRIVATE STRATEGY</small>
+            <h1 id="strategies-title">策略工作台</h1>
+            <p>编辑策略代码、参数与版本。</p>
           </div>
-          <label className="strategy-search">
-            <Code2 aria-hidden="true" />
-            <input value={search} onChange={(event) => setSearch(event.target.value)} placeholder="搜索策略名称…" aria-label="搜索策略名称" />
-          </label>
-          <div className="strategy-list">
-            {loadingList ? <div className="strategy-empty"><LoaderCircle className="spin" aria-hidden="true" />正在加载策略…</div>
-              : visibleStrategies.length > 0 ? visibleStrategies.map((item) => (
-                <button
-                  className={`strategy-list__item${item.id === strategyId ? " strategy-list__item--selected" : ""}`}
-                  key={item.id}
-                  type="button"
-                  onClick={() => selectStrategy(item.id)}
-                >
-                  <span className={`strategy-list__dot${item.current_revision_id ? " strategy-list__dot--published" : ""}`} aria-hidden="true" />
-                  <span className="strategy-list__copy"><strong>{item.name}</strong><small>{item.description || "尚未填写说明"}</small></span>
-                  <span className="strategy-list__meta">{item.current_revision_id ? "已发布" : "草稿"}<br /><time>{formatTimestamp(item.updated_at)}</time></span>
-                </button>
-              )) : <div className="strategy-empty"><FileCode2 aria-hidden="true" /><strong>{search ? "没有匹配策略" : "还没有策略"}</strong><span>{search ? "换个关键词试试。" : "点击右上角新建第一条私有策略。"}</span></div>}
+          <div className="qfs-actions">
+            <button
+              aria-expanded={explorerVisible}
+              onClick={() => {
+                if (narrow)
+                  setOverlay(overlay === "explorer" ? "" : "explorer");
+                else setExplorer(!explorer);
+              }}
+            >
+              策略目录
+            </button>
+            <button
+              aria-expanded={contextVisible}
+              onClick={() => {
+                if (narrow) setOverlay(overlay === "context" ? "" : "context");
+                else setContextOpen(!contextOpen);
+              }}
+            >
+              参数面板
+            </button>
+            <button disabled={busy} onClick={showCreate}>
+              <Plus />
+              新建策略
+            </button>
+            <button
+              className="qfs-primary"
+              disabled={controlsDisabled}
+              onClick={() => void handlePublish()}
+            >
+              <Rocket />
+              {publishing ? "发布中…" : "发布版本"}
+            </button>
           </div>
-        </aside>
-
-        <main className="strategy-editor" aria-label="策略编辑器">
-          {!strategyId ? <StrategyWelcome onCreate={() => setCreateOpen(true)} />
-            : loadingDetail || !detail || !draft ? <div className="strategy-editor__loading"><LoaderCircle className="spin" aria-hidden="true" />正在加载策略详情…</div>
-              : <>
-                <div className="strategy-editor__header">
-                  <div className="strategy-editor__title">
-                    <span className={`strategy-state strategy-state--${detail.state}`}><i aria-hidden="true" />{stateLabel(detail, validation, isDirty)}</span>
-                    <h3>{detail.name}</h3>
-                    <p>{detail.current_revision ? `当前发布版本 v${detail.current_revision.revision_number}` : "尚未发布版本"} · 草稿 v{detail.draft.version}</p>
-                  </div>
-                  <div className="strategy-editor__actions">
-                    <button className="toolbar-button" type="button" disabled={refreshing} onClick={() => void loadDetail(detail.id)} title="放弃本地未保存修改并重新读取"><RefreshCw aria-hidden="true" />重载</button>
-                    <button className="toolbar-button" type="button" disabled={!isDirty || saving || isArchived} onClick={() => void handleSave()}><Save aria-hidden="true" />{saving ? "保存中" : "保存草稿"}</button>
-                    <button className="toolbar-button toolbar-button--validate" type="button" disabled={validating || saving || isArchived} onClick={() => void handleValidate()}><ShieldCheck aria-hidden="true" />{validating ? "校验中" : "校验"}</button>
-                    <button className="task-create-button" type="button" disabled={publishing || saving || validating || isArchived} onClick={() => void handlePublish()}><Rocket aria-hidden="true" />{publishing ? "发布中" : "发布版本"}</button>
-                  </div>
-                </div>
-                <div className="strategy-editor__run-gate" role="status">
-                  {detail.current_revision
-                    ? <span>回测将绑定已发布版本 v{detail.current_revision.revision_number}（不可变）。{isDirty || detail.draft_changed_since_revision ? "当前草稿有未发布修改，回测不会使用这些修改。" : ""} <Link className="strategy-open-backtest" to={`/admin/strategies/${detail.id}/backtests`}>进入回测工作台</Link></span>
-                    : <span>请先发布策略，未发布草稿不能进入回测。</span>}
-                </div>
-
-                <form className="strategy-editor__form" onSubmit={(event) => void handleSave(event)}>
-                  <div className="strategy-metadata-grid">
-                    <label><span>策略名称</span><input value={draft.name} disabled={isArchived} onChange={(event) => updateDraftField("name", event.target.value)} maxLength={100} /></label>
-                    <label><span>说明</span><input value={draft.description} disabled={isArchived} onChange={(event) => updateDraftField("description", event.target.value)} maxLength={10_000} placeholder="描述策略用途和预期行为" /></label>
-                  </div>
-
-                  <div className="strategy-code-panel">
-                    <div className="strategy-panel__heading">
-                      <div><span className="workbench-eyebrow">SOURCE MODULE</span><h4><FileCode2 aria-hidden="true" />strategy.py</h4></div>
-                      <span>{sourceLineCount(draft.sourceCode)} 行 · {new TextEncoder().encode(draft.sourceCode).length.toLocaleString("zh-CN")} bytes</span>
-                    </div>
-                    <textarea
-                      className="strategy-source-editor"
-                      value={draft.sourceCode}
-                      disabled={isArchived}
-                      onChange={(event) => updateDraftField("sourceCode", event.target.value)}
-                      onKeyDown={(event) => handleEditorKeyDown(event, draft.sourceCode, (value) => updateDraftField("sourceCode", value))}
-                      spellCheck={false}
-                      wrap="off"
-                      aria-label="策略 Python 源码"
-                    />
-                    <div className="strategy-editor__hint"><Code2 aria-hidden="true" />必须提供同步的 <code>run(context, parameters)</code> 入口。当前校验只解析源码，不会在 API 进程中执行它。</div>
-                  </div>
-
-                  <div className="strategy-contract-grid">
-                    <JsonEditor
-                      label="参数 Schema"
-                      eyebrow="PARAMETER CONTRACT"
-                      value={draft.parameterSchema}
-                      disabled={isArchived}
-                      onChange={(value) => updateDraftField("parameterSchema", value)}
-                      hint="顶层应为 object；用于描述策略可配置参数。"
-                    />
-                    <JsonEditor
-                      label="默认参数"
-                      eyebrow="DEFAULT VALUES"
-                      value={draft.defaultParameters}
-                      disabled={isArchived}
-                      onChange={(value) => updateDraftField("defaultParameters", value)}
-                      hint="运行任务未覆盖时使用的 JSON 对象。"
-                    />
-                  </div>
-                </form>
-
-                <div className="strategy-editor__footer">
-                  <div className={`strategy-save-state${isDirty ? " strategy-save-state--dirty" : ""}`}><span aria-hidden="true" />{isDirty ? "有未保存修改" : `已保存 · ${formatTimestamp(detail.draft.updated_at)}`}<small>{shortHash(detail.draft.source_hash)}</small></div>
-                  <div className="strategy-editor__footer-actions">
-                    <Link className="toolbar-button" to="/admin/tasks"><ExternalLink aria-hidden="true" />任务调度</Link>
-                    <button className="danger-text-button" type="button" disabled={archiving || isArchived} onClick={() => void handleArchive()}><Archive aria-hidden="true" />归档策略</button>
+        </header>
+        {error && (
+          <div className="qfs-message qfs-error" role="alert">
+            {error}
+            <button onClick={() => setError(null)} aria-label="关闭错误">
+              <X />
+            </button>
+          </div>
+        )}
+        {notice && (
+          <div className="qfs-message" role="status">
+            {notice}
+            <button onClick={() => setNotice(null)} aria-label="关闭提示">
+              <X />
+            </button>
+          </div>
+        )}
+        <div
+          ref={workbenchRef}
+          className={`qfs-workbench ${narrow ? "qfs-narrow" : ""}`}
+        >
+          {narrow && (explorerVisible || contextVisible) && (
+            <button
+              className="qfs-scrim"
+              aria-label="关闭辅助面板"
+              onClick={() => setOverlay("")}
+            />
+          )}
+          {explorerVisible && (
+            <>
+              <aside
+                className="qfs-explorer"
+                style={{ width: sizes.left }}
+                aria-label="策略目录"
+              >
+                <header>
+                  <strong>策略目录</strong>
+                  <span>{visibleStrategies.length} 项</span>
+                  <button
+                    disabled={busy}
+                    onClick={() => void refreshPage()}
+                    aria-label="刷新策略"
+                  >
+                    <RefreshCw />
+                  </button>
+                </header>
+                <div className="qfs-search">
+                  <input
+                    aria-label="搜索策略"
+                    placeholder="搜索名称、说明或 ID"
+                    value={search}
+                    onChange={(e) => setSearch(e.target.value)}
+                  />
+                  <div className="qfs-filters">
+                    {[
+                      ["all", "全部"],
+                      ["active", "使用中"],
+                      ["archived", "已归档"],
+                    ].map(([key, label]) => (
+                      <button
+                        key={key}
+                        aria-pressed={filter === key}
+                        onClick={() => setFilter(key)}
+                      >
+                        {label}
+                      </button>
+                    ))}
                   </div>
                 </div>
-
-                <ValidationPanel validation={validation} status={statusText(validation)} />
-
-                <section className="strategy-revisions" aria-labelledby="strategy-revisions-title">
-                  <div className="strategy-section-heading"><div><span className="workbench-eyebrow">IMMUTABLE HISTORY</span><h4 id="strategy-revisions-title"><History aria-hidden="true" />版本历史</h4></div><span>{revisions.length} 个已发布版本</span></div>
-                  {revisions.length > 0 ? <div className="strategy-revision-list">{revisions.map((revision) => (
-                    <button className={`strategy-revision-row${revision.revision_number === currentRevisionNumber ? " strategy-revision-row--current" : ""}`} type="button" key={revision.id} onClick={() => void openRevision(revision)}>
-                      <span className="strategy-revision-row__version"><GitBranch aria-hidden="true" />v{revision.revision_number}</span>
-                      <span><strong>{revision.revision_number === currentRevisionNumber ? "当前发布版本" : "已发布版本"}</strong><small>{shortHash(revision.source_hash)}</small></span>
-                      <time>{formatTimestamp(revision.published_at)}</time>
-                      <ExternalLink aria-hidden="true" />
+                <div className="qfs-list">
+                  {loadingList ? (
+                    <p role="status">加载策略…</p>
+                  ) : !visibleStrategies.length ? (
+                    <p>暂无匹配策略</p>
+                  ) : (
+                    visibleStrategies.map((item) => (
+                      <button
+                        disabled={busy}
+                        key={item.id}
+                        aria-current={
+                          item.id === strategyId ? "true" : undefined
+                        }
+                        className={item.id === strategyId ? "qfs-selected" : ""}
+                        onClick={() => {
+                          selectStrategy(item.id);
+                          if (narrow) setOverlay("");
+                        }}
+                      >
+                        <strong>{item.name}</strong>
+                        <span className="qfs-badge">
+                          {item.state === "archived"
+                            ? "已归档"
+                            : item.current_revision_id
+                              ? "已发布"
+                              : "未发布"}
+                        </span>
+                        <small>{item.description || "暂无说明"}</small>
+                        <small>{formatTimestamp(item.updated_at)}</small>
+                      </button>
+                    ))
+                  )}
+                </div>
+              </aside>
+              {!narrow && (
+                <ResizeHandle
+                  label="策略目录宽度"
+                  value={sizes.left}
+                  min={196}
+                  max={320}
+                  onChange={(left) => setSizes({ ...sizes, left })}
+                />
+              )}
+            </>
+          )}
+          <section className="qfs-editor-panel" aria-label="策略编辑区">
+            {loadingDetail || (detail && detail.id !== strategyId) ? (
+              <div className="qfs-empty" role="status">
+                加载策略内容…
+              </div>
+            ) : !detail || !draft ? (
+              <div className="qfs-empty">
+                <Code2 />
+                <h2>选择或创建策略</h2>
+                <p>源码、参数与版本将在这里显示。</p>
+                <button onClick={showCreate}>新建策略</button>
+              </div>
+            ) : (
+              <>
+                <header className="qfs-object">
+                  <div>
+                    <strong>{detail.name}</strong>
+                    <span className="qfs-badge">
+                      {stateLabel(detail, stale ? null : validation, isDirty)}
+                      {currentRevisionNumber
+                        ? ` · v${currentRevisionNumber}`
+                        : ""}
+                    </span>
+                    <small title={detail.id}>{detail.id}</small>
+                  </div>
+                  <div className="qfs-actions">
+                    <button
+                      disabled={controlsDisabled}
+                      onClick={() => void handleValidate()}
+                    >
+                      <ShieldCheck />
+                      {validating ? "检查中…" : "静态检查"}
                     </button>
-                  ))}</div> : <div className="strategy-history-empty"><Clock3 aria-hidden="true" /><span>发布后会在这里保留不可变版本，便于审计和回溯。</span></div>}
-                </section>
-
-                <section className="strategy-scheduling-note" aria-label="调度绑定状态">
-                  <div><Clock3 aria-hidden="true" /><span><strong>调度绑定</strong><small>当前阶段先完成策略编写、校验和版本发布；执行阶段将让任务调度引用指定策略版本。</small></span></div>
-                  <Link to="/admin/tasks">查看任务调度 <ExternalLink aria-hidden="true" /></Link>
-                </section>
-              </>}
-        </main>
-      </div>
-
-      {createOpen && <CreateStrategyDialog draft={createDraft} saving={saving} onChange={setCreateDraft} onClose={() => setCreateOpen(false)} onSubmit={handleCreate} />}
-      {revisionPreview && <RevisionPreviewDialog revision={revisionPreview} loading={revisionLoading} onClose={() => setRevisionPreview(null)} />}
-      {revisionLoading && !revisionPreview && <div className="strategy-toast"><LoaderCircle className="spin" aria-hidden="true" />正在读取版本…</div>}
-    </section>
+                    <button
+                      disabled={controlsDisabled}
+                      onClick={() => void handleSave()}
+                    >
+                      <Save />
+                      {saving ? "保存中…" : "保存草稿"}
+                    </button>
+                    <button
+                      disabled={busy || !currentRevisionNumber}
+                      title={
+                        !currentRevisionNumber
+                          ? "请先发布策略"
+                          : `使用已发布 v${currentRevisionNumber}`
+                      }
+                      onClick={() =>
+                        navigate(`/admin/strategies/${detail.id}/backtests`)
+                      }
+                    >
+                      <ExternalLink />
+                      创建回测
+                    </button>
+                  </div>
+                </header>
+                {(isDirty || detail.draft_changed_since_revision) &&
+                  currentRevisionNumber && (
+                    <div className="qfs-version-note">
+                      创建回测使用已发布 v{currentRevisionNumber}
+                      ，不包含未发布修改。
+                    </div>
+                  )}
+                {!currentRevisionNumber && (
+                  <div className="qfs-version-note">
+                    当前策略尚未发布，发布后可以创建回测。
+                  </div>
+                )}
+                <div
+                  className="qfs-file-tabs"
+                  role="tablist"
+                  aria-label="草稿内容"
+                >
+                  {(
+                    [
+                      ["sourceCode", "strategy.py"],
+                      ["defaultParameters", "params.json"],
+                      ["description", "策略说明"],
+                    ] as const
+                  ).map(([key, label]) => (
+                    <button
+                      key={key}
+                      role="tab"
+                      aria-selected={file === key}
+                      onClick={() => {
+                        setFile(key);
+                        setCursor({ line: 1, column: 1 });
+                      }}
+                    >
+                      {label}
+                    </button>
+                  ))}
+                  <span>
+                    {isDirty ? "未保存" : isArchived ? "只读" : "已保存"} ·
+                    UTF-8
+                  </span>
+                </div>
+                {file === "description" && (
+                  <div className="qfs-description-head">
+                    <label>
+                      策略名称
+                      <input
+                        maxLength={100}
+                        disabled={controlsDisabled}
+                        value={draft.name}
+                        onChange={(e) =>
+                          updateDraftField("name", e.target.value)
+                        }
+                      />
+                    </label>
+                    <p>策略说明不随发布版本冻结。</p>
+                  </div>
+                )}
+                <div className="qfs-code" role="tabpanel">
+                  <pre ref={linesRef} aria-hidden="true">
+                    {Array.from(
+                      { length: sourceLineCount(editorValue) },
+                      (_, i) => i + 1,
+                    ).join("\n")}
+                  </pre>
+                  <textarea
+                    ref={editorRef}
+                    aria-label={
+                      file === "sourceCode"
+                        ? "策略源码"
+                        : file === "defaultParameters"
+                          ? "默认参数 JSON"
+                          : "策略说明"
+                    }
+                    value={editorValue}
+                    readOnly={controlsDisabled}
+                    maxLength={file === "description" ? 10000 : undefined}
+                    wrap="off"
+                    spellCheck={false}
+                    onChange={(e) => {
+                      updateDraftField(file, e.target.value);
+                      updateCursor();
+                    }}
+                    onClick={updateCursor}
+                    onKeyUp={updateCursor}
+                    onScroll={(e) => {
+                      if (linesRef.current)
+                        linesRef.current.scrollTop = e.currentTarget.scrollTop;
+                    }}
+                    onKeyDown={(e) => {
+                      if (e.key === "Tab" && !controlsDisabled) {
+                        e.preventDefault();
+                        const t = e.currentTarget,
+                          start = t.selectionStart,
+                          end = t.selectionEnd;
+                        updateDraftField(
+                          file,
+                          editorValue.slice(0, start) +
+                            "    " +
+                            editorValue.slice(end),
+                        );
+                        requestAnimationFrame(() => {
+                          t.selectionStart = t.selectionEnd = start + 4;
+                          updateCursor();
+                        });
+                      }
+                    }}
+                  />
+                </div>
+                <footer className="qfs-status">
+                  <button
+                    onClick={() => setDiagnostics(!diagnostics)}
+                    aria-expanded={diagnostics}
+                  >
+                    {checkLabel}
+                  </button>
+                  <span>
+                    Ln {cursor.line}, Col {cursor.column}　
+                    {file === "sourceCode"
+                      ? "Python"
+                      : file === "defaultParameters"
+                        ? "JSON"
+                        : "文本"}{" "}
+                    · Spaces: 4
+                  </span>
+                </footer>
+                {diagnostics && (
+                  <>
+                    <ResizeHandle
+                      horizontal
+                      reverse
+                      label="诊断面板高度"
+                      value={sizes.bottom}
+                      min={120}
+                      max={320}
+                      onChange={(bottom) => setSizes({ ...sizes, bottom })}
+                    />
+                    <section
+                      className="qfs-diagnostics"
+                      style={{ height: sizes.bottom }}
+                    >
+                      <header>
+                        <strong>静态检查 · {checkLabel}</strong>
+                        <button
+                          onClick={() => setDiagnostics(false)}
+                          aria-label="关闭诊断"
+                        >
+                          <X />
+                        </button>
+                      </header>
+                      <p>检查 Python 语法、入口签名与参数契约，不执行策略。</p>
+                      {validation?.issues.map((issue, i) => (
+                        <button
+                          className="qfs-issue"
+                          key={i}
+                          onClick={() => {
+                            setFile("sourceCode");
+                            requestAnimationFrame(() => {
+                              const e = editorRef.current;
+                              if (!e) return;
+                              const pos =
+                                draft.sourceCode
+                                  .split("\n")
+                                  .slice(0, Math.max(0, (issue.line || 1) - 1))
+                                  .join("\n").length +
+                                (issue.line && issue.line > 1 ? 1 : 0);
+                              e.focus();
+                              e.setSelectionRange(pos, pos);
+                              e.scrollTop = Math.max(
+                                0,
+                                ((issue.line || 1) - 3) * 22,
+                              );
+                              updateCursor();
+                            });
+                          }}
+                        >
+                          {issueLocation(issue)} · {issue.message}
+                        </button>
+                      ))}
+                    </section>
+                  </>
+                )}
+              </>
+            )}
+          </section>
+          {contextVisible && (
+            <>
+              {!narrow && (
+                <ResizeHandle
+                  reverse
+                  label="上下文面板宽度"
+                  value={sizes.right}
+                  min={280}
+                  max={420}
+                  onChange={(right) => setSizes({ ...sizes, right })}
+                />
+              )}
+              <aside
+                className="qfs-context"
+                style={{ width: sizes.right }}
+                aria-label="策略上下文"
+              >
+                <header>
+                  <strong>策略上下文</strong>
+                  <span>当前对象</span>
+                </header>
+                <div
+                  className="qfs-context-tabs"
+                  role="tablist"
+                  aria-label="上下文"
+                >
+                  {[
+                    ["parameters", "参数"],
+                    ["check", "检查"],
+                    ["history", "版本"],
+                    ["links", "关联"],
+                  ].map(([key, label]) => (
+                    <button
+                      role="tab"
+                      aria-selected={panel === key}
+                      key={key}
+                      onClick={() => setPanel(key)}
+                    >
+                      {label}
+                    </button>
+                  ))}
+                </div>
+                <div className="qfs-context-body" role="tabpanel">
+                  {!detail || detail.id !== strategyId ? (
+                    <p>请选择策略</p>
+                  ) : panel === "parameters" ? (
+                    <>
+                      <h3>默认参数</h3>
+                      {parameters && Object.keys(parameters).length ? (
+                        Object.entries(parameters).map(([key, value]) => (
+                          <label className="qfs-parameter" key={key}>
+                            <span>{key}</span>
+                            {typeof value === "boolean" ? (
+                              <input
+                                type="checkbox"
+                                checked={value}
+                                disabled={controlsDisabled}
+                                onChange={(e) =>
+                                  updateDraftField(
+                                    "defaultParameters",
+                                    prettyJson({
+                                      ...parameters,
+                                      [key]: e.target.checked,
+                                    }),
+                                  )
+                                }
+                              />
+                            ) : typeof value === "string" ? (
+                              <input
+                                value={value}
+                                disabled={controlsDisabled}
+                                onChange={(e) =>
+                                  updateDraftField(
+                                    "defaultParameters",
+                                    prettyJson({
+                                      ...parameters,
+                                      [key]: e.target.value,
+                                    }),
+                                  )
+                                }
+                              />
+                            ) : typeof value === "number" ? (
+                              <input
+                                type="number"
+                                value={value}
+                                disabled={controlsDisabled}
+                                onChange={(e) => {
+                                  if (
+                                    e.target.value !== "" &&
+                                    Number.isFinite(e.target.valueAsNumber)
+                                  )
+                                    updateDraftField(
+                                      "defaultParameters",
+                                      prettyJson({
+                                        ...parameters,
+                                        [key]: e.target.valueAsNumber,
+                                      }),
+                                    );
+                                }}
+                              />
+                            ) : (
+                              <button
+                                onClick={() => setFile("defaultParameters")}
+                              >
+                                在 JSON 中编辑
+                              </button>
+                            )}
+                          </label>
+                        ))
+                      ) : (
+                        <p className="qfs-muted">
+                          {parameters
+                            ? "暂无默认参数，可在 params.json 中添加。"
+                            : "JSON 尚未有效，请在 params.json 中修正。"}
+                        </p>
+                      )}
+                      <div className="qfs-section-head">
+                        <h3>参数 Schema</h3>
+                        <button
+                          disabled={controlsDisabled}
+                          onClick={formatSchema}
+                        >
+                          格式化
+                        </button>
+                      </div>
+                      <textarea
+                        className="qfs-schema"
+                        aria-label="参数 Schema"
+                        value={draft?.parameterSchema || ""}
+                        readOnly={controlsDisabled}
+                        spellCheck={false}
+                        onChange={(e) =>
+                          updateDraftField("parameterSchema", e.target.value)
+                        }
+                      />
+                      <p className="qfs-muted">
+                        复杂结构保留在 JSON 中编辑，保存时校验格式。
+                      </p>
+                    </>
+                  ) : panel === "check" ? (
+                    <>
+                      <h3>{checkLabel}</h3>
+                      <p>语法、入口签名、默认参数与 Schema 契约。</p>
+                      <p className="qfs-muted">
+                        静态检查不代表策略运行或回测已通过。
+                      </p>
+                      <button onClick={() => setDiagnostics(true)}>
+                        查看检查详情
+                      </button>
+                    </>
+                  ) : panel === "history" ? (
+                    <>
+                      <h3>发布版本</h3>
+                      {revisionLoading && <p role="status">加载版本…</p>}
+                      {!revisions.length ? (
+                        <p>暂无发布版本</p>
+                      ) : (
+                        revisions.map((r) => (
+                          <button
+                            disabled={busy}
+                            className="qfs-record"
+                            key={r.id}
+                            onClick={() => void openRevision(r)}
+                          >
+                            <strong>
+                              v{r.revision_number}
+                              {r.id === detail.current_revision_id
+                                ? " · 当前发布版本"
+                                : ""}
+                            </strong>
+                            <small>{formatTimestamp(r.published_at)}</small>
+                            <code>{shortHash(r.source_hash)}</code>
+                          </button>
+                        ))
+                      )}
+                      <div className="qfs-record">
+                        <strong>当前草稿</strong>
+                        <small>
+                          最后保存 {formatTimestamp(detail.draft.updated_at)}
+                        </small>
+                      </div>
+                      <button
+                        disabled={controlsDisabled}
+                        onClick={() => void handleArchive()}
+                      >
+                        <Archive />
+                        归档策略
+                      </button>
+                    </>
+                  ) : (
+                    <RecentRuns strategyId={detail.id} />
+                  )}
+                </div>
+              </aside>
+            </>
+          )}
+        </div>
+      </section>
+      {createOpen && (
+        <Drawer title="创建策略" onClose={closeCreate}>
+          <form onSubmit={handleCreate}>
+            <p>填写基本信息并选择初始模板，创建后进入编辑器。</p>
+            {error && (
+              <p role="alert" className="qfs-error">
+                {error}
+              </p>
+            )}
+            <label>
+              策略名称
+              <input
+                autoFocus
+                required
+                maxLength={100}
+                disabled={busy}
+                value={createDraft.name}
+                onChange={(e) =>
+                  setCreateDraft({ ...createDraft, name: e.target.value })
+                }
+              />
+            </label>
+            <label>
+              初始模板
+              <select
+                disabled={busy}
+                value={createDraft.template}
+                onChange={(e) =>
+                  setCreateDraft({
+                    ...createDraft,
+                    template: e.target.value as TemplateKey,
+                  })
+                }
+              >
+                {Object.entries(TEMPLATES).map(([key, t]) => (
+                  <option value={key} key={key}>
+                    {t.label}
+                  </option>
+                ))}
+              </select>
+            </label>
+            <label>
+              说明（可选）
+              <textarea
+                maxLength={10000}
+                disabled={busy}
+                value={createDraft.description}
+                onChange={(e) =>
+                  setCreateDraft({
+                    ...createDraft,
+                    description: e.target.value,
+                  })
+                }
+              />
+            </label>
+            <p className="qfs-muted">
+              {createDraft.template === "blank"
+                ? "空白模板需要实现策略逻辑后再发布。"
+                : createDraft.template === "rotation"
+                  ? "使用原始收盘价计算动量；回测前核对回看窗口与数据范围。"
+                  : "保留当前持仓，不产生新的交易意图。"}
+            </p>
+            <footer>
+              <button type="button" disabled={busy} onClick={closeCreate}>
+                取消
+              </button>
+              <button
+                className="qfs-primary"
+                disabled={busy || !createDraft.name.trim()}
+              >
+                {busy ? "创建中…" : "创建并进入编辑器"}
+              </button>
+            </footer>
+          </form>
+        </Drawer>
+      )}
+      {revisionPreview && (
+        <Drawer
+          title={`发布版本 v${revisionPreview.revision_number}`}
+          onClose={() => setRevisionPreview(null)}
+        >
+          <p>
+            发布于 {formatTimestamp(revisionPreview.published_at)} · 只读快照
+          </p>
+          <h3>strategy.py</h3>
+          <pre>{revisionPreview.source_code}</pre>
+          <h3>参数 Schema</h3>
+          <pre>{prettyJson(revisionPreview.parameter_schema)}</pre>
+          <h3>默认参数</h3>
+          <pre>{prettyJson(revisionPreview.default_parameters)}</pre>
+        </Drawer>
+      )}
+    </OverviewShell>
   );
 }
-
-function isSameEditorDraftSafe(detail: StrategyDetail, draft: EditorDraft): boolean {
+function isSameEditorDraftSafe(detail: StrategyDetail, draft: EditorDraft) {
   try {
     return isSameEditorDraft(detail, draft);
   } catch {
-    // Invalid local JSON is necessarily a pending edit and should never be lost.
     return false;
   }
 }
 
-function handleEditorKeyDown(
-  event: KeyboardEvent<HTMLTextAreaElement>,
-  source: string,
-  setSource: (value: string) => void
-) {
-  if (event.key !== "Tab") return;
-  event.preventDefault();
-  const target = event.currentTarget;
-  const start = target.selectionStart;
-  const end = target.selectionEnd;
-  const next = `${source.slice(0, start)}    ${source.slice(end)}`;
-  setSource(next);
-  requestAnimationFrame(() => {
-    target.selectionStart = start + 4;
-    target.selectionEnd = start + 4;
-  });
-}
-
-function StrategyWelcome({ onCreate }: { onCreate: () => void }) {
-  return <div className="strategy-welcome"><div className="strategy-welcome__mark"><Code2 aria-hidden="true" /></div><span className="workbench-eyebrow">PRIVATE BY DESIGN</span><h3>把策略留在你的部署里</h3><p>源码和因子只保存在当前部署的 PostgreSQL。先创建一条策略，再从草稿开始编写；发布后每个版本都会被完整保留。</p><button className="task-create-button" type="button" onClick={onCreate}><Plus aria-hidden="true" />新建第一条策略</button></div>;
-}
-
-function JsonEditor({
-  label,
-  eyebrow,
-  value,
-  disabled,
-  onChange,
-  hint
-}: {
-  label: string;
-  eyebrow: string;
-  value: string;
-  disabled: boolean;
-  onChange: (value: string) => void;
-  hint: string;
-}) {
-  return <label className="strategy-json-editor"><div className="strategy-panel__heading"><div><span className="workbench-eyebrow">{eyebrow}</span><h4>{label}</h4></div><Copy aria-hidden="true" /></div><textarea value={value} disabled={disabled} onChange={(event) => onChange(event.target.value)} spellCheck={false} wrap="off" aria-label={label} /><small>{hint}</small></label>;
-}
-
-function ValidationPanel({ validation, status }: { validation: StrategyValidationResult | null; status: string }) {
-  return <section className={`strategy-validation${validation?.valid ? " strategy-validation--valid" : validation ? " strategy-validation--invalid" : ""}`} aria-labelledby="strategy-validation-title">
-    <div className="strategy-section-heading"><div><span className="workbench-eyebrow">STATIC CHECK</span><h4 id="strategy-validation-title"><ShieldCheck aria-hidden="true" />发布前校验</h4></div><span>{status}</span></div>
-    {!validation ? <div className="strategy-validation__empty"><ShieldCheck aria-hidden="true" /><span>保存草稿后点击“校验”，确认入口和参数契约可用于发布。</span></div>
-      : validation.valid ? <div className="strategy-validation__result"><CircleCheck aria-hidden="true" /><span><strong>校验通过</strong><small>当前草稿满足首期静态策略契约，可以发布为不可变版本。</small></span></div>
-        : <div className="strategy-issues">{validation.issues.map((issue, index) => <div className="strategy-issue" key={`${issue.code}-${index}`}><CircleAlert aria-hidden="true" /><span><strong>{issue.message}</strong><small>{issueLocation(issue)} · {issue.code}</small></span></div>)}</div>}
-  </section>;
-}
-
-function CreateStrategyDialog({
-  draft,
-  saving,
-  onChange,
-  onClose,
-  onSubmit
-}: {
-  draft: CreateDraft;
-  saving: boolean;
-  onChange: (draft: CreateDraft) => void;
-  onClose: () => void;
-  onSubmit: (event: FormEvent<HTMLFormElement>) => void;
-}) {
-  function setField<K extends keyof CreateDraft>(field: K, value: CreateDraft[K]) {
-    onChange({ ...draft, [field]: value });
+function sessionValue(key: string, fallback: string) {
+  try {
+    return sessionStorage.getItem("qfs-" + key) ?? fallback;
+  } catch {
+    return fallback;
   }
-
-  return <div className="prototype-modal strategy-modal-backdrop" role="presentation" onMouseDown={onClose}>
-    <form className="prototype-modal__dialog strategy-create-dialog" onSubmit={onSubmit} onMouseDown={(event) => event.stopPropagation()}>
-      <div className="prototype-modal__heading"><div><span>NEW PRIVATE STRATEGY</span><h3>创建策略</h3></div><button className="icon-button" type="button" onClick={onClose} aria-label="关闭创建策略对话框"><X aria-hidden="true" /></button></div>
-      <p className="strategy-modal__notice"><ShieldCheck aria-hidden="true" />源码会直接写入 PostgreSQL，不会创建本地策略文件。</p>
-      <label><span>策略名称</span><input autoFocus value={draft.name} onChange={(event) => setField("name", event.target.value)} placeholder="例如：ETF 趋势策略" maxLength={100} /></label>
-      <label><span>说明（可选）</span><input value={draft.description} onChange={(event) => setField("description", event.target.value)} placeholder="描述策略用途" maxLength={10_000} /></label>
-      <label><span>初始源码</span><textarea className="strategy-create-source" value={draft.sourceCode} onChange={(event) => setField("sourceCode", event.target.value)} spellCheck={false} wrap="off" /></label>
-      <div className="prototype-modal__actions"><button className="secondary-button" type="button" onClick={onClose}>取消</button><button className="task-create-button" type="submit" disabled={saving || !draft.name.trim()}>{saving && <LoaderCircle className="spin" aria-hidden="true" />}{saving ? "创建中" : "创建并编辑"}</button></div>
-    </form>
-  </div>;
-}
-
-function RevisionPreviewDialog({ revision, loading, onClose }: { revision: StrategyRevision; loading: boolean; onClose: () => void }) {
-  return <div className="prototype-modal strategy-modal-backdrop" role="presentation" onMouseDown={onClose}>
-    <section className="prototype-modal__dialog strategy-revision-dialog" role="dialog" aria-modal="true" aria-labelledby="revision-preview-title" onMouseDown={(event) => event.stopPropagation()}>
-      <div className="prototype-modal__heading"><div><span>IMMUTABLE REVISION · v{revision.revision_number}</span><h3 id="revision-preview-title">版本源码快照</h3></div><button className="icon-button" type="button" onClick={onClose} aria-label="关闭版本预览"><X aria-hidden="true" /></button></div>
-      <div className="strategy-revision-dialog__facts"><span>发布于 {formatTimestamp(revision.published_at)}</span><code>{revision.source_hash}</code></div>
-      <pre><code>{revision.source_code}</code></pre>
-      {loading && <span className="strategy-revision-dialog__loading"><LoaderCircle className="spin" aria-hidden="true" />加载中</span>}
-      <div className="prototype-modal__actions"><button className="secondary-button" type="button" onClick={onClose}>关闭</button></div>
-    </section>
-  </div>;
 }

--- a/frontend/src/pages/strategies/StrategyWorkspace.css
+++ b/frontend/src/pages/strategies/StrategyWorkspace.css
@@ -1,0 +1,685 @@
+.qfs-root {
+  --canvas: #f6f3ee;
+  --surface: #fffdfc;
+  --accent: #e85f32;
+  --sidebar-collapsed: 74px;
+  font-size: 14px;
+  color: #253140;
+}
+.qfs-root .qfo-main {
+  padding: 16px 20px;
+  overflow: hidden;
+  display: flex;
+  min-height: 0;
+}
+.qfs-root .qfo-topbar {
+  height: 54px;
+}
+.qfs-root .qfo-shell {
+  min-width: 0;
+  min-height: 0;
+}
+.qfs-page {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  flex: 1;
+  min-height: 0;
+  min-width: 0;
+}
+.qfs-root .qfs-heading {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 16px;
+}
+.qfs-root .qfs-heading h1 {
+  font-size: 25px;
+  line-height: 34px;
+  margin: 0;
+}
+.qfs-heading small {
+  font-size: 12px;
+  letter-spacing: 1.4px;
+  color: #d44a23;
+}
+.qfs-heading p {
+  margin: 2px 0 0;
+  color: #647382;
+  font-size: 12px;
+}
+.qfs-actions {
+  display: flex;
+  gap: 6px;
+  align-items: center;
+  flex-wrap: wrap;
+}
+.qfs-root button,
+.qfs-drawer button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+  border: 1px solid #d9d3ca;
+  background: #fffdfc;
+  border-radius: 7px;
+  padding: 7px 10px;
+  min-height: 34px;
+  font: inherit;
+  font-size: 12px;
+  color: #334151;
+  cursor: pointer;
+}
+.qfs-root button:hover:not(:disabled),
+.qfs-drawer button:hover:not(:disabled) {
+  border-color: #e85f32;
+  background: #fff3eb;
+}
+.qfs-root button:disabled,
+.qfs-drawer button:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+.qfs-root svg,
+.qfs-drawer svg {
+  width: 15px;
+  height: 15px;
+  flex: none;
+}
+.qfs-root button.qfs-primary,
+.qfs-drawer button.qfs-primary {
+  background: #e85f32;
+  border-color: #e85f32;
+  color: #fff;
+}
+.qfs-root :focus-visible,
+.qfs-drawer :focus-visible {
+  outline: 2px solid #b9431e;
+  outline-offset: 2px;
+}
+.qfs-root input,
+.qfs-root select,
+.qfs-root textarea,
+.qfs-drawer input,
+.qfs-drawer select,
+.qfs-drawer textarea {
+  font: inherit;
+  min-width: 0;
+  border: 1px solid #d9d3ca;
+  border-radius: 6px;
+  background: #faf8f5;
+  color: #263343;
+  padding: 9px;
+}
+.qfs-root input,
+.qfs-drawer input,
+.qfs-drawer select {
+  min-height: 36px;
+}
+.qfs-root .qfs-message {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 12px;
+  padding: 7px 12px;
+  background: #eef6f0;
+  border: 1px solid #c2d7c8;
+  border-radius: 6px;
+  flex-shrink: 0;
+  font-size: 13px;
+}
+.qfs-root .qfs-error,
+.qfs-drawer .qfs-error {
+  color: #a73227;
+  background: #fff0ed;
+}
+.qfs-message button {
+  padding: 3px;
+  min-height: 26px;
+}
+.qfs-workbench {
+  display: flex;
+  flex: 1;
+  min-height: 0;
+  min-width: 0;
+  position: relative;
+  overflow: hidden;
+}
+.qfs-explorer,
+.qfs-context {
+  flex: none;
+  background: #fffdfc;
+  border: 1px solid #dad4cc;
+  border-radius: 10px;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+  min-height: 0;
+}
+.qfs-root .qfs-explorer > header,
+.qfs-root .qfs-context > header {
+  display: flex;
+  gap: 8px;
+  align-items: center;
+  padding: 12px;
+  min-height: 48px;
+  border-bottom: 1px solid #e3ddd5;
+  font-size: 12px;
+}
+.qfs-explorer > header span,
+.qfs-context > header span {
+  margin-left: auto;
+  color: #657381;
+}
+.qfs-explorer > header button {
+  padding: 4px;
+  min-height: 28px;
+}
+.qfs-search {
+  padding: 10px;
+  border-bottom: 1px solid #e3ddd5;
+}
+.qfs-search > input {
+  width: 100%;
+  font-size: 12px;
+}
+.qfs-filters {
+  display: flex;
+  gap: 4px;
+  margin-top: 10px;
+}
+.qfs-filters button {
+  padding: 5px 7px;
+  min-height: 28px;
+  white-space: nowrap;
+}
+.qfs-root button[aria-pressed="true"] {
+  color: #bf461e;
+  background: #fff0e8;
+  border-color: #edb99f;
+}
+.qfs-list {
+  overflow: auto;
+  padding: 8px;
+  flex: 1;
+}
+.qfs-list > p {
+  padding: 8px;
+  font-size: 13px;
+}
+.qfs-root .qfs-list > button {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  text-align: left;
+  width: 100%;
+  padding: 12px 8px;
+  margin-bottom: 4px;
+  border-color: transparent;
+  gap: 6px;
+  align-items: start;
+}
+.qfs-root .qfs-list > button strong {
+  font-size: 14px;
+  overflow-wrap: anywhere;
+}
+.qfs-root .qfs-list > button small {
+  grid-column: 1/-1;
+  text-overflow: ellipsis;
+  overflow: hidden;
+  white-space: nowrap;
+  color: #657382;
+  font-size: 12px;
+}
+.qfs-root .qfs-list > button.qfs-selected {
+  background: #fff4ed;
+  border-color: #f0b79d;
+}
+.qfs-badge {
+  display: inline-block;
+  font-size: 12px;
+  color: #32784d;
+  background: #edf5ee;
+  padding: 3px 6px;
+  border-radius: 5px;
+  white-space: nowrap;
+}
+.qfs-resize {
+  width: 8px;
+  flex: none;
+  cursor: col-resize;
+  touch-action: none;
+  position: relative;
+}
+.qfs-resize:hover,
+.qfs-resize:focus-visible {
+  background: #edc7b5;
+  border-radius: 4px;
+}
+.qfs-resize-y {
+  width: auto;
+  height: 7px;
+  cursor: row-resize;
+  background: #263342;
+}
+.qfs-editor-panel {
+  flex: 1;
+  min-width: 360px;
+  min-height: 0;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+  border: 1px solid #d9d3ca;
+  border-radius: 10px;
+  background: #101720;
+}
+.qfs-object {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+  padding: 12px;
+  background: #fffdfc;
+  flex-wrap: wrap;
+}
+.qfs-object > div:first-child {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-wrap: wrap;
+  min-width: 0;
+}
+.qfs-object strong {
+  font-size: 14px;
+  overflow-wrap: anywhere;
+}
+.qfs-object small {
+  font-size: 12px;
+  color: #647382;
+  max-width: 180px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.qfs-version-note {
+  background: #fff8e9;
+  color: #795a28;
+  padding: 6px 12px;
+  font-size: 12px;
+}
+.qfs-file-tabs {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  padding: 7px 10px;
+  background: #151e29;
+  border-bottom: 1px solid #2c3949;
+  flex-wrap: wrap;
+}
+.qfs-root .qfs-file-tabs button {
+  color: #b7c5d2;
+  background: transparent;
+  border-color: transparent;
+  font-family: ui-monospace, SFMono-Regular, Consolas, monospace;
+  white-space: nowrap;
+}
+.qfs-root .qfs-file-tabs button[aria-selected="true"] {
+  color: #f0f4f7;
+  background: #0b1118;
+  border-color: #3b4b5c;
+}
+.qfs-file-tabs > span {
+  margin-left: auto;
+  color: #a4b2c0;
+  font-size: 12px;
+}
+.qfs-code {
+  display: flex;
+  flex: 1;
+  min-height: 100px;
+  overflow: hidden;
+}
+.qfs-code pre {
+  width: 48px;
+  flex: none;
+  overflow: hidden;
+  text-align: right;
+  padding: 12px 8px 12px 0;
+  margin: 0;
+  background: #0b1118;
+  color: #8e9eae;
+  font:
+    13px/22px ui-monospace,
+    SFMono-Regular,
+    Consolas,
+    monospace;
+  user-select: none;
+}
+.qfs-root .qfs-code textarea {
+  flex: 1;
+  width: 0;
+  min-width: 0;
+  border: 0;
+  border-radius: 0;
+  outline-offset: -2px;
+  resize: none;
+  background: #101720;
+  color: #dbe6f0;
+  padding: 12px 16px;
+  font:
+    13px/22px ui-monospace,
+    SFMono-Regular,
+    Consolas,
+    monospace;
+  tab-size: 4;
+  overflow: auto;
+}
+.qfs-description-head {
+  padding: 10px 14px;
+  background: #fffdfc;
+}
+.qfs-description-head label {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+.qfs-description-head p {
+  margin: 6px 0 0;
+  font-size: 12px;
+  color: #637282;
+}
+.qfs-status {
+  background: #151e29;
+  color: #a7b6c5;
+  border-top: 1px solid #2c3949;
+  padding: 5px 8px;
+  display: flex;
+  gap: 8px;
+  align-items: center;
+  justify-content: space-between;
+  flex-wrap: wrap;
+  font-size: 12px;
+}
+.qfs-root .qfs-status button {
+  background: transparent;
+  color: #bdcbd7;
+  border: 0;
+  padding: 3px 4px;
+  min-height: 26px;
+  text-align: left;
+}
+.qfs-diagnostics {
+  flex: none;
+  overflow: auto;
+  background: #fffdfc;
+  padding: 12px;
+  font-size: 12px;
+  max-height: 40vh;
+}
+.qfs-diagnostics header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+}
+.qfs-root .qfs-issue {
+  display: block;
+  text-align: left;
+  width: 100%;
+  margin: 5px 0;
+  color: #ad3929;
+}
+.qfs-context-tabs {
+  display: flex;
+  gap: 3px;
+  padding: 8px;
+  border-bottom: 1px solid #e1dad2;
+}
+.qfs-root .qfs-context-tabs button {
+  flex: 1;
+  border: 0;
+}
+.qfs-root .qfs-context-tabs button[aria-selected="true"] {
+  background: #fff0e8;
+  color: #be471f;
+}
+.qfs-context-body {
+  overflow: auto;
+  padding: 14px;
+  flex: 1;
+  min-height: 0;
+}
+.qfs-context-body h3 {
+  font-size: 14px;
+  margin: 4px 0 12px;
+}
+.qfs-context-body p {
+  font-size: 13px;
+  line-height: 1.65;
+}
+.qfs-muted {
+  color: #667482;
+  font-size: 12px;
+  line-height: 1.6;
+}
+.qfs-parameter {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+  padding: 12px 0;
+  border-bottom: 1px solid #e4ddd5;
+  font-size: 12px;
+  overflow-wrap: anywhere;
+}
+.qfs-parameter input:not([type="checkbox"]) {
+  width: 105px;
+  font-size: 13px;
+}
+.qfs-section-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin: 18px 0 10px;
+  gap: 8px;
+}
+.qfs-section-head h3 {
+  margin: 0;
+}
+.qfs-root .qfs-schema {
+  width: 100%;
+  min-height: 260px;
+  resize: vertical;
+  font:
+    12px/20px ui-monospace,
+    SFMono-Regular,
+    Consolas,
+    monospace;
+}
+.qfs-root .qfs-record {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  text-align: left;
+  border: 1px solid #e1d9cf;
+  padding: 12px;
+  border-radius: 7px;
+  margin-bottom: 8px;
+  width: 100%;
+  gap: 7px;
+  overflow-wrap: anywhere;
+}
+.qfs-record small {
+  font-size: 12px;
+  color: #637282;
+  word-break: break-all;
+}
+.qfs-record code {
+  font-size: 12px;
+}
+.qfs-context-body a {
+  color: #b44421;
+}
+.qfs-empty {
+  display: flex;
+  flex: 1;
+  align-items: center;
+  justify-content: center;
+  flex-direction: column;
+  background: #fffdfc;
+  color: #667482;
+  padding: 24px;
+  text-align: center;
+}
+.qfs-empty svg {
+  width: 32px;
+  height: 32px;
+}
+.qfs-empty h2 {
+  font-size: 18px;
+}
+.qfs-drawer {
+  position: fixed;
+  margin: 0 0 0 auto;
+  inset: 0;
+  width: 480px;
+  max-width: 100vw;
+  height: 100dvh;
+  max-height: 100dvh;
+  box-sizing: border-box;
+  border: 0;
+  border-left: 1px solid #d8d0c5;
+  background: #fffdfc;
+  color: #263343;
+  padding: 24px;
+  overflow: auto;
+  font:
+    14px/1.6 system-ui,
+    sans-serif;
+  box-shadow: -12px 0 40px #0002;
+}
+.qfs-drawer::backdrop {
+  background: #121a2455;
+}
+.qfs-drawer header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 16px;
+  margin-bottom: 24px;
+}
+.qfs-drawer header small {
+  color: #c34c27;
+  font-size: 12px;
+  letter-spacing: 1px;
+}
+.qfs-drawer h2 {
+  font-size: 22px;
+  margin: 0;
+}
+.qfs-drawer label {
+  display: flex;
+  flex-direction: column;
+  gap: 7px;
+  margin: 20px 0;
+}
+.qfs-drawer textarea {
+  min-height: 120px;
+  resize: vertical;
+}
+.qfs-drawer footer {
+  display: flex;
+  justify-content: flex-end;
+  gap: 10px;
+  margin-top: 24px;
+}
+.qfs-drawer pre {
+  background: #101720;
+  color: #dae4ed;
+  padding: 16px;
+  overflow: auto;
+  border-radius: 7px;
+  font: 13px/22px monospace;
+}
+.qfs-drawer h3 {
+  font-size: 14px;
+  margin-top: 24px;
+}
+.qfs-narrow .qfs-explorer,
+.qfs-narrow .qfs-context {
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  z-index: 3;
+  box-shadow: 0 8px 24px #0003;
+  max-width: calc(100% - 12px);
+}
+.qfs-narrow .qfs-explorer {
+  left: 0;
+}
+.qfs-narrow .qfs-context {
+  right: 0;
+}
+.qfs-root .qfs-scrim {
+  position: absolute;
+  inset: 0;
+  z-index: 2;
+  background: #14213440;
+  border: 0;
+  border-radius: 0;
+}
+.qfs-root .qfs-narrow .qfs-editor-panel {
+  min-width: 0;
+}
+.qfs-root .qfs-narrow .qfs-code textarea {
+  min-width: 0;
+}
+@media (max-width: 1200px) {
+  .qfs-root .qfs-heading {
+    align-items: flex-start;
+  }
+  .qfs-heading > .qfs-actions {
+    justify-content: flex-end;
+    max-width: 65%;
+  }
+  .qfs-root .qfo-main {
+    padding: 12px;
+  }
+  .qfs-object small {
+    display: none;
+  }
+}
+@media (max-width: 600px) {
+  .qfs-root .qfs-heading {
+    flex-direction: column;
+    gap: 8px;
+  }
+  .qfs-heading > .qfs-actions {
+    max-width: 100%;
+    justify-content: flex-start;
+  }
+  .qfs-object {
+    padding: 8px;
+  }
+  .qfs-object .qfs-actions {
+    gap: 4px;
+  }
+  .qfs-root .qfs-object button {
+    padding: 6px;
+  }
+  .qfs-root .qfo-main {
+    padding: 8px;
+  }
+  .qfs-file-tabs > span {
+    width: 100%;
+    margin-left: 0;
+  }
+  .qfs-status > span {
+    display: none;
+  }
+  .qfs-code pre {
+    width: 34px;
+  }
+  .qfs-root .qfs-code textarea {
+    padding: 12px 8px;
+  }
+}

--- a/frontend/src/pages/strategies/WorkspaceParts.tsx
+++ b/frontend/src/pages/strategies/WorkspaceParts.tsx
@@ -1,0 +1,214 @@
+import { useEffect, useRef, useState } from "react";
+import type { ReactNode } from "react";
+import { Link } from "react-router-dom";
+import { X } from "lucide-react";
+import {
+  fetchStrategyBacktestWorkspace,
+  type BacktestRun,
+} from "../../api/backtestRuns";
+
+export function ResizeHandle({
+  label,
+  value,
+  min,
+  max,
+  onChange,
+  horizontal = false,
+  reverse = false,
+}: {
+  label: string;
+  value: number;
+  min: number;
+  max: number;
+  onChange: (n: number) => void;
+  horizontal?: boolean;
+  reverse?: boolean;
+}) {
+  const drag = useRef<{ position: number; value: number } | null>(null);
+  return (
+    <div
+      className={`qfs-resize ${horizontal ? "qfs-resize-y" : ""}`}
+      role="separator"
+      tabIndex={0}
+      aria-label={label}
+      aria-orientation={horizontal ? "horizontal" : "vertical"}
+      aria-valuenow={value}
+      aria-valuemin={min}
+      aria-valuemax={max}
+      onKeyDown={(e) => {
+        const d =
+          e.key === "ArrowRight" || e.key === "ArrowDown"
+            ? 10
+            : e.key === "ArrowLeft" || e.key === "ArrowUp"
+              ? -10
+              : 0;
+        if (d) {
+          e.preventDefault();
+          onChange(
+            Math.min(max, Math.max(min, value + d * (reverse ? -1 : 1))),
+          );
+        }
+      }}
+      onPointerDown={(e) => {
+        drag.current = { position: horizontal ? e.clientY : e.clientX, value };
+        e.currentTarget.setPointerCapture(e.pointerId);
+      }}
+      onPointerMove={(e) => {
+        if (drag.current)
+          onChange(
+            Math.min(
+              max,
+              Math.max(
+                min,
+                drag.current.value +
+                  ((horizontal ? e.clientY : e.clientX) -
+                    drag.current.position) *
+                    (reverse ? -1 : 1),
+              ),
+            ),
+          );
+      }}
+      onPointerUp={() => {
+        drag.current = null;
+      }}
+      onLostPointerCapture={() => {
+        drag.current = null;
+      }}
+    />
+  );
+}
+export function Drawer({
+  title,
+  onClose,
+  children,
+}: {
+  title: string;
+  onClose: () => void;
+  children: ReactNode;
+}) {
+  const ref = useRef<HTMLDialogElement>(null);
+  useEffect(() => {
+    const prior = document.activeElement as HTMLElement;
+    ref.current?.showModal();
+    return () => {
+      if (prior?.isConnected) prior.focus();
+    };
+  }, []);
+  return (
+    <dialog
+      className="qfs-drawer"
+      ref={ref}
+      aria-label={title}
+      onCancel={(e) => {
+        e.preventDefault();
+        onClose();
+      }}
+      onClick={(e) => {
+        if (e.target === e.currentTarget) {
+          const r = e.currentTarget.getBoundingClientRect();
+          if (e.clientX < r.left || e.clientX > r.right) onClose();
+        }
+      }}
+    >
+      <header>
+        <div>
+          <small>STRATEGY WORKSPACE</small>
+          <h2>{title}</h2>
+        </div>
+        <button type="button" onClick={onClose} aria-label={`关闭${title}`}>
+          <X />
+        </button>
+      </header>
+      {children}
+    </dialog>
+  );
+}
+export function RecentRuns({ strategyId }: { strategyId: string }) {
+  const [rows, setRows] = useState<BacktestRun[]>([]),
+    [error, setError] = useState(""),
+    [loading, setLoading] = useState(true);
+  useEffect(() => {
+    const c = new AbortController();
+    setLoading(true);
+    setRows([]);
+    setError("");
+    (async () => {
+      try {
+        let cursor: string | undefined;
+        let recent: BacktestRun[] = [];
+        // The existing cursor API is ascending and snapshot-bounded.
+        // Walk it to retain the actual latest ten without inventing a total.
+        do {
+          const workspace = await fetchStrategyBacktestWorkspace(
+            strategyId,
+            c.signal,
+            cursor,
+          );
+          if (c.signal.aborted) return;
+          recent = [...recent, ...workspace.runs.items].slice(-10);
+          const next = workspace.runs.has_more
+            ? workspace.runs.next_cursor
+            : undefined;
+          if (workspace.runs.has_more && (!next || next === cursor))
+            throw new Error("回测历史分页无效，请重试。");
+          cursor = next || undefined;
+        } while (cursor);
+        setRows(recent.reverse());
+      } catch (e) {
+        if (!c.signal.aborted)
+          setError(e instanceof Error ? e.message : "回测历史加载失败。");
+      } finally {
+        if (!c.signal.aborted) setLoading(false);
+      }
+    })();
+    return () => c.abort();
+  }, [strategyId]);
+  return (
+    <>
+      <h3>最近回测</h3>
+      <p className="qfs-muted">
+        最多展示最近 10 次运行，账户引用属于对应回测。
+      </p>
+      {loading ? (
+        <p role="status">加载中…</p>
+      ) : error ? (
+        <p role="alert">{error}</p>
+      ) : !rows.length ? (
+        <p>暂无回测记录</p>
+      ) : (
+        rows.map((r) => (
+          <div className="qfs-record" key={r.run_id}>
+            <Link to={`/admin/strategies/${strategyId}/backtests`}>
+              {r.label || r.run_id}
+            </Link>
+            <small>
+              状态：
+              {(
+                {
+                  succeeded: "成功",
+                  failed: "失败",
+                  running: "运行中",
+                  queued: "排队中",
+                  cancelled: "已取消",
+                } as Record<string, string>
+              )[r.status] || r.status}
+            </small>
+            <small>版本引用：{r.strategy_revision_id || "—"}</small>
+            <small>
+              账户：{r.account_profile_id || "未指定"}
+              {r.account_profile_version
+                ? ` · v${r.account_profile_version}`
+                : ""}
+            </small>
+          </div>
+        ))
+      )}
+      <Link to={`/admin/strategies/${strategyId}/backtests`}>
+        查看回测工作台 →
+      </Link>
+      <h3>策略数据接口</h3>
+      <p className="qfs-muted">查询能力与使用说明</p>
+      <Link to="/admin/strategy-data">打开接口文档 →</Link>
+    </>
+  );
+}

--- a/frontend/src/pages/strategies/rotation.py
+++ b/frontend/src/pages/strategies/rotation.py
@@ -1,0 +1,34 @@
+"""Raw-close momentum example; review parameters before running a backtest."""
+from decimal import Decimal, ROUND_DOWN
+
+
+def run(context, parameters):
+    lookback = parameters.get("lookback", 60)
+    holding_size = parameters.get("holding_size", 3)
+    if type(lookback) is not int or lookback < 2:
+        raise ValueError("lookback must be an integer of at least 2")
+    if type(holding_size) is not int or holding_size < 1:
+        raise ValueError("holding_size must be a positive integer")
+    candidates = context.universe.query(
+        exchanges=["SSE", "SZSE"], asset_classes=["etf"]
+    )
+    ranked = []
+    for candidate in candidates:
+        # Data-contract failures must remain visible; do not hide them as hold.
+        bars = context.data.bars(candidate.instrument_id, lookback_sessions=lookback)
+        if len(bars) < lookback:
+            continue
+        closes = [bar.values.get("close") for bar in bars]
+        if any(value is None or not value.is_finite() or value <= 0 for value in closes):
+            continue
+        momentum = closes[-1] / closes[0] - Decimal(1)
+        ranked.append((momentum, str(candidate.instrument_id)))
+    ranked.sort(key=lambda item: (-item[0], item[1]))
+    leaders = ranked[:holding_size]
+    if not leaders:
+        return {"mode": "hold"}
+    # Round down so the total target cannot exceed one; retain residual cash.
+    weight = (Decimal(1) / Decimal(len(leaders))).quantize(
+        Decimal("0.00000001"), rounding=ROUND_DOWN
+    )
+    return {"mode": "target_weights", "targets": {item[1]: str(weight) for item in leaders}}

--- a/frontend/src/pages/strategies/templates.ts
+++ b/frontend/src/pages/strategies/templates.ts
@@ -1,0 +1,47 @@
+import rotationSource from "./rotation.py?raw";
+export const EMPTY_SCHEMA = {
+  type: "object",
+  properties: {},
+  additionalProperties: false,
+};
+export const TEMPLATES = {
+  hold: {
+    label: "持有 / 不交易模板",
+    source:
+      '"""Keep existing positions without submitting new targets."""\n\ndef run(context, parameters):\n    return {"mode": "hold"}\n',
+    schema: EMPTY_SCHEMA,
+    parameters: {},
+  },
+  blank: {
+    label: "空白 Python 模板",
+    source:
+      '"""Implement the strategy before publishing."""\n\ndef run(context, parameters):\n    # TODO: implement a hold or target_weights decision.\n    raise NotImplementedError("Strategy is not implemented")\n',
+    schema: EMPTY_SCHEMA,
+    parameters: {},
+  },
+  rotation: {
+    label: "ETF 轮动模板",
+    source: rotationSource,
+    schema: {
+      type: "object",
+      properties: {
+        lookback: {
+          type: "integer",
+          minimum: 2,
+          maximum: 252,
+          description: "原始收盘价回看交易日数",
+        },
+        holding_size: {
+          type: "integer",
+          minimum: 1,
+          maximum: 20,
+          description: "最多持有 ETF 数量",
+        },
+      },
+      required: ["lookback", "holding_size"],
+      additionalProperties: false,
+    },
+    parameters: { lookback: 60, holding_size: 3 },
+  },
+};
+export type TemplateKey = keyof typeof TEMPLATES;

--- a/frontend/tests/strategy-template.test.py
+++ b/frontend/tests/strategy-template.test.py
@@ -1,0 +1,59 @@
+"""Exercise the shipped template against the real immutable strategy protocol."""
+import unittest
+from pathlib import Path
+from datetime import date, datetime, timezone
+from decimal import Decimal
+from types import ModuleType, SimpleNamespace
+from uuid import UUID
+from app.strategy_protocol.adapter import FunctionStrategyAdapter
+from app.strategy_protocol.synthetic import ContractCheckParameters, build_synthetic_context
+from app.strategies.validation import validate_strategy_draft
+
+SOURCE = (Path(__file__).parents[1] / 'src/pages/strategies/rotation.py').read_text()
+
+class RotationTemplateTest(unittest.TestCase):
+    def setUp(self):
+        self.module = ModuleType('reviewed_rotation_template')
+        exec(compile(SOURCE, 'rotation.py', 'exec'), self.module.__dict__)
+
+    def test_real_protocol_accepts_published_template(self):
+        now = datetime(2026, 9, 12, 15, tzinfo=timezone.utc)
+        context, _ = build_synthetic_context(ContractCheckParameters(
+            session_date=date(2026, 9, 12), decision_time=now, data_cutoff=now,
+            static_instrument_ids=(), initial_positions=()))
+        decision = FunctionStrategyAdapter(self.module, parameters={'lookback': 2, 'holding_size': 3}).on_step(context)
+        self.assertEqual(decision.mode, 'target_weights')
+        self.assertGreater(len(decision.targets), 0)
+        self.assertLessEqual(sum(decision.targets.values()), Decimal(1))
+        self.assertTrue(validate_strategy_draft(SOURCE, parameter_schema={}, default_parameters={}).valid)
+
+    def context(self, windows):
+        candidates=[SimpleNamespace(instrument_id=UUID(int=i+1)) for i in range(len(windows))]
+        def bars(instrument_id, *, lookback_sessions):
+            return [SimpleNamespace(values={'close':v}) for v in windows[instrument_id.int-1]]
+        return SimpleNamespace(universe=SimpleNamespace(query=lambda **kw: candidates), data=SimpleNamespace(bars=bars))
+
+    def test_empty_and_bad_windows_hold(self):
+        for windows in [[], [[]], [[Decimal('NaN'),Decimal(2)]], [[Decimal(0),Decimal(2)]], [[None,Decimal(2)]], [[Decimal(1)]]]:
+            with self.subTest(windows=windows):
+                self.assertEqual(self.module.run(self.context(windows), {'lookback':2}), {'mode':'hold'})
+
+    def test_rank_ties_and_decimal_weights_are_deterministic(self):
+        windows=[[Decimal(1),Decimal(2)]]*3
+        result=self.module.run(self.context(windows), {'lookback':2,'holding_size':3})
+        self.assertEqual(list(result['targets']), [str(UUID(int=i)) for i in range(1,4)])
+        self.assertTrue(all(isinstance(v,str) for v in result['targets'].values()))
+        self.assertLessEqual(sum(map(Decimal,result['targets'].values())), Decimal(1))
+
+    def test_data_failures_are_not_suppressed(self):
+        context=self.context([[Decimal(1),Decimal(2)]])
+        def fail(*a,**kw): raise RuntimeError('missing PIT evidence')
+        context.data.bars=fail
+        with self.assertRaisesRegex(RuntimeError,'missing PIT'):
+            self.module.run(context,{'lookback':2})
+
+    def test_invalid_parameters_are_rejected(self):
+        for params in [{'lookback':True},{'lookback':1},{'holding_size':0},{'holding_size':1.5}]:
+            with self.assertRaises(ValueError): self.module.run(self.context([]),params)
+
+if __name__=='__main__': unittest.main()

--- a/frontend/tests/strategy-workspace.e2e.cjs
+++ b/frontend/tests/strategy-workspace.e2e.cjs
@@ -1,0 +1,73 @@
+// Run with PLAYWRIGHT_MODULE pointing to the installed Playwright module.
+// Isolated browser context: all business APIs below are test fixtures only.
+const {chromium}=require(process.env.PLAYWRIGHT_MODULE||'playwright');
+const assert=require('node:assert/strict');
+(async()=>{
+ const browser=await chromium.connectOverCDP(process.env.CDP_URL||'http://127.0.0.1:9421');
+ const context=await browser.newContext({viewport:{width:1440,height:960}});
+ await context.addInitScript(()=>sessionStorage.setItem('quant-foundry.api-token','local-fixture-only'));
+ const page=await context.newPage();const errors=[];page.on('pageerror',e=>errors.push(e.message));
+ const source='def run(context, parameters):\n    return {"mode": "hold"}\n';
+ const make=(id)=>({id,name:'策略 '+id,description:null,state:'active',current_revision_id:null,version:1,created_at:'2026-09-12T08:00:00Z',updated_at:'2026-09-12T08:00:00Z',draft_changed_since_revision:true,draft:{source_code:source,source_hash:'abcdef',parameter_schema:{type:'object'},default_parameters:{lookback:60},version:1,created_at:'2026-09-12T08:00:00Z',updated_at:'2026-09-12T08:00:00Z'},current_revision:null});
+ const rows={one:make('one'),two:make('two')};let conflict=false,delaySave=false,saveCount=0,metadataCount=0;const revisions={};
+ await context.route(url=>url.pathname.startsWith('/api/'),async route=>{
+  const request=route.request(),url=new URL(request.url()),path=url.pathname,method=request.method();
+  let body={},status=200;const parts=path.split('/'),id=parts[4],row=rows[id];
+  if(path==='/api/admin/strategies'){
+   if(method==='GET')body=Object.values(rows);
+   else {body=rows.new={...make('new'),...request.postDataJSON()};body.draft.source_code=body.source_code;body.draft.parameter_schema=body.parameter_schema;body.draft.default_parameters=body.default_parameters;status=201;}
+  }else if(row){
+   if(parts[5]==='draft'){
+    saveCount++;if(delaySave)await new Promise(r=>setTimeout(r,350));
+    if(conflict){status=409;body={detail:'draft version conflict'};conflict=false;}
+    else{const payload=request.postDataJSON();assert.equal(payload.version,row.draft.version);row.draft={...row.draft,...payload,version:row.draft.version+1};body=row.draft;}
+   }else if(parts[5]==='validate')body={valid:true,draft_version:row.draft.version,source_hash:row.draft.source_hash,issues:[]};
+   else if(parts[5]==='publish'){const r={id:'rev-'+id,revision_number:1,source_hash:'abcdef',runtime_manifest:{},published_at:'2026-09-12T08:01:00Z',...row.draft};revisions[id]=r;row.current_revision=r;row.current_revision_id=r.id;row.draft_changed_since_revision=false;body=r;status=201;}
+   else if(parts[5]==='revisions')body=parts[6]?revisions[id]:(revisions[id]?[revisions[id]]:[]);
+   else if(parts[5]==='backtests')body={runs:{items:[],has_more:false},published_revisions:[],strategy:row};
+   else if(method==='PATCH'){metadataCount++;const payload=request.postDataJSON();assert.equal(payload.version,row.version);Object.assign(row,payload,{version:row.version+1});body=row;}
+   else if(method==='DELETE'){row.state='archived';status=204;}
+   else body=row;
+  }else if(path.includes('auth')){status=204;}else if(path.includes('version'))body={version:'0.2.0'};
+  await route.fulfill({status,contentType:'application/json',body:status===204?'':JSON.stringify(body)});
+ });
+ try {
+  await page.goto('http://127.0.0.1:5179/admin/strategies/one');await page.getByRole('textbox',{name:'策略源码',exact:true}).waitFor();
+  const code=()=>page.getByRole('textbox',{name:'策略源码',exact:true});
+  await code().fill(source+'# unsaved\n');
+  await page.getByRole('tab',{name:'params.json',exact:true}).click();
+  await page.getByRole('textbox',{name:'默认参数 JSON',exact:true}).fill('{invalid');
+  await page.getByRole('tab',{name:'strategy.py',exact:true}).click();
+  assert.match(await code().inputValue(),/unsaved/);
+  await page.getByRole('button',{name:'保存草稿',exact:true}).click();
+  await page.getByRole('alert').filter({hasText:'JSON'}).waitFor();assert.equal(saveCount,0);
+  await page.getByRole('tab',{name:'params.json',exact:true}).click();
+  await page.getByRole('textbox',{name:'默认参数 JSON',exact:true}).fill('{"lookback": 80, "nested": {"keep": true}}');
+  await page.getByRole('tab',{name:'策略说明',exact:true}).click();
+  await page.getByRole('textbox',{name:'策略名称',exact:true}).fill('改名策略');
+  conflict=true;await page.getByRole('button',{name:'保存草稿',exact:true}).click();
+  await page.getByRole('alert').filter({hasText:'版本冲突'}).waitFor();assert.equal(metadataCount,1);
+  await page.getByRole('button',{name:'保存草稿',exact:true}).click();
+  await page.getByRole('status').filter({hasText:'草稿已保存'}).waitFor();assert.equal(metadataCount,1);assert.equal(rows.one.draft.default_parameters.nested.keep,true);
+  await page.getByRole('button',{name:'静态检查',exact:true}).click();await page.getByRole('status').filter({hasText:'静态校验通过'}).waitFor();
+  await page.getByRole('tab',{name:'strategy.py',exact:true}).click();await code().fill(source+'# edit again\n');
+  assert.match(await page.locator('.qfs-status').innerText(),/检查已过期/);
+  await page.evaluate(()=>{window.confirm=()=>false;});await page.locator('.qfs-list button').filter({hasText:'策略 two'}).click();assert.match(page.url(),/one$/);assert.match(await code().inputValue(),/edit again/);
+  delaySave=true;await page.getByRole('button',{name:'保存草稿',exact:true}).click();assert.equal(await code().getAttribute('readonly'),'');await page.getByRole('status').filter({hasText:'草稿已保存'}).waitFor();delaySave=false;
+  await page.getByRole('button',{name:'发布版本',exact:true}).click();await page.getByRole('status').filter({hasText:'已发布策略版本'}).waitFor();
+  await page.getByRole('tab',{name:'版本',exact:true}).click();await page.getByRole('button',{name:/v1 · 当前发布版本/}).click();await page.getByRole('dialog',{name:'发布版本 v1'}).waitFor();assert.match(await page.getByRole('dialog').innerText(),/默认参数/);await page.getByRole('button',{name:'关闭发布版本 v1',exact:true}).click();
+  await page.locator('.qfs-list button').filter({hasText:'策略 two'}).click();await page.waitForURL('**/two');await page.locator('.qfs-object strong').filter({hasText:'策略 two'}).waitFor();await code().fill(source+'# protect back\n');await page.locator('.qfs-file-tabs').filter({hasText:'未保存'}).waitFor();
+  await page.evaluate(()=>{window.confirm=()=>false;});await page.evaluate(()=>history.back());await page.waitForTimeout(150);assert.match(page.url(),/two$/);assert.match(await code().inputValue(),/protect back/);
+  await page.evaluate(()=>{window.confirm=()=>true;});await page.evaluate(()=>history.back());await page.waitForURL('**/one');
+  await page.getByRole('button',{name:'新建策略',exact:true}).click();await page.getByRole('dialog',{name:'创建策略'}).waitFor();await page.getByRole('textbox',{name:'策略名称',exact:true}).fill('新模板');await page.getByLabel('初始模板').selectOption('rotation');
+  await page.getByRole('button',{name:'创建并进入编辑器',exact:true}).click();await page.waitForURL('**/new');await page.locator('.qfs-object strong').filter({hasText:'新模板'}).waitFor();assert.match(await code().inputValue(),/context.universe.query/);
+  await page.getByRole('tab',{name:'版本',exact:true}).click();await page.evaluate(()=>{window.confirm=()=>true;});await page.getByRole('button',{name:'归档策略',exact:true}).click();await page.getByRole('status').filter({hasText:'策略已归档'}).waitFor();assert.equal(await code().getAttribute('readonly'),'');
+  for(const width of [1440,1200,900,860,600,390]){
+   await page.setViewportSize({width,height:900});await page.waitForTimeout(70);
+   assert.equal(await page.evaluate(()=>document.documentElement.scrollWidth<=innerWidth),true,`page overflow ${width}`);
+   assert.equal(await page.getByRole('button',{name:'新建策略',exact:true}).isVisible(),true);
+   if(width<900){await page.getByRole('button',{name:'参数面板',exact:true}).click();assert.equal(await page.getByRole('complementary',{name:'策略上下文'}).isVisible(),true);await page.keyboard.press('Escape');}
+  }
+  assert.deepEqual(errors,[]);console.log('PASS: dirty tabs, malformed JSON, partial-save conflict retry, stale checks, locked saves, publish/snapshot, navigation/back protection, create/archive, responsive panels.');
+ } catch(e) {console.error('PAGE',page.url(),errors,await page.locator('body').innerText());throw e;} finally {await context.close();await browser.close();}
+})().catch(e=>{console.error(e);process.exitCode=1;});


### PR DESCRIPTION
将策略编辑页升级为已批准的三栏工作台，接入目录、源码/参数/说明编辑、静态检查、草稿保存、版本发布及快照、归档和最近回测。支持可调面板、窄屏辅助面板、创建抽屉、快捷保存、冲突保留输入与真实 strategy_protocol ETF 模板。

切换策略时保留代码及上下文面板，禁用旧内容操作，最新请求返回后统一替换，避免清空和重建造成闪烁。统一页面宽度与全局侧栏状态，去除短暂加载浮条及鼠标点击红框，保存成功提示三秒后消失。未保存修改由稳定的页内确认框保护，用户明确取消或继续后才结束拦截。

验证：2026-09-13 用户在本地 5179 明确人工验收通过。同步最新 origin/main 后，49 项非浏览器前端测试及生产构建通过。初版已完成模板 5 项 Python 测试和隔离浏览器联调；本轮按用户要求未操作浏览器，浏览器回归脚本已适配新确认框但未重跑。构建仅有既有分包体积提示。

本地验收文档已更新，根目录 docs 文件不进入提交。无后端、数据库迁移或部署配置变更。
